### PR TITLE
Update cognitive-java to 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Use the Gradle wrapper:
 ```
 
 `./gradlew cognitive-java-check` runs the shared `media.barney.cognitive-java`
-`0.3.0` gate against the repository's production Java sources. `./gradlew check`
+`0.4.0` gate against the repository's production Java sources. `./gradlew check`
 now includes the cognitive gate. `qualityGate` remains the repo-local
 convenience task that runs `check` plus the dedicated `crap-java-check` and
 `cognitive-java-check` tasks.

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
     id 'jacoco'
     id 'media.barney.crap-java' version '0.3.2'
-    id 'media.barney.cognitive-java' version '0.3.0'
+    id 'media.barney.cognitive-java' version '0.4.0'
     id 'net.ltgt.errorprone' version '5.1.0'
     id 'org.springframework.boot' version '3.5.13'
 }


### PR DESCRIPTION
## Summary
- bump the shared media.barney.cognitive-java Gradle plugin from 