### PR TITLE
Add formatting-github-comment skill

### DIFF
--- a/skills/formatting-github-comment/SKILL.md
+++ b/skills/formatting-github-comment/SKILL.md
@@ -2,16 +2,15 @@
 name: formatting-github-comment
 description: Format GitHub comments and descriptions into concise, readable Markdown suitable for collaborative work.
 ---
+<!-- markdownlint-disable MD025 -->
 
-# formatting-github-comment
-
-## Purpose
+# Purpose
 
 Turn raw review notes, implementation summaries, issue descriptions, or status
 updates into clear GitHub-flavored Markdown comments that are easy to scan and
 act on.
 
-## When to Use
+# When to Use
 
 - use when writing GitHub issue descriptions, PR summaries, review replies, or
   follow-up comments
@@ -19,18 +18,23 @@ act on.
   comment
 - use when raw notes need to be normalized into concise Markdown before
   posting
-- use the bundled `references/` and `examples/` files when they already match
-  the target GitHub artifact shape
+- use `references/markdown-comment-formatting.md` for general Markdown comment
+  structure and formatting decisions
+- use `examples/github-comment.md` when shaping a full issue, PR, or status
+  comment
+- use `examples/review-thread-reply.md` when shaping a short review-thread
+  reply
 
-## Inputs
+# Inputs
 
 - the communication goal
 - the intended audience and context
 - the raw points, findings, or status details to include
 - any formatting constraints such as brevity, required headings, or code blocks
-- optional use of the bundled examples and formatting notes
+- optional use of `references/markdown-comment-formatting.md` and the example
+  files when the target artifact already matches one of those shapes
 
-## Workflow
+# Workflow
 
 1. Identify the main outcome the comment must communicate.
 2. Remove repetition, filler, and low-signal detail that does not help the
@@ -41,16 +45,19 @@ act on.
    headings, flat lists, inline code, fenced code blocks, and links.
 5. Keep line wrapping, spacing, and code spans consistent so the comment reads
    cleanly in GitHub.
-6. Reuse the bundled examples or references when they fit the artifact type.
+6. Reuse `references/markdown-comment-formatting.md` for general formatting,
+   `examples/github-comment.md` for full comments, and
+   `examples/review-thread-reply.md` for short thread replies when they fit the
+   target artifact type.
 
-## Outputs
+# Outputs
 
 - a concise GitHub-ready Markdown comment, description, or reply
 - optional short sections when structure materially improves readability
 - optional fenced code blocks or file references when the content needs them
 - optional reuse of the bundled example shapes for review replies or summaries
 
-## Guardrails
+# Guardrails
 
 - do not add content that was not supported by the input
 - do not over-format simple messages with unnecessary headings or nesting
@@ -59,7 +66,7 @@ act on.
 - do not emit literal `\n` escape sequences in Markdown meant for GitHub
 - do not mention `@copilot` in PR comments
 
-## Exit Checks
+# Exit Checks
 
 - the main point is understandable in one pass
 - the Markdown uses only flat, readable structure

--- a/skills/formatting-github-comment/SKILL.md
+++ b/skills/formatting-github-comment/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: formatting-github-comment
+description: Format GitHub comments and descriptions into concise, readable Markdown suitable for collaborative work.
+---
+
+# formatting-github-comment
+
+## Purpose
+
+Turn raw review notes, implementation summaries, issue descriptions, or status
+updates into clear GitHub-flavored Markdown comments that are easy to scan and
+act on.
+
+## When to Use
+
+- use when writing GitHub issue descriptions, PR summaries, review replies, or
+  follow-up comments
+- use when another skill needs help shaping its output into a clean GitHub
+  comment
+- use when raw notes need to be normalized into concise Markdown before
+  posting
+- use the bundled `references/` and `examples/` files when they already match
+  the target GitHub artifact shape
+
+## Inputs
+
+- the communication goal
+- the intended audience and context
+- the raw points, findings, or status details to include
+- any formatting constraints such as brevity, required headings, or code blocks
+- optional use of the bundled examples and formatting notes
+
+## Workflow
+
+1. Identify the main outcome the comment must communicate.
+2. Remove repetition, filler, and low-signal detail that does not help the
+   reader act.
+3. Choose a simple structure such as a short summary paragraph, a flat bullet
+   list, or a short verification section.
+4. Use Markdown features only when they improve readability, such as short
+   headings, flat lists, inline code, fenced code blocks, and links.
+5. Keep line wrapping, spacing, and code spans consistent so the comment reads
+   cleanly in GitHub.
+6. Reuse the bundled examples or references when they fit the artifact type.
+
+## Outputs
+
+- a concise GitHub-ready Markdown comment, description, or reply
+- optional short sections when structure materially improves readability
+- optional fenced code blocks or file references when the content needs them
+- optional reuse of the bundled example shapes for review replies or summaries
+
+## Guardrails
+
+- do not add content that was not supported by the input
+- do not over-format simple messages with unnecessary headings or nesting
+- do not hide the main action behind long narrative prose
+- do not rely on formatting that is fragile or hard to edit later
+- do not emit literal `\n` escape sequences in Markdown meant for GitHub
+- do not mention `@copilot` in PR comments
+
+## Exit Checks
+
+- the main point is understandable in one pass
+- the Markdown uses only flat, readable structure
+- code spans and code blocks are syntactically correct
+- the result is concise enough for GitHub discussion flow
+- the output shape matches the intended GitHub artifact

--- a/skills/formatting-github-comment/examples/github-comment.md
+++ b/skills/formatting-github-comment/examples/github-comment.md
@@ -1,0 +1,12 @@
+# Example GitHub Comment
+
+## Summary
+
+- add the new `quality-gate` bundle under `skills/`
+- document how it composes child skills
+- keep the issue limited to canonical skill content
+
+## Verification
+
+- `./gradlew qualityGate`
+- `npx --yes markdownlint-cli2 "**/*.md" "!**/node_modules/**" --config .markdownlint.json`

--- a/skills/formatting-github-comment/examples/review-thread-reply.md
+++ b/skills/formatting-github-comment/examples/review-thread-reply.md
@@ -1,0 +1,4 @@
+# Review Thread Reply Example
+
+Fixed in `<commit>` by keeping the inline command on one line and tightening
+the surrounding wording so the comment renders cleanly in GitHub.

--- a/skills/formatting-github-comment/references/markdown-comment-formatting.md
+++ b/skills/formatting-github-comment/references/markdown-comment-formatting.md
@@ -1,0 +1,10 @@
+# Markdown Comment Formatting Notes
+
+Distilled from `ai-rules/AI-RULES/FORMATTING.md` and recent GitHub review
+feedback patterns.
+
+- Keep lines wrapped so long comments stay readable in diffs and source view.
+- Keep Markdown structurally simple and avoid fragile formatting.
+- Keep inline code on one line so renderers do not split or mangle it.
+- Prefer a short paragraph or flat bullets over deeply nested structure.
+- Use exact identifiers and links when the comment needs traceability.

--- a/skills/formatting-github-comment/references/markdown-comment-formatting.md
+++ b/skills/formatting-github-comment/references/markdown-comment-formatting.md
@@ -1,7 +1,7 @@
 # Markdown Comment Formatting Notes
 
-Distilled from `ai-rules/AI-RULES/FORMATTING.md` and recent GitHub review
-feedback patterns.
+Distilled from internal formatting guidance and recent GitHub review feedback
+patterns.
 
 - Keep lines wrapped so long comments stay readable in diffs and source view.
 - Keep Markdown structurally simple and avoid fragile formatting.


### PR DESCRIPTION
## Summary
- add the canonical `formatting-github-comment` leaf skill bundle
- document reusable GitHub comment formatting behavior and guardrails
- include bundled examples and reference notes for comment shaping

Closes #28

## Verification
- `./gradlew qualityGate`
- `npx --yes markdownlint-cli2 "**/*.md" "!**/node_modules/**" --config .markdownlint.json`