### PR TITLE
Add plan skill

### DIFF
--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -1,14 +1,17 @@
 ---
 name: plan
-description: Create a decision-complete implementation plan before work starts and update the plan when new answers materially change it.
+description: >-
+  Create a decision-complete implementation plan before work starts and
+  update the plan when new answers materially change it.
 ---
-<!-- markdownlint-disable MD025 -->
 
 # Purpose
 
 Produce a decision-complete plan for implementation work so execution can
 proceed without leaving important design, scope, or verification choices
 implicit.
+
+<!-- markdownlint-disable MD025 -->
 
 # When to Use
 

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -21,6 +21,8 @@ implicit.
 - use `references/decision-complete-planning.md` for planning behavior and
   refresh rules
 - use `references/workflow-order.md` when the execution sequence matters
+- use `examples/implementation-plan.md` when a concrete plan shape with
+  verification details helps
 - use `targets/codex.md` only when Codex-specific additive notes apply
 
 # Inputs
@@ -32,6 +34,8 @@ implicit.
 - `references/decision-complete-plan.md`,
   `references/decision-complete-planning.md`, and
   `references/workflow-order.md`
+- `examples/implementation-plan.md` when the output needs a concrete example
+  shape
 - any applicable target-specific note such as `targets/codex.md`
 
 # Workflow
@@ -51,7 +55,9 @@ implicit.
    verification are explicit.
 7. Use `references/decision-complete-planning.md` and
    `references/workflow-order.md` to refine planning behavior and sequencing.
-8. Apply any target-specific note such as `targets/codex.md` only after the
+8. Use `examples/implementation-plan.md` when a concrete output shape or
+   verification section is helpful.
+9. Apply any target-specific note such as `targets/codex.md` only after the
    canonical plan is stable.
 
 # Outputs
@@ -61,6 +67,7 @@ implicit.
 - a concrete verification strategy and acceptance criteria
 - an updated plan when later user input materially changes the intended
   implementation path
+- optional reuse of `examples/implementation-plan.md` as a concrete shape
 - optional target-specific planning note when a bundled target file applies
 
 # Guardrails

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -2,32 +2,39 @@
 name: plan
 description: Create a decision-complete implementation plan before work starts and update the plan when new answers materially change it.
 ---
+<!-- markdownlint-disable MD025 -->
 
-# plan
-
-## Purpose
+# Purpose
 
 Produce a decision-complete plan for implementation work so execution can
 proceed without leaving important design, scope, or verification choices
 implicit.
 
-## When to Use
+# When to Use
 
 - use before implementation for multi-step or high-risk work
 - use when the user explicitly asks for a plan
 - use when questions or discovered constraints can materially change the
   implementation path
-- use the bundled planning and workflow-order references when shaping the plan
+- use `references/decision-complete-plan.md` to make sure the plan is
+  decision-complete
+- use `references/decision-complete-planning.md` for planning behavior and
+  refresh rules
+- use `references/workflow-order.md` when the execution sequence matters
+- use `targets/codex.md` only when Codex-specific additive notes apply
 
-## Inputs
+# Inputs
 
 - the user request and success criteria
 - relevant repository context, constraints, and existing implementation shape
 - unresolved product or technical tradeoffs
 - any user answers that materially affect the plan
-- the bundled references and any applicable target-specific notes
+- `references/decision-complete-plan.md`,
+  `references/decision-complete-planning.md`, and
+  `references/workflow-order.md`
+- any applicable target-specific note such as `targets/codex.md`
 
-## Workflow
+# Workflow
 
 1. Explore the repository and surrounding context before asking questions that
    could be answered by inspection.
@@ -40,10 +47,14 @@ implicit.
 5. If a user answer has significant impact on the plan, present the altered
    plan before starting implementation instead of switching directly into
    coding.
-6. Apply any bundled target-specific notes only after the canonical plan is
-   stable.
+6. Use `references/decision-complete-plan.md` to confirm scope, decisions, and
+   verification are explicit.
+7. Use `references/decision-complete-planning.md` and
+   `references/workflow-order.md` to refine planning behavior and sequencing.
+8. Apply any target-specific note such as `targets/codex.md` only after the
+   canonical plan is stable.
 
-## Outputs
+# Outputs
 
 - a decision-complete implementation plan
 - explicit assumptions and chosen defaults
@@ -52,14 +63,14 @@ implicit.
   implementation path
 - optional target-specific planning note when a bundled target file applies
 
-## Guardrails
+# Guardrails
 
 - do not start implementation when important plan decisions are still open
 - do not ask questions that can be resolved by repository exploration
 - do not leave critical behavior, interfaces, or test strategy implicit
 - do not treat a materially changed plan as unchanged after new answers arrive
 
-## Exit Checks
+# Exit Checks
 
 - the plan is implementation-ready and leaves no critical decisions open
 - important assumptions are explicit

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: plan
+description: Create a decision-complete implementation plan before work starts and update the plan when new answers materially change it.
+---
+
+# plan
+
+## Purpose
+
+Produce a decision-complete plan for implementation work so execution can
+proceed without leaving important design, scope, or verification choices
+implicit.
+
+## When to Use
+
+- use before implementation for multi-step or high-risk work
+- use when the user explicitly asks for a plan
+- use when questions or discovered constraints can materially change the
+  implementation path
+- use the bundled planning and workflow-order references when shaping the plan
+
+## Inputs
+
+- the user request and success criteria
+- relevant repository context, constraints, and existing implementation shape
+- unresolved product or technical tradeoffs
+- any user answers that materially affect the plan
+- the bundled references and any applicable target-specific notes
+
+## Workflow
+
+1. Explore the repository and surrounding context before asking questions that
+   could be answered by inspection.
+2. State the implementation goal, success criteria, key constraints, and
+   important assumptions.
+3. Ask only the questions that materially change the plan or lock important
+   tradeoffs.
+4. Produce a decision-complete plan covering approach, dependencies, edge
+   cases, verification, and acceptance signals.
+5. If a user answer has significant impact on the plan, present the altered
+   plan before starting implementation instead of switching directly into
+   coding.
+6. Apply any bundled target-specific notes only after the canonical plan is
+   stable.
+
+## Outputs
+
+- a decision-complete implementation plan
+- explicit assumptions and chosen defaults
+- a concrete verification strategy and acceptance criteria
+- an updated plan when later user input materially changes the intended
+  implementation path
+- optional target-specific planning note when a bundled target file applies
+
+## Guardrails
+
+- do not start implementation when important plan decisions are still open
+- do not ask questions that can be resolved by repository exploration
+- do not leave critical behavior, interfaces, or test strategy implicit
+- do not treat a materially changed plan as unchanged after new answers arrive
+
+## Exit Checks
+
+- the plan is implementation-ready and leaves no critical decisions open
+- important assumptions are explicit
+- verification steps and acceptance signals are concrete
+- any answer that materially changed the approach is reflected in the latest
+  plan

--- a/skills/plan/examples/implementation-plan.md
+++ b/skills/plan/examples/implementation-plan.md
@@ -1,0 +1,23 @@
+# Example Plan Shape
+
+## Summary
+
+- add a new canonical skill bundle under `skills/`
+- keep supporting files explicit and referenced
+- preserve the current repository contract
+
+## Key Changes
+
+- create `SKILL.md` with required frontmatter and sections
+- add a small reference note and one example file
+- update only files required for the issue
+
+## Test Plan
+
+- `./gradlew qualityGate`
+- `npx --yes markdownlint-cli2 "**/*.md" "!**/node_modules/**" --config .markdownlint.json`
+
+## Assumptions
+
+- no new target-specific notes are required for v1
+- the skill remains tool-agnostic

--- a/skills/plan/references/decision-complete-plan.md
+++ b/skills/plan/references/decision-complete-plan.md
@@ -1,0 +1,13 @@
+# Decision-Complete Plan Reference
+
+A strong implementation plan should make these elements explicit:
+
+- goal and success criteria
+- in-scope and out-of-scope items
+- target files, interfaces, or subsystems
+- key design decisions and chosen defaults
+- important risks, edge cases, and mitigations
+- verification steps and acceptance criteria
+
+Repository exploration comes before clarification questions when the answer can
+be discovered locally.

--- a/skills/plan/references/decision-complete-planning.md
+++ b/skills/plan/references/decision-complete-planning.md
@@ -1,6 +1,6 @@
 # Decision-Complete Planning Notes
 
-Distilled from `ai-rules/PLAN/PLAN.md`.
+Distilled from the project's planning guidance.
 
 - Explore first and ask only high-impact clarifying questions.
 - Keep the plan dependency-aware and implementation-ready.

--- a/skills/plan/references/decision-complete-planning.md
+++ b/skills/plan/references/decision-complete-planning.md
@@ -1,0 +1,9 @@
+# Decision-Complete Planning Notes
+
+Distilled from `ai-rules/PLAN/PLAN.md`.
+
+- Explore first and ask only high-impact clarifying questions.
+- Keep the plan dependency-aware and implementation-ready.
+- Make assumptions explicit instead of letting them hide in execution.
+- Define verification before implementation starts.
+- If new information changes the plan materially, refresh the plan first.

--- a/skills/plan/references/workflow-order.md
+++ b/skills/plan/references/workflow-order.md
@@ -1,0 +1,13 @@
+# Workflow Order Reference
+
+Implementation work should follow a stable execution order:
+
+- plan first
+- create a dedicated issue branch
+- implement the bounded change
+- open a PR or MR
+- handle review and validation
+- merge only after the review gate is clean
+
+This keeps the scope aligned to one concern and prevents implementation from
+starting without an actionable plan.

--- a/skills/plan/targets/codex.md
+++ b/skills/plan/targets/codex.md
@@ -1,0 +1,7 @@
+# Codex Notes
+
+- Use Plan mode when the environment supports it.
+- If a user's answers materially change scope, assumptions, or sequencing,
+  present the altered plan before starting implementation.
+- Do not treat materially changed planning input as permission to continue with
+  the previous implementation path unchanged.


### PR DESCRIPTION
## Summary
- add the canonical `plan` leaf skill bundle
- capture decision-complete planning behavior and workflow ordering
- add a Codex-specific target note for plan-mode behavior

Closes #31

## Verification
- `./gradlew qualityGate`
- `npx --yes markdownlint-cli2 "**/*.md" "!**/node_modules/**" --config .markdownlint.json`