### PR TITLE
Add pr-review skill

### DIFF
--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: pr-review
+description: Define the family-root responsibility boundaries for handling PR review findings and review conversations safely.
+---
+
+# pr-review
+
+## Purpose
+
+Define the canonical PR review responsibility boundary for classifying findings,
+handling review conversations, and deciding whether a thread may be resolved.
+
+## When to Use
+
+- use when a PR or MR review workflow is active
+- use when review comments or conversations need ownership or closure
+  decisions
+- use as the family-root skill for later `pr-review-write`,
+  `pr-review-respond`, `pr-review-loop`, and `pr-merge` skills
+- use the bundled references and examples when shaping the root family
+  contract or thread-handling behavior
+
+## Inputs
+
+- the PR or MR diff and current review state
+- active review comments and threads
+- repository or session rules about who may resolve conversations
+- relevant tests, checks, and changed files
+- the bundled references for boundary and loop-derived guardrails
+
+## Workflow
+
+1. Read the review state, changed scope, and active conversations.
+2. Determine whether the current actor is responsible for handling or resolving
+   each thread.
+3. Classify each finding as valid, invalid, or unresolved.
+4. Ensure each resolved thread has a final explanatory reply describing how it
+   was handled or why it was not addressed.
+5. Delegate detailed finding-writing, response, loop, or merge behavior to the
+   specialized child skills when those are available.
+6. Reuse the bundled example replies when they fit the current thread shape.
+
+## Outputs
+
+- a classified review state for the active findings
+- concise thread responses or closure decisions
+- an explicit list of unresolved items when ownership or evidence is missing
+
+## Guardrails
+
+- do not resolve review conversations unless responsibility is clear
+- do not close a thread without a final comment explaining the outcome
+- do not broaden this skill into full merge-loop orchestration
+- do not duplicate detailed finding-writing or fix-response behavior that
+  belongs in child skills
+
+## Exit Checks
+
+- every handled thread has a classification
+- every resolved thread has a final rationale comment
+- unclear ownership or unresolved responsibility is surfaced explicitly
+- no merge-loop or implementation behavior was silently inlined here

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -2,33 +2,39 @@
 name: pr-review
 description: Define the family-root responsibility boundaries for handling PR review findings and review conversations safely.
 ---
+<!-- markdownlint-disable MD025 -->
 
-# pr-review
-
-## Purpose
+# Purpose
 
 Define the canonical PR review responsibility boundary for classifying findings,
 handling review conversations, and deciding whether a thread may be resolved.
 
-## When to Use
+# When to Use
 
 - use when a PR or MR review workflow is active
 - use when review comments or conversations need ownership or closure
   decisions
 - use as the family-root skill for later `pr-review-write`,
   `pr-review-respond`, `pr-review-loop`, and `pr-merge` skills
-- use the bundled references and examples when shaping the root family
-  contract or thread-handling behavior
+- use `references/review-family-guardrails.md` for shared review-family
+  guardrails
+- use `references/review-boundary.md` for the root-versus-child boundary
+- use `references/pr-review-loop-source.md` for review-loop-derived closure
+  conditions
+- use `examples/thread-resolution.md` and `examples/resolution-comment.md`
+  when a thread-handling example is helpful
 
-## Inputs
+# Inputs
 
 - the PR or MR diff and current review state
 - active review comments and threads
 - repository or session rules about who may resolve conversations
 - relevant tests, checks, and changed files
-- the bundled references for boundary and loop-derived guardrails
+- `references/review-family-guardrails.md`,
+  `references/review-boundary.md`, and
+  `references/pr-review-loop-source.md`
 
-## Workflow
+# Workflow
 
 1. Read the review state, changed scope, and active conversations.
 2. Determine whether the current actor is responsible for handling or resolving
@@ -38,15 +44,20 @@ handling review conversations, and deciding whether a thread may be resolved.
    was handled or why it was not addressed.
 5. Delegate detailed finding-writing, response, loop, or merge behavior to the
    specialized child skills when those are available.
-6. Reuse the bundled example replies when they fit the current thread shape.
+6. Use `references/review-family-guardrails.md` and
+   `references/review-boundary.md` to keep the root skill scoped correctly.
+7. Use `references/pr-review-loop-source.md` only for closure semantics that
+   belong in the root skill.
+8. Reuse `examples/thread-resolution.md` and
+   `examples/resolution-comment.md` when they fit the current thread shape.
 
-## Outputs
+# Outputs
 
 - a classified review state for the active findings
 - concise thread responses or closure decisions
 - an explicit list of unresolved items when ownership or evidence is missing
 
-## Guardrails
+# Guardrails
 
 - do not resolve review conversations unless responsibility is clear
 - do not close a thread without a final comment explaining the outcome
@@ -54,7 +65,7 @@ handling review conversations, and deciding whether a thread may be resolved.
 - do not duplicate detailed finding-writing or fix-response behavior that
   belongs in child skills
 
-## Exit Checks
+# Exit Checks
 
 - every handled thread has a classification
 - every resolved thread has a final rationale comment

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -73,6 +73,6 @@ handling review conversations, and deciding whether a thread may be resolved.
 
 - every handled thread has a classification
 - every resolved thread has a final rationale comment
-- unclear ownership or unresolved responsibility is surfaced explicitly
+- unclear ownership or unresolved responsibility are surfaced explicitly
 - missing closure authority is surfaced explicitly and leaves the thread open
 - no merge-loop or implementation behavior was silently inlined here

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -11,7 +11,7 @@ handling review conversations, and deciding whether a thread may be resolved.
 
 # When to Use
 
-- use when a PR or MR review workflow is active
+- use when a PR or merge request (MR) review workflow is active
 - use when review comments or conversations need ownership or closure
   decisions
 - use as the family-root skill for later `pr-review-write`,
@@ -39,16 +39,19 @@ handling review conversations, and deciding whether a thread may be resolved.
 1. Read the review state, changed scope, and active conversations.
 2. Determine whether the current actor is responsible for handling or resolving
    each thread.
-3. Classify each finding as valid, invalid, or unresolved.
-4. Ensure each resolved thread has a final explanatory reply describing how it
+3. If conversation-resolution rules are missing or unclear, ask the
+   user or maintainer whether the current actor may resolve review
+   conversations and keep the thread open until that authority is clarified.
+4. Classify each finding as valid, invalid, or unresolved.
+5. Ensure each resolved thread has a final explanatory reply describing how it
    was handled or why it was not addressed.
-5. Delegate detailed finding-writing, response, loop, or merge behavior to the
+6. Delegate detailed finding-writing, response, loop, or merge behavior to the
    specialized child skills when those are available.
-6. Use `references/review-family-guardrails.md` and
+7. Use `references/review-family-guardrails.md` and
    `references/review-boundary.md` to keep the root skill scoped correctly.
-7. Use `references/pr-review-loop-source.md` only for closure semantics that
+8. Use `references/pr-review-loop-source.md` only for closure semantics that
    belong in the root skill.
-8. Reuse `examples/thread-resolution.md` and
+9. Reuse `examples/thread-resolution.md` and
    `examples/resolution-comment.md` when they fit the current thread shape.
 
 # Outputs
@@ -60,6 +63,7 @@ handling review conversations, and deciding whether a thread may be resolved.
 # Guardrails
 
 - do not resolve review conversations unless responsibility is clear
+- do not resolve review conversations when closure authority is unknown
 - do not close a thread without a final comment explaining the outcome
 - do not broaden this skill into full merge-loop orchestration
 - do not duplicate detailed finding-writing or fix-response behavior that
@@ -70,4 +74,5 @@ handling review conversations, and deciding whether a thread may be resolved.
 - every handled thread has a classification
 - every resolved thread has a final rationale comment
 - unclear ownership or unresolved responsibility is surfaced explicitly
+- missing closure authority is surfaced explicitly and leaves the thread open
 - no merge-loop or implementation behavior was silently inlined here

--- a/skills/pr-review/examples/resolution-comment.md
+++ b/skills/pr-review/examples/resolution-comment.md
@@ -1,0 +1,5 @@
+# Resolution Comment Example
+
+Valid finding. Fixed in `<commit>` by adjusting the implementation and
+preserving the intended behavior. Resolving because the change is merged into
+this PR and the thread now has a concrete rationale.

--- a/skills/pr-review/examples/thread-resolution.md
+++ b/skills/pr-review/examples/thread-resolution.md
@@ -1,0 +1,22 @@
+# Example Thread Handling
+
+## Valid Finding
+
+Classification: valid
+
+Final reply: Fixed in the follow-up commit by narrowing the scope and adding
+the missing verification step.
+
+## Invalid Finding
+
+Classification: invalid
+
+Final reply: Leaving the implementation as-is because the referenced behavior
+is already covered by the existing guard clause and regression test.
+
+## Unresolved Ownership
+
+Classification: unresolved
+
+Final reply: Not resolving this conversation yet because the current review
+rules do not clearly assign ownership for closure.

--- a/skills/pr-review/references/pr-review-loop-source.md
+++ b/skills/pr-review/references/pr-review-loop-source.md
@@ -1,11 +1,13 @@
 # PR Review Loop Source Notes
 
-Relevant ideas distilled from the repository review loop guidance:
+Relevant review-loop heuristics used by this skill:
 
-- every review item should be handled on its own branch and PR
-- review state must be re-evaluated after each push
-- missing ownership or unclear state should block conversation resolution
-- a clean merge gate requires green checks, no unresolved valid findings, and
+- handling each review item on its own branch and PR often works best
+- review state should generally be re-evaluated after each push
+- missing ownership or unclear state should usually block conversation
+  resolution
+- a clean merge gate typically includes green checks, no unresolved valid
+  findings, and
   no open review threads
 
 The root `pr-review` skill uses these ideas only for responsibility and closure

--- a/skills/pr-review/references/pr-review-loop-source.md
+++ b/skills/pr-review/references/pr-review-loop-source.md
@@ -1,0 +1,12 @@
+# PR Review Loop Source Notes
+
+Relevant ideas distilled from the repository review loop guidance:
+
+- every review item should be handled on its own branch and PR
+- review state must be re-evaluated after each push
+- missing ownership or unclear state should block conversation resolution
+- a clean merge gate requires green checks, no unresolved valid findings, and
+  no open review threads
+
+The root `pr-review` skill uses these ideas only for responsibility and closure
+semantics. The detailed loop orchestration belongs in `pr-review-loop`.

--- a/skills/pr-review/references/review-boundary.md
+++ b/skills/pr-review/references/review-boundary.md
@@ -1,0 +1,12 @@
+# PR Review Boundary Reference
+
+The family-root `pr-review` skill establishes the shared review contract:
+
+- classify findings clearly
+- respect ownership rules before resolving conversations
+- leave a final explanatory comment before closing a thread
+- separate the root responsibility contract from specialized subflows such as
+  finding authoring, response handling, loop orchestration, and merge gating
+
+This keeps later family skills specialized without repeating the same boundary
+rules.

--- a/skills/pr-review/references/review-family-guardrails.md
+++ b/skills/pr-review/references/review-family-guardrails.md
@@ -1,0 +1,10 @@
+# Review Family Guardrails
+
+Distilled from `ai-rules/REVIEW/REVIEW.md`, `REVIEW/CODE_REVIEW.md`, and
+`AI-RULES/PR-REVIEW-LOOP.md`.
+
+- classify findings explicitly instead of treating all comments the same
+- keep evidence and rationale visible in the thread
+- resolve conversations only when ownership and closure conditions are met
+- keep unresolved or ambiguous findings visible
+- treat post-push review state and green checks as separate merge conditions

--- a/skills/pr-review/references/review-family-guardrails.md
+++ b/skills/pr-review/references/review-family-guardrails.md
@@ -1,7 +1,6 @@
 # Review Family Guardrails
 
-Distilled from `ai-rules/REVIEW/REVIEW.md`, `REVIEW/CODE_REVIEW.md`, and
-`AI-RULES/PR-REVIEW-LOOP.md`.
+Distilled from the review, code review, and PR review loop guidance sources.
 
 - classify findings explicitly instead of treating all comments the same
 - keep evidence and rationale visible in the thread


### PR DESCRIPTION
## Summary
- add the canonical `pr-review` family-root skill bundle
- define ownership, classification, and thread-closure guardrails
- include bundled references and example review replies

Closes #36

## Verification
- `./gradlew qualityGate`
- `npx --yes markdownlint-cli2 "**/*.md" "!**/node_modules/**" --config .markdownlint.json`