### PR TITLE
Add quality-crap skill

### DIFF
--- a/skills/quality-crap/SKILL.md
+++ b/skills/quality-crap/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: quality-crap
+description: Enforce a hard CRAP-score threshold of at most 8 for the bounded change set.
+---
+<!-- markdownlint-disable MD025 -->
+
+# Purpose
+
+Evaluate the bounded change set against a hard CRAP-score threshold so methods
+with excessive combined complexity and weak coverage are rejected before merge.
+
+# When to Use
+
+- use when the repository or delivery flow exposes a CRAP metric or equivalent
+  combined complexity-and-coverage score
+- use when reviewing or refactoring methods touched by the current change
+- use `references/crap-threshold.md` for the hard threshold, evidence order,
+  and reduction levers
+- use `examples/crap-review-finding.md` when reporting a failing method in
+  review or gate output
+
+# Inputs
+
+- the changed files, methods, or bounded diff under review
+- the strongest available CRAP evidence, such as CI output or a local
+  `crap-java-check` report
+- available tests or coverage-improvement options for the bounded scope
+- `references/crap-threshold.md`
+
+# Workflow
+
+1. Collect the strongest available CRAP evidence for the changed scope from CI,
+   local tooling, or an equivalent report.
+2. Treat every relevant method with CRAP score greater than `8` as a failing
+   result.
+3. If the score is unavailable for the relevant scope, surface missing evidence
+   instead of inventing an exact CRAP value.
+4. Reduce failing scores by simplifying control flow, extracting cohesive
+   methods, or adding focused tests that cover the risky branches.
+5. Re-run the metric after changes and record the final worst score for the
+   bounded scope.
+6. Use `examples/crap-review-finding.md` when communicating the remaining
+   finding or the final pass result.
+
+# Outputs
+
+- a pass or fail result for the bounded scope against the `<= 8` threshold
+- method-level findings with metric evidence when the threshold is violated
+- explicit note when evidence is missing and the gate cannot be confirmed
+
+# Guardrails
+
+- do not treat a score above `8` as advisory
+- do not guess an exact CRAP number when tool evidence is unavailable
+- do not mask a high score with unrelated cleanup outside the bounded change
+- do not claim the gate passed unless the metric evidence supports that result
+
+# Exit Checks
+
+- every relevant method is backed by CRAP evidence or an explicit missing
+  evidence note
+- no relevant method exceeds CRAP score `8` without a failing result
+- any refactor or test addition preserves behavior and stays bounded to the
+  identified risk

--- a/skills/quality-crap/examples/crap-review-finding.md
+++ b/skills/quality-crap/examples/crap-review-finding.md
@@ -1,0 +1,10 @@
+# Example CRAP Finding
+
+The bounded change still fails `quality-crap`.
+
+- `OrderRetryService#retryFailedOrders`: CRAP `11.2`
+- threshold: `<= 8`
+- evidence source: local `crap-java-check`
+
+Suggested next step: flatten the nested retry/error handling branches and add a
+focused test for the timeout path before re-running the gate.

--- a/skills/quality-crap/references/crap-threshold.md
+++ b/skills/quality-crap/references/crap-threshold.md
@@ -1,0 +1,15 @@
+# CRAP Threshold Notes
+
+Distilled from the repository quality-gate expectations and the `quality-crap`
+issue contract.
+
+- Hard threshold: relevant methods in the bounded scope must have CRAP score
+  `<= 8`.
+- Prefer the strongest available evidence source:
+  CI gate, local report, or other authoritative tooling output.
+- If no report is available for the bounded scope, treat that as missing
+  evidence rather than as an automatic pass.
+- CRAP combines structural complexity and test coverage risk, so reductions may
+  come from either clearer code shape or stronger focused tests.
+- Good reduction levers include early-return refactors, extracting cohesive
+  branches, and covering previously untested risky paths.


### PR DESCRIPTION
## Summary
- add the canonical quality-crap skill bundle
- document the hard CRAP threshold of <= 8 and the evidence order
- add a supporting reference and review-finding example

Closes #1