### PR TITLE
Add correctness-equals-hashcode skill

### DIFF
--- a/skills/correctness-equals-hashcode/SKILL.md
+++ b/skills/correctness-equals-hashcode/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: correctness-equals-hashcode
+description: >-
+  Verify the equals/hashCode contract for touched Java equality code and check
+  Comparable consistency when applicable.
+---
+<!-- markdownlint-disable MD025 -->
+
+# Purpose
+
+Verify that touched Java `equals(...)` and `hashCode()` implementations still
+satisfy the official equality contract and remain consistent with
+`Comparable` when the type implements it.
+
+# When to Use
+
+- use when a Java `equals(...)` and/or `hashCode()` implementation was added,
+  changed, or regenerated
+- use when Lombok, records, IDE generation, or field selection changes affect
+  Java equality semantics
+- use when the Java type implements `Comparable` and equality changes could
+  break the "consistent with equals" expectation
+- use `references/equals-hashcode-contract.md` for the equality contract and
+  field-selection checks
+- use `references/comparable-consistency.md` when `Comparable` is implemented
+- use `examples/equality-review-finding.md` when reporting a contract failure
+
+# Inputs
+
+- the touched Java type and its current `equals(...)`, `hashCode()`, or
+  generated-equality configuration
+- the fields that define the type's semantic identity
+- whether the type implements `Comparable`
+- relevant tests or callers that rely on equality, hashing, or sorted
+  collections
+- `references/equals-hashcode-contract.md`
+- `references/comparable-consistency.md` when `Comparable` is implemented
+
+# Workflow
+
+1. Identify whether the bounded Java change touched `equals(...)`,
+   `hashCode()`, or the field/configuration set that drives generated equality.
+2. Verify the equality contract from
+   `references/equals-hashcode-contract.md`:
+   reflexive, symmetric, transitive, consistent, and `false` for `null`.
+3. Verify that equal objects always produce the same hash code and that
+   `hashCode()` uses the same semantic field set as `equals(...)`.
+4. Review the selected equality fields for type semantics:
+   include the fields that define identity, exclude fields that would make
+   equality unstable or semantically misleading.
+5. If the type implements `Comparable`, apply
+   `references/comparable-consistency.md` and verify that
+   `compareTo(...) == 0` stays consistent with `equals(...)`, or that any
+   intentional deviation is explicit and safe for the bounded use case.
+6. Use `examples/equality-review-finding.md` when communicating a failing
+   contract or missing test coverage.
+
+# Outputs
+
+- a pass or fail result for the touched equality implementation
+- concrete findings for violated equals/hashCode or Comparable consistency
+  rules
+- a concise remediation direction when the Java equality contract is broken
+
+# Guardrails
+
+- do not treat matching hash codes as proof that `equals(...)` is correct
+- do not accept `equals(...)` and `hashCode()` using different semantic field
+  sets
+- do not ignore `Comparable` consistency when the type implements it
+- do not keep equality definitions that depend on unstable or semantically
+  irrelevant fields without an explicit bounded rationale
+
+# Exit Checks
+
+- the touched Java equality implementation satisfies the equals/hashCode
+  contract
+- equal objects always have identical hash codes
+- the semantic field set is consistent across `equals(...)` and `hashCode()`
+- `Comparable` consistency was checked whenever the type implements it
+- any remaining failure is reported with a concrete contract violation and next
+  step

--- a/skills/correctness-equals-hashcode/examples/equality-review-finding.md
+++ b/skills/correctness-equals-hashcode/examples/equality-review-finding.md
@@ -1,0 +1,9 @@
+# Example Equality Review Finding
+
+```text
+The updated `equals(...)` and `hashCode()` implementations use different field
+sets: `equals(...)` compares `id` and `tenantId`, but `hashCode()` only hashes
+`id`. That violates the equals/hashCode contract because equal objects must
+always produce the same hash code. Update `hashCode()` to use the same semantic
+identity fields as `equals(...)`, then rerun the equality-focused tests.
+```

--- a/skills/correctness-equals-hashcode/references/comparable-consistency.md
+++ b/skills/correctness-equals-hashcode/references/comparable-consistency.md
@@ -1,0 +1,15 @@
+# Comparable Consistency
+
+Distilled from the Java `Comparable` expectation plus the issue requirement.
+
+- If a Java type implements `Comparable`, check whether `compareTo(...) == 0`
+  matches `equals(...)`.
+- The default safe expectation is that ordering equality and object equality are
+  consistent.
+- If `compareTo(...) == 0` can hold for objects that are not equal, treat that
+  as a high-risk deviation and require an explicit bounded rationale.
+- Review sorted collections and maps carefully when equality and ordering can
+  diverge, because duplicates or lookup behavior may become surprising.
+
+This skill only verifies the equality-consistency aspect. Broader ordering
+correctness belongs in `correctness-comparable`.

--- a/skills/correctness-equals-hashcode/references/equals-hashcode-contract.md
+++ b/skills/correctness-equals-hashcode/references/equals-hashcode-contract.md
@@ -1,0 +1,21 @@
+# equals/hashCode Contract
+
+Distilled from the Java equality contract plus the issue requirements.
+
+- `equals(...)` must be reflexive:
+  `x.equals(x)` must be `true`.
+- `equals(...)` must be symmetric:
+  if `x.equals(y)` is `true`, then `y.equals(x)` must also be `true`.
+- `equals(...)` must be transitive:
+  if `x.equals(y)` and `y.equals(z)` are `true`, then `x.equals(z)` must also
+  be `true`.
+- `equals(...)` must be consistent for an unchanged object state.
+- `x.equals(null)` must return `false`.
+- If two objects are equal, they must produce the same hash code.
+- `equals(...)` and `hashCode()` must use the same semantic field set.
+- Review the chosen field set explicitly:
+  include the fields that define the type's semantic identity and exclude
+  fields that would make equality unstable or semantically misleading.
+
+These checks apply whether equality is handwritten, record-derived, or
+generated through tooling such as Lombok or an IDE.


### PR DESCRIPTION
## Summary
- add the `correctness-equals-hashcode` leaf skill bundle
- document the Java equality contract and hash consistency checks
- add Comparable consistency guidance for touched equality code

Closes #23

## Verification
- `./gradlew qualityGate`
- `npx --yes markdownlint-cli2 "**/*.md" "!**/node_modules/**" --config .markdownlint.json`