### PR TITLE
Add correctness-comparable skill

### DIFF
--- a/skills/correctness-comparable/SKILL.md
+++ b/skills/correctness-comparable/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: correctness-comparable
+description: >-
+  Verify Java Comparable implementations, including ordering semantics and the
+  consistent-with-equals expectation.
+---
+<!-- markdownlint-disable MD025 -->
+
+# Purpose
+
+Verify that a touched Java `Comparable` implementation defines a safe ordering
+and does not violate the "consistent with equals" expectation.
+
+# When to Use
+
+- use when a Java type adds, changes, or relies on `Comparable`
+- use when `compareTo(...)`, ordering fields, or sorted-collection behavior is
+  touched
+- use when a Java type implementing `Comparable` also defines custom equality
+  and the ordering/equality relationship must be checked explicitly
+- use `references/comparable-contract.md` for the ordering and equality
+  consistency checks
+- use `examples/comparable-review-finding.md` when reporting a failing
+  Comparable implementation
+
+# Inputs
+
+- the touched Java type and its `compareTo(...)` implementation
+- the fields that define the intended ordering
+- whether the Java type also overrides `equals(...)` and `hashCode()`
+- any bounded usage in sorted collections, maps, or ordered APIs
+- `references/comparable-contract.md`
+
+# Workflow
+
+1. Identify whether the bounded Java change touched `compareTo(...)`, ordering
+   fields, or any generated/composed comparison logic.
+2. Verify the ordering contract from `references/comparable-contract.md`:
+   sign symmetry, transitivity, and stable zero-comparison behavior.
+3. Verify that `compareTo(...) == 0` is consistent with `equals(...)`, or treat
+   any intentional deviation as a high-risk case that must be explicit and
+   safe for the bounded use.
+4. Review the selected ordering fields for semantic stability so sorted
+   collections or maps do not behave unexpectedly.
+5. Use `examples/comparable-review-finding.md` when communicating the failing
+   contract or missing coverage.
+
+# Outputs
+
+- a pass or fail result for the touched Java Comparable implementation
+- concrete findings for ordering or equality-consistency violations
+- a concise remediation direction when the ordering contract is broken
+
+# Guardrails
+
+- do not accept a `Comparable` implementation that violates sign symmetry or
+  transitivity
+- do not ignore the "consistent with equals" expectation when `compareTo(...)`
+  can return `0`
+- do not keep ordering based on unstable or semantically irrelevant fields
+  without an explicit bounded rationale
+- do not use this skill as a substitute for `correctness-equals-hashcode` when
+  the bounded change also requires a full equality-contract review
+
+# Exit Checks
+
+- the touched `Comparable` implementation satisfies the ordering contract
+- `compareTo(...) == 0` has been checked against `equals(...)`
+- sorted-collection or ordered-API behavior remains safe for the bounded case
+- any remaining failure is reported with a concrete contract violation and next
+  step

--- a/skills/correctness-comparable/examples/comparable-review-finding.md
+++ b/skills/correctness-comparable/examples/comparable-review-finding.md
@@ -1,0 +1,9 @@
+# Example Comparable Review Finding
+
+```text
+The updated `compareTo(...)` returns `0` whenever `priority` matches, but
+`equals(...)` still compares both `priority` and `id`. That makes the natural
+ordering inconsistent with equals, so a `TreeSet` or `TreeMap` can collapse
+distinct objects unexpectedly. Align `compareTo(...)` with the same semantic
+identity, or document and bound the deviation explicitly before merging.
+```

--- a/skills/correctness-comparable/references/comparable-contract.md
+++ b/skills/correctness-comparable/references/comparable-contract.md
@@ -1,0 +1,20 @@
+# Comparable Contract
+
+Distilled from the Java `Comparable` contract and the issue requirement.
+
+- `x.compareTo(y)` and `y.compareTo(x)` must have opposite signs when both are
+  valid to compare.
+- The ordering must be transitive.
+- If `x.compareTo(y) == 0`, then comparisons against a third value must behave
+  consistently with that zero-result.
+- The default safe expectation is that `x.compareTo(y) == 0` implies
+  `x.equals(y)`.
+- If a Java type intentionally diverges from that equality expectation, treat
+  it as a high-risk bounded exception and review every sorted collection or map
+  use carefully.
+- Ordering fields should be semantically stable and should not make
+  `Comparable` behavior surprising or inconsistent during normal use.
+
+This skill is focused on ordering correctness. Use
+`correctness-equals-hashcode` when the bounded change also needs a full
+equality-contract review.


### PR DESCRIPTION
## Summary
- add the `correctness-comparable` leaf skill bundle
- document the Java Comparable contract and ordering checks
- document the consistent-with-equals expectation for natural ordering

Closes #26

## Verification
- `./gradlew qualityGate`
- `npx --yes markdownlint-cli2 "**/*.md" "!**/node_modules/**" --config .markdownlint.json`