### PR TITLE
Add pr-write-description skill

### DIFF
--- a/skills/pr-write-description/SKILL.md
+++ b/skills/pr-write-description/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: pr-write-description
-description: Write concise pull request descriptions for code reviewers. Use when opening or updating a GitHub PR description with implementation summary, review focus, validation, and residual risk.
+description: >-
+  Write concise pull request descriptions for code reviewers. Use when opening
+  or updating a GitHub PR description with implementation summary, review
+  focus, validation, and residual risk.
 ---
 <!-- markdownlint-disable MD025 -->
 

--- a/skills/pr-write-description/SKILL.md
+++ b/skills/pr-write-description/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: pr-write-description
+description: Write concise pull request descriptions for code reviewers. Use when opening or updating a GitHub PR description with implementation summary, review focus, validation, and residual risk.
+---
+<!-- markdownlint-disable MD025 -->
+
+# Purpose
+
+Write a reviewer-focused PR description that makes scope, non-obvious changes,
+validation, and residual risk easy to scan before review starts.
+
+# When to Use
+
+- use when opening a new GitHub PR for implementation work
+- use when updating a PR description after scope or validation changes
+- use when another workflow needs a concise reviewer-facing implementation
+  summary
+- use `references/pr-description-template.md` for the canonical reviewer-facing
+  section layout
+- use `references/reviewer-focus.md` to decide what reviewers may skim versus
+  where they should pay attention
+- use `examples/pull-request-description.md` when a concrete output shape helps
+- use `formatting-github-comment` after the content is decided and needs final
+  GitHub Markdown normalization
+
+# Inputs
+
+- the issue or implementation concern being delivered
+- the bounded scope of the PR
+- the key changes and explicit non-goals
+- generated, copied, or otherwise low-risk files reviewers may skim
+- non-obvious logic, decisions, or tradeoffs reviewers should inspect closely
+- tests executed, manual checks, and residual risks
+- `references/pr-description-template.md` and
+  `references/reviewer-focus.md`
+
+# Workflow
+
+1. Identify the single issue or concern the PR is meant to deliver.
+2. Summarize the scope, key changes, and explicit non-goals in a short
+   implementation summary.
+3. Call out files or change categories reviewers may skim, such as generated
+   files, copied templates, or standard imports.
+4. Highlight non-obvious logic, tradeoffs, and review focus areas that deserve
+   close inspection.
+5. Record concrete validation evidence, including tests run, manual checks, and
+   any remaining residual risk.
+6. Use `references/pr-description-template.md` as the baseline shape and
+   `references/reviewer-focus.md` when deciding what belongs in review focus
+   versus the implementation summary.
+7. Use `examples/pull-request-description.md` when a concrete GitHub-ready
+   example helps.
+8. Hand the final draft to `formatting-github-comment` when Markdown
+   normalization is still needed before posting.
+
+# Outputs
+
+- a reviewer-focused PR description with implementation summary, review focus,
+  and validation sections
+- explicit note of non-goals and residual risk
+- a concise artifact that can be posted directly to GitHub after formatting
+
+# Guardrails
+
+- do not restate the entire diff file-by-file
+- do not hide important review focus behind generic summary prose
+- do not omit residual risk just because checks are green
+- do not broaden this skill into PR review-thread handling or merge decisions
+- do not emit literal `\n` escape sequences in Markdown meant for GitHub
+
+# Exit Checks
+
+- the PR scope is clear and tied to one implementation concern
+- reviewers can tell what to skim and what to inspect closely
+- tests, manual checks, and residual risks are explicit
+- the description is concise enough to work as a GitHub PR body

--- a/skills/pr-write-description/examples/pull-request-description.md
+++ b/skills/pr-write-description/examples/pull-request-description.md
@@ -1,0 +1,19 @@
+# Example Pull Request Description
+
+## Implementation Summary
+- Scope: add the `pr-write-description` skill and its supporting references
+- Key changes: define the reviewer-facing PR body shape, review-focus guidance,
+  and one GitHub-ready example
+- Non-goals: PR review handling, merge decisions, or issue-comment authoring
+
+## Review Focus
+- Generated/copied files and standard imports that can be skimmed: none
+- Non-obvious code paths and rationale: the skill separates reviewer-facing
+  scope from validation so PR descriptions stay concise and scannable
+
+## Validation
+- Tests executed: `./gradlew qualityGate`; `npx --yes markdownlint-cli2
+  "**/*.md" "!**/node_modules/**" --config .markdownlint.json`
+- Manual checks: verified the skill references only existing bundled files
+- Residual risks: reviewer-focus guidance still depends on the calling workflow
+  surfacing the right diff context

--- a/skills/pr-write-description/references/pr-description-template.md
+++ b/skills/pr-write-description/references/pr-description-template.md
@@ -1,0 +1,23 @@
+# PR Description Template
+
+Use this template when a PR description needs a predictable reviewer-facing
+shape.
+
+```md
+## Implementation Summary
+- Scope:
+- Key changes:
+- Non-goals:
+
+## Review Focus
+- Generated/copied files and standard imports that can be skimmed:
+- Non-obvious code paths and rationale:
+
+## Validation
+- Tests executed:
+- Manual checks:
+- Residual risks:
+```
+
+Keep each bullet concrete. Replace placeholders instead of leaving generic text
+in place.

--- a/skills/pr-write-description/references/reviewer-focus.md
+++ b/skills/pr-write-description/references/reviewer-focus.md
@@ -1,0 +1,16 @@
+# Reviewer Focus
+
+Use the `Review Focus` section to steer reviewer attention deliberately.
+
+Include:
+
+- non-obvious control flow or business rules
+- unusual tradeoffs or compatibility decisions
+- places where correctness depends on subtle assumptions
+- files that look noisy but are safe to skim quickly
+
+Avoid:
+
+- repeating every changed file
+- generic statements like "please review everything"
+- validation details that belong in the `Validation` section


### PR DESCRIPTION
## Implementation Summary
- Scope: add the `pr-write-description` skill for reviewer-focused PR bodies
- Key changes: add the skill definition, a canonical PR description template, reviewer-focus guidance, and a GitHub-ready example
- Non-goals: PR review handling, merge workflow, or issue-comment authoring

## Review Focus
- Generated/copied files and standard imports that can be skimmed: bundled example and reference Markdown files
- Non-obvious code paths and rationale: the skill keeps review focus separate from validation so PR descriptions stay concise and scannable

## Validation
- Tests executed: `./gradlew qualityGate`; `npx --yes markdownlint-cli2 "**/*.md" "!**/node_modules/**" --config .markdownlint.json`
- Manual checks: verified the skill references only bundled files and the existing formatting skill by name
- Residual risks: later PR family skills may refine the workflow around this writer, but the writer scope is intentionally narrow

Closes #8
