### PR TITLE
Add issue-write-summary-comment skill

### DIFF
--- a/skills/issue-write-summary-comment/SKILL.md
+++ b/skills/issue-write-summary-comment/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: issue-write-summary-comment
-description: Write short GitHub issue summary comments for product owners, reviewers, and QA. Use when reporting delivered scope, validation status, QA notes, and follow-ups on an issue.
+description: >-
+  Write short GitHub issue summary comments for product owners, reviewers,
+  and QA. Use when reporting delivered scope, validation status, QA notes,
+  and follow-ups on an issue.
 ---
 <!-- markdownlint-disable MD025 -->
 

--- a/skills/issue-write-summary-comment/SKILL.md
+++ b/skills/issue-write-summary-comment/SKILL.md
@@ -15,7 +15,7 @@ validated, and what follow-up attention remains for non-implementer readers.
 - use when product owners, reviewers, or QA need a short implementation outcome
   comment
 - use when a PR landed and the issue needs a concise summary of scope,
-  validation, and open risk
+  validation, and open risks
 - use `references/issue-summary-template.md` for the canonical summary-comment
   shape
 - use `references/audience-focus.md` when deciding what matters to PO, reviewer,
@@ -28,7 +28,7 @@ validated, and what follow-up attention remains for non-implementer readers.
 # Inputs
 
 - what was delivered or changed
-- acceptance-criteria or scope status
+- acceptance criteria or scope status
 - validation status, executed tests, and manual checks
 - QA notes, test focus, and open risks or follow-ups
 - `references/issue-summary-template.md` and

--- a/skills/issue-write-summary-comment/SKILL.md
+++ b/skills/issue-write-summary-comment/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: issue-write-summary-comment
+description: Write short GitHub issue summary comments for product owners, reviewers, and QA. Use when reporting delivered scope, validation status, QA notes, and follow-ups on an issue.
+---
+<!-- markdownlint-disable MD025 -->
+
+# Purpose
+
+Write a concise issue comment that summarizes what was delivered, how it was
+validated, and what follow-up attention remains for non-implementer readers.
+
+# When to Use
+
+- use when posting a delivery or status summary on a linked GitHub issue
+- use when product owners, reviewers, or QA need a short implementation outcome
+  comment
+- use when a PR landed and the issue needs a concise summary of scope,
+  validation, and open risk
+- use `references/issue-summary-template.md` for the canonical summary-comment
+  shape
+- use `references/audience-focus.md` when deciding what matters to PO, reviewer,
+  and QA audiences
+- use `examples/issue-summary-comment.md` when a concrete GitHub-ready example
+  helps
+- use `formatting-github-comment` after the content is decided and needs final
+  GitHub Markdown normalization
+
+# Inputs
+
+- what was delivered or changed
+- acceptance-criteria or scope status
+- validation status, executed tests, and manual checks
+- QA notes, test focus, and open risks or follow-ups
+- `references/issue-summary-template.md` and
+  `references/audience-focus.md`
+
+# Workflow
+
+1. State what was delivered in plain language instead of repeating commit
+   history.
+2. Summarize acceptance or scope status at the level relevant to the issue.
+3. Record validation status, including tests run and important manual checks.
+4. Add QA focus and open risks only when they help downstream readers act.
+5. Use `references/issue-summary-template.md` to keep the comment short and
+   structured.
+6. Use `references/audience-focus.md` when deciding whether a detail belongs in
+   the issue summary or in a more technical PR discussion.
+7. Use `examples/issue-summary-comment.md` when a concrete GitHub-ready shape
+   helps.
+8. Hand the final draft to `formatting-github-comment` when Markdown
+   normalization is still needed before posting.
+
+# Outputs
+
+- a short GitHub issue comment describing delivery status, validation, QA
+  focus, and open follow-ups
+- a comment shape suitable for product owners, reviewers, and QA readers
+
+# Guardrails
+
+- do not turn the issue comment into a second PR description
+- do not omit validation status when delivery is claimed
+- do not hide open risks or follow-ups behind vague status language
+- do not emit literal `\n` escape sequences in Markdown meant for GitHub
+- do not broaden this skill into issue creation or PR review handling
+
+# Exit Checks
+
+- the comment states what was delivered and how it was validated
+- QA focus and follow-up items are explicit when they exist
+- the summary stays concise enough for issue discussion flow
+- the result is ready for GitHub posting after formatting

--- a/skills/issue-write-summary-comment/examples/issue-summary-comment.md
+++ b/skills/issue-write-summary-comment/examples/issue-summary-comment.md
@@ -1,0 +1,11 @@
+# Example Issue Summary Comment
+
+- Delivered: added `issue-write-summary-comment` with a canonical summary
+  template, audience guidance, and one GitHub-ready example
+- Acceptance criteria status: issue-summary comments can now reuse one concise
+  structure for delivery, validation, and follow-ups
+- Validation status: `./gradlew qualityGate` and markdownlint passed locally
+- QA notes / test focus: verify later workflows keep issue comments shorter than
+  the matching PR descriptions
+- Open risks or follow-ups: issue creation and PR-to-issue orchestration remain
+  separate skills

--- a/skills/issue-write-summary-comment/references/audience-focus.md
+++ b/skills/issue-write-summary-comment/references/audience-focus.md
@@ -1,0 +1,15 @@
+# Audience Focus
+
+Write the issue summary for cross-functional readers.
+
+Prefer:
+
+- plain delivery language over commit-by-commit detail
+- validation signals that QA or reviewers can trust quickly
+- explicit follow-ups when work is intentionally deferred
+
+Avoid:
+
+- deep implementation rationale better suited to the PR description
+- diff-level technical noise
+- vague status phrases such as "done" with no validation context

--- a/skills/issue-write-summary-comment/references/issue-summary-template.md
+++ b/skills/issue-write-summary-comment/references/issue-summary-template.md
@@ -1,0 +1,14 @@
+# Issue Summary Template
+
+Use this shape when the issue comment needs a predictable delivery summary.
+
+```md
+- Delivered:
+- Acceptance criteria status:
+- Validation status:
+- QA notes / test focus:
+- Open risks or follow-ups:
+```
+
+Omit a line only when it is genuinely not applicable and that omission will not
+mislead the reader.


### PR DESCRIPTION
## Implementation Summary
- Scope: add the `issue-write-summary-comment` skill for short delivery/status comments on GitHub issues
- Key changes: add the skill definition, canonical issue-summary template, audience guidance, and a GitHub-ready example
- Non-goals: issue creation, PR description writing, or review handling

## Review Focus
- Generated/copied files and standard imports that can be skimmed: bundled example and reference Markdown files
- Non-obvious code paths and rationale: the skill is aimed at PO, reviewer, and QA audiences, so it deliberately avoids turning issue comments into second PR descriptions

## Validation
- Tests executed: `./gradlew qualityGate`; `npx --yes markdownlint-cli2 "**/*.md" "!**/node_modules/**" --config .markdownlint.json`
- Manual checks: verified the summary shape aligns with the existing issue-tracker summary guidance from `ai-rules`
- Residual risks: later orchestration skills may decide when to post the comment, but not its core content model

Closes #10
