### PR TITLE
Add issue-write-description skill

### DIFF
--- a/skills/issue-write-description/SKILL.md
+++ b/skills/issue-write-description/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: issue-write-description
+description: Write structured GitHub issue descriptions for implementation, backlog, or follow-up work. Use when opening or updating issue bodies and when another workflow needs a concise issue template.
+---
+<!-- markdownlint-disable MD025 -->
+
+# Purpose
+
+Write a clear GitHub issue description that explains the problem, the intended
+outcome, and the relevant constraints without turning the issue into a long
+design document.
+
+# When to Use
+
+- use when opening a GitHub issue for implementation, backlog, or follow-up
+  work
+- use when updating an existing issue body after scope or assumptions change
+- use when another workflow needs a reusable, concise issue-description shape
+- use `references/issue-description-structure.md` for the canonical section
+  order and field expectations
+- use `references/github-issue-publishing.md` when the description will be
+  posted with `gh issue create` or `gh issue edit`
+- use `examples/implementation-issue.md` when a concrete issue-body shape helps
+- use `formatting-github-comment` after the content is decided and needs final
+  GitHub Markdown normalization
+
+# Inputs
+
+- the problem or opportunity the issue should capture
+- the intended outcome or requested change
+- scope boundaries, constraints, and assumptions
+- optional acceptance checks, verification notes, or non-goals
+- `references/issue-description-structure.md` and
+  `references/github-issue-publishing.md`
+
+# Workflow
+
+1. State the problem in concrete terms instead of generic backlog language.
+2. Describe the intended outcome and the bounded scope of the issue.
+3. Add important constraints, assumptions, or non-goals only when they help a
+   later implementer avoid avoidable mistakes.
+4. Include concrete validation or acceptance notes when they materially shape
+   implementation or review.
+5. Use `references/issue-description-structure.md` to keep the body concise and
+   complete.
+6. Use `references/github-issue-publishing.md` before posting or updating the
+   issue through GitHub tooling.
+7. Use `examples/implementation-issue.md` when a concrete GitHub-ready shape
+   helps.
+8. Hand the final draft to `formatting-github-comment` when Markdown
+   normalization is still needed before posting.
+
+# Outputs
+
+- a GitHub-ready issue description with problem, outcome, scope, and relevant
+  constraints
+- optional acceptance or validation notes when they materially affect later
+  work
+- a concise issue body that can be posted directly after formatting
+
+# Guardrails
+
+- do not turn the issue body into an implementation transcript
+- do not leave the problem statement implicit
+- do not omit key scope boundaries or non-goals when they materially matter
+- do not emit literal `\n` escape sequences in Markdown meant for GitHub
+- do not broaden this skill into issue creation, assignment, or implementation
+  workflow
+
+# Exit Checks
+
+- the issue explains the problem and intended outcome in one pass
+- scope boundaries and key assumptions are explicit
+- the issue body is concise enough for GitHub discussion flow
+- the Markdown is safe to publish through `gh issue create` or `gh issue edit`

--- a/skills/issue-write-description/SKILL.md
+++ b/skills/issue-write-description/SKILL.md
@@ -38,7 +38,7 @@ design document.
 1. State the problem in concrete terms instead of generic backlog language.
 2. Describe the intended outcome and the bounded scope of the issue.
 3. Add important constraints, assumptions, or non-goals only when they help a
-   later implementer avoid avoidable mistakes.
+   later implementer avoid common mistakes.
 4. Include concrete validation or acceptance notes when they materially shape
    implementation or review.
 5. Use `references/issue-description-structure.md` to keep the body concise and

--- a/skills/issue-write-description/SKILL.md
+++ b/skills/issue-write-description/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: issue-write-description
-description: Write structured GitHub issue descriptions for implementation, backlog, or follow-up work. Use when opening or updating issue bodies and when another workflow needs a concise issue template.
+description: >-
+  Write structured GitHub issue descriptions for implementation, backlog, or
+  follow-up work. Use when opening or updating issue bodies and when another
+  workflow needs a concise issue template.
 ---
 <!-- markdownlint-disable MD025 -->
 

--- a/skills/issue-write-description/examples/implementation-issue.md
+++ b/skills/issue-write-description/examples/implementation-issue.md
@@ -1,0 +1,17 @@
+# Example Issue Description
+
+## Summary
+- Problem: authoring workflows need a reusable way to write concise GitHub
+  issue bodies
+- Outcome: add an `issue-write-description` skill with one canonical structure,
+  publishing notes, and a concrete example
+
+## Scope
+- In scope: skill definition, bundled references, and a GitHub-ready example
+- Out of scope: issue creation, assignment, or project-board updates
+
+## Notes
+- Constraints / assumptions: keep the issue body concise and compatible with
+  `gh issue create --body-file`
+- Validation / acceptance notes: markdownlint and repository quality checks
+  must still pass after the skill is added

--- a/skills/issue-write-description/references/github-issue-publishing.md
+++ b/skills/issue-write-description/references/github-issue-publishing.md
@@ -1,0 +1,10 @@
+# GitHub Issue Publishing
+
+When posting or updating a GitHub issue body from the CLI:
+
+- prefer `gh issue create --body-file <path>` for new issues
+- prefer `gh issue edit <id> --body-file <path>` for updates
+- block publish if the body still contains literal `\n` escape sequences
+- verify the rendered issue keeps headings, bullets, and code blocks intact
+
+Use raw Markdown with real newlines instead of escaped JSON-style strings.

--- a/skills/issue-write-description/references/issue-description-structure.md
+++ b/skills/issue-write-description/references/issue-description-structure.md
@@ -1,0 +1,20 @@
+# Issue Description Structure
+
+Use this structure when the issue body needs a predictable shape.
+
+```md
+## Summary
+- Problem:
+- Outcome:
+
+## Scope
+- In scope:
+- Out of scope:
+
+## Notes
+- Constraints / assumptions:
+- Validation / acceptance notes:
+```
+
+Compress sections when the issue is simple, but keep the problem and outcome
+explicit.


### PR DESCRIPTION
## Implementation Summary
- Scope: add the `issue-write-description` skill for concise GitHub issue bodies
- Key changes: add the skill definition, canonical issue-body structure, GitHub publishing notes, and one implementation-issue example
- Non-goals: issue creation, assignment, or project-board workflow

## Review Focus
- Generated/copied files and standard imports that can be skimmed: bundled example and reference Markdown files
- Non-obvious code paths and rationale: the skill separates issue-body structure from publishing mechanics so later workflows can compose it safely

## Validation
- Tests executed: `./gradlew qualityGate`; `npx --yes markdownlint-cli2 "**/*.md" "!**/node_modules/**" --config .markdownlint.json`
- Manual checks: verified the guidance matches the existing GitHub formatting and body-file publishing constraints
- Residual risks: later issue orchestration skills may refine the surrounding flow, but the description contract is intentionally narrow

Closes #9
