### PR TITLE
Add skill-improve capture skill

### DIFF
--- a/skills/skill-improve/SKILL.md
+++ b/skills/skill-improve/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: skill-improve
-description: Capture an improvement proposal for an existing skill as a canonical backlog entry. Use when normal work reveals a reusable improvement to a public or centrally maintained skill and the improvement should be recorded without blocking the current task.
+description: >-
+  Capture an improvement proposal for an existing skill as a canonical
+  backlog entry. Use when normal work reveals a reusable improvement to a
+  public or centrally maintained skill and the improvement should be recorded
+  without blocking the current task.
 ---
 <!-- markdownlint-disable MD025 -->
 

--- a/skills/skill-improve/SKILL.md
+++ b/skills/skill-improve/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: skill-improve
+description: Capture an improvement proposal for an existing skill as a canonical backlog entry. Use when normal work reveals a reusable improvement to a public or centrally maintained skill and the improvement should be recorded without blocking the current task.
+---
+<!-- markdownlint-disable MD025 -->
+
+# Purpose
+
+Capture a reusable improvement proposal for an existing skill so central
+improvements to the `ai-skills` catalog are not lost when they are discovered
+during unrelated daily work.
+
+# When to Use
+
+- use when normal work reveals a missing behavior, weak guidance, or other
+  reusable improvement to an existing skill
+- use when the target skill belongs to the public `ai-skills` catalog and the
+  improvement should be proposed centrally for everyone
+- use when GitHub access is unavailable and the same canonical improvement
+  record must be preserved as local Markdown instead
+- use `references/improvement-triage.md` to decide whether the observed gap is
+  worth central capture
+- use `references/backlog-target-selection.md` to decide between GitHub and
+  local Markdown storage
+- use `examples/public-skill-improvement-issue.md` and
+  `examples/local-skill-improvement-entry.md` when a concrete rendered example
+  helps
+- use `skill-template` to normalize the canonical field set before rendering
+- use `formatting-github-comment` when the GitHub issue body still needs final
+  Markdown normalization
+
+# Inputs
+
+- the existing skill id or name
+- the observed gap, defect, or missing guidance
+- why the improvement is reusable beyond the current task
+- when the missing behavior matters or gets triggered
+- the rough improvement proposal or expected change in behavior
+- related skills, dependencies, or adjacent skill families
+- source context or notes from the originating task
+- `references/improvement-triage.md` and
+  `references/backlog-target-selection.md`
+
+# Workflow
+
+1. Confirm the observation is a reusable improvement to an existing skill
+   rather than only a local workaround or private policy difference.
+2. Use `references/improvement-triage.md` to decide whether the proposal should
+   be captured centrally.
+3. Normalize the improvement with `skill-template`, using `change-type:
+   improve` and recording the target skill, motivation, reusability rationale,
+   trigger conditions, rough improvement shape, related skills, source
+   context, and status.
+4. Choose the storage target with
+   `references/backlog-target-selection.md`: GitHub issue when the improvement
+   belongs in the public `ai-skills` backlog and access exists, otherwise local
+   Markdown.
+5. Render the canonical improvement entry for the chosen target without
+   changing the underlying semantics.
+6. Hand GitHub-bound Markdown to `formatting-github-comment` when the rendered
+   issue body still needs final normalization.
+7. Stop after the improvement proposal is captured and return any current
+   implementation work to the normal agent workflow outside this skill.
+
+# Outputs
+
+- a canonical backlog entry for improving an existing skill
+- a GitHub issue rendering when central publication is appropriate and possible
+- a local Markdown rendering when GitHub is unavailable or inappropriate
+
+# Guardrails
+
+- do not implement the skill improvement inside this capture workflow
+- do not create a central backlog item for a purely repo-local private skill
+- do not make GitHub the only supported storage target
+- do not let central backlog capture block the current task
+- do not silently change the canonical field set between renderings
+
+# Exit Checks
+
+- the proposal targets an existing skill and uses `change-type: improve`
+- the chosen storage target matches access and publication constraints
+- the rendered record stays aligned with the canonical template
+- the workflow stops after capture and returns implementation to normal flow

--- a/skills/skill-improve/examples/local-skill-improvement-entry.md
+++ b/skills/skill-improve/examples/local-skill-improvement-entry.md
@@ -1,0 +1,18 @@
+# Example Local Skill Improvement Entry
+
+Title: Improve existing review skill with reviewer-response guidance
+Change type: improve
+Proposed skill id/name: pr-review
+Problem or motivation: current review handling guidance identifies findings but
+does not yet define a reusable response-writing child skill
+Why reusable beyond the originating task: the same response-writing gap appears
+whenever valid findings need concise, respectful replies
+When to use / trigger: when working with PR review findings that need a
+reviewer-facing response rather than only a code change
+Rough workflow or responsibilities: add a child skill that classifies the
+finding, drafts the response, and leaves merge or loop orchestration to later
+skills
+Related skills or dependencies: pr-review, pr-review-write, pr-review-loop
+Source context or notes: captured while handling review findings on a company
+laptop without permission to create a central GitHub issue
+Status: idea

--- a/skills/skill-improve/examples/public-skill-improvement-issue.md
+++ b/skills/skill-improve/examples/public-skill-improvement-issue.md
@@ -1,0 +1,18 @@
+# Example Public Skill Improvement Issue
+
+## Summary
+- Problem: the `pr-review` family lacks a child skill dedicated to writing
+  reviewer-facing responses to valid findings
+- Outcome: capture a central improvement proposal for a future
+  `pr-review-respond` skill
+
+## Scope
+- In scope: describe the improvement gap, trigger conditions, and expected
+  family relationship
+- Out of scope: implementing the improvement in the current task
+
+## Notes
+- Constraints / assumptions: the improvement should preserve the current
+  `pr-review` boundary and stay tool-agnostic
+- Validation / acceptance notes: publish as a GitHub issue in `ai-skills` when
+  access exists; otherwise keep the same record as local Markdown

--- a/skills/skill-improve/references/backlog-target-selection.md
+++ b/skills/skill-improve/references/backlog-target-selection.md
@@ -1,0 +1,18 @@
+# Backlog Target Selection
+
+Choose the target after the improvement proposal is normalized.
+
+Use a GitHub issue in `ai-skills` when:
+
+- the target skill is part of the public `ai-skills` catalog
+- the improvement should benefit the shared catalog
+- the acting environment has permission to create the issue
+
+Use a local Markdown record when:
+
+- GitHub access is unavailable
+- the current environment cannot reach the central GitHub repository
+- the improvement should still be preserved for later transfer upstream
+
+Do not block the current task if central issue creation is unavailable. Record
+the improvement locally and continue with normal work.

--- a/skills/skill-improve/references/improvement-triage.md
+++ b/skills/skill-improve/references/improvement-triage.md
@@ -1,0 +1,12 @@
+# Improvement Triage
+
+Prefer a central `ai-skills` improvement backlog entry when most of the
+following are true:
+
+- the target skill is already in the public `ai-skills` catalog
+- the observed gap is likely to affect more than one repository or user
+- the missing behavior is not only a private company policy or local exception
+- the proposed improvement can be described in tool-agnostic terms
+
+Prefer local-only capture or no separate backlog item when the observation is
+purely private, one-off, or already covered by existing skill guidance.


### PR DESCRIPTION
## Implementation Summary
- Scope: add the `skill-improve` capture skill for recording reusable improvements to existing skills
- Key changes: add the skill definition, improvement triage guidance, backlog target selection guidance, and rendered examples for GitHub and local Markdown capture
- Non-goals: implementing the improvement or blocking the current task on central backlog publication

## Review Focus
- Generated/copied files and standard imports that can be skimmed: bundled example and reference Markdown files
- Non-obvious code paths and rationale: the skill is intentionally additive to normal work and stops after central improvement capture so implementation stays in the normal agent workflow

## Validation
- Tests executed: `./gradlew qualityGate`; `npx --yes markdownlint-cli2 "**/*.md" "!**/node_modules/**" --config .markdownlint.json`
- Manual checks: verified the workflow mirrors `skill-new` while switching to `change-type: improve` and existing-skill targeting
- Residual risks: future family cleanup may factor shared capture guidance between `skill-new` and `skill-improve`, but the current boundary is explicit

Closes #37
