### PR TITLE
Add pr-review-respond skill

### DIFF
--- a/skills/pr-review-respond/SKILL.md
+++ b/skills/pr-review-respond/SKILL.md
@@ -15,7 +15,7 @@ an explicit response, and an appropriate fix or rationale.
 # When to Use
 
 - use when a PR or MR review produced actionable findings or questions
-- use when every review thread needs an explicit valid or invalid
+- use when every review thread needs an explicit valid, invalid, or unresolved
   classification
 - use when valid findings should be fixed on the branch with focused tests when
   appropriate
@@ -44,23 +44,27 @@ an explicit response, and an appropriate fix or rationale.
    focused regression test or proof of behavior.
 3. For invalid findings, explain the concrete rationale instead of dismissing
    the concern vaguely.
-4. Reply to every thread with the classification and concise outcome.
-5. Resolve handled threads only when repository or session rules allow the
+4. For unresolved findings, explain what evidence, clarification, or follow-up
+   is still needed and keep the thread open until that gap is closed.
+5. Reply to every thread with the classification and concise outcome.
+6. Resolve handled threads only when repository or session rules allow the
    current actor to resolve them.
-6. Use `references/regression-test-expectations.md` to keep fixes and tests
+7. Use `references/regression-test-expectations.md` to keep fixes and tests
    proportional to the finding.
-7. Use the bundled examples when a valid or invalid response shape helps.
+8. Use the bundled examples when a valid or invalid response shape helps.
 
 # Outputs
 
 - a classification for each handled review finding
 - bounded fixes and regression evidence for valid findings when appropriate
 - concise replies on every addressed review thread
+- explicit missing-evidence or follow-up requests for unresolved findings
 
 # Guardrails
 
 - do not leave actionable review comments unanswered
 - do not classify a finding as invalid without concrete rationale
+- do not silently treat unresolved findings as valid or invalid
 - do not skip regression evidence when a valid finding changes behavior
 - do not broaden this skill into the full review loop or final merge decision
 
@@ -69,4 +73,5 @@ an explicit response, and an appropriate fix or rationale.
 - every handled thread has an explicit classification
 - valid findings have a fix, a justified deferral, or clear blocking reason
 - invalid findings have a factual rationale
+- unresolved findings state what is still needed before closure
 - replies are concise and suitable for PR review flow

--- a/skills/pr-review-respond/SKILL.md
+++ b/skills/pr-review-respond/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: pr-review-respond
+description: >-
+  Respond to PR or MR review findings by classifying each finding, fixing
+  valid findings when appropriate, and replying to every thread with concise
+  rationale. Use when addressing review comments after a review pass.
+---
+<!-- markdownlint-disable MD025 -->
+
+# Purpose
+
+Handle review findings consistently so each thread gets a clear classification,
+an explicit response, and an appropriate fix or rationale.
+
+# When to Use
+
+- use when a PR or MR review produced actionable findings or questions
+- use when every review thread needs an explicit valid or invalid
+  classification
+- use when valid findings should be fixed on the branch with focused tests when
+  appropriate
+- use as the response-handling child skill under `pr-review`
+- use `references/finding-classification.md` for valid versus invalid
+  classification rules
+- use `references/regression-test-expectations.md` for fix and regression-test
+  expectations
+- use `examples/valid-finding-response.md` and
+  `examples/invalid-finding-response.md` when a concrete thread reply helps
+
+# Inputs
+
+- the review findings and active review threads
+- the changed scope and relevant evidence
+- repository or session rules for resolving conversations
+- available tests or focused reproduction steps
+- `references/finding-classification.md` and
+  `references/regression-test-expectations.md`
+
+# Workflow
+
+1. Classify each finding as valid, invalid, or unresolved based on the current
+   code, rules, and evidence.
+2. For valid findings, apply a bounded fix when appropriate and prefer adding a
+   focused regression test or proof of behavior.
+3. For invalid findings, explain the concrete rationale instead of dismissing
+   the concern vaguely.
+4. Reply to every thread with the classification and concise outcome.
+5. Resolve handled threads only when repository or session rules allow the
+   current actor to resolve them.
+6. Use `references/regression-test-expectations.md` to keep fixes and tests
+   proportional to the finding.
+7. Use the bundled examples when a valid or invalid response shape helps.
+
+# Outputs
+
+- a classification for each handled review finding
+- bounded fixes and regression evidence for valid findings when appropriate
+- concise replies on every addressed review thread
+
+# Guardrails
+
+- do not leave actionable review comments unanswered
+- do not classify a finding as invalid without concrete rationale
+- do not skip regression evidence when a valid finding changes behavior
+- do not broaden this skill into the full review loop or final merge decision
+
+# Exit Checks
+
+- every handled thread has an explicit classification
+- valid findings have a fix, a justified deferral, or clear blocking reason
+- invalid findings have a factual rationale
+- replies are concise and suitable for PR review flow

--- a/skills/pr-review-respond/examples/invalid-finding-response.md
+++ b/skills/pr-review-respond/examples/invalid-finding-response.md
@@ -1,0 +1,4 @@
+# Example Invalid Finding Response
+
+Invalid for the current scope. This path already routes through the shared
+validator, and the existing regression test covers the reported scenario.

--- a/skills/pr-review-respond/examples/valid-finding-response.md
+++ b/skills/pr-review-respond/examples/valid-finding-response.md
@@ -1,0 +1,4 @@
+# Example Valid Finding Response
+
+Valid. The null-path was not covered in the original change, so I added the
+guard and a regression test for the failing case in the same PR.

--- a/skills/pr-review-respond/references/finding-classification.md
+++ b/skills/pr-review-respond/references/finding-classification.md
@@ -1,0 +1,10 @@
+# Finding Classification
+
+Use these states:
+
+- `valid`: the finding identifies a real issue for the current scope
+- `invalid`: the finding does not hold given the current code, rules, or
+  evidence
+- `unresolved`: available evidence is insufficient to classify confidently
+
+Every handled finding should move into one of these states explicitly.

--- a/skills/pr-review-respond/references/regression-test-expectations.md
+++ b/skills/pr-review-respond/references/regression-test-expectations.md
@@ -1,0 +1,13 @@
+# Regression Test Expectations
+
+For valid findings:
+
+- prefer a focused regression test when behavior changed or a bug was fixed
+- keep the test scope bounded to the reported risk
+- if a regression test is not practical, explain the concrete reason in the
+  thread response
+
+For invalid findings:
+
+- add proof of correct behavior when it is cheap and materially reduces doubt
+- otherwise explain why existing behavior or tests already cover the concern


### PR DESCRIPTION
## Implementation Summary
- Scope: add the `pr-review-respond` child skill for classifying and replying to review findings
- Key changes: add the skill definition, finding-classification guidance, regression-test expectations, and valid/invalid response examples
- Non-goals: full review-loop orchestration or final merge decisions

## Review Focus
- Generated/copied files and standard imports that can be skimmed: bundled example and reference Markdown files
- Non-obvious code paths and rationale: the skill explicitly requires a reply on every handled thread while keeping merge-loop mechanics outside this child skill

## Validation
- Tests executed: `./gradlew qualityGate`; `npx --yes markdownlint-cli2 "**/*.md" "!**/node_modules/**" --config .markdownlint.json`
- Manual checks: verified the workflow reflects the issue requirements for valid/invalid classification, bounded fixes, and regression evidence
- Residual risks: later loop orchestration will decide timing and repetition, but the per-finding response contract is fixed here

Closes #4
