### PR TITLE
Add issue-create skill

### DIFF
--- a/skills/issue-create/SKILL.md
+++ b/skills/issue-create/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: issue-create
+description: >-
+  Create GitHub issues from structured intent by composing issue drafting and
+  GitHub-ready formatting. Use when a workflow needs to publish or prepare a
+  concise GitHub issue body and title for implementation, backlog, or
+  follow-up work.
+---
+<!-- markdownlint-disable MD025 -->
+
+# Purpose
+
+Create a GitHub issue, or a GitHub-ready issue artifact when permissions are
+missing, without forcing the caller to manually combine drafting, formatting,
+and publish steps.
+
+# When to Use
+
+- use when a workflow needs to open a GitHub issue for implementation, backlog,
+  or follow-up work
+- use when the issue body still needs drafting through `issue-write-description`
+- use when the issue body needs final GitHub Markdown normalization through
+  `formatting-github-comment`
+- use when GitHub issue creation is available and the issue should be published
+- use `references/github-issue-creation.md` for CLI creation/update mechanics
+- use `references/issue-create-boundary.md` to keep this skill scoped to issue
+  creation rather than implementation
+- use `examples/issue-create-flow.md` when a concrete create-or-render flow
+  helps
+
+# Inputs
+
+- the repository and target issue tracker context
+- the issue title or raw title idea
+- the problem, intended outcome, scope, and important notes for the issue body
+- optional labels, assignees, or other issue metadata
+- publication constraints such as missing GitHub access or permission
+- `references/github-issue-creation.md` and
+  `references/issue-create-boundary.md`
+
+# Workflow
+
+1. Confirm the target concern should exist as a GitHub issue rather than only
+   as a local note or PR comment.
+2. Draft the issue title and body with `issue-write-description` when the issue
+   content is still raw or incomplete.
+3. Normalize the final Markdown with `formatting-github-comment` when the
+   rendered body still needs GitHub-ready structure.
+4. Create or update the GitHub issue with the strongest available mechanism,
+   preferring body-file based publication from
+   `references/github-issue-creation.md`.
+5. If GitHub publication is unavailable, stop after producing a ready-to-post
+   title and body artifact instead of blocking the primary task.
+6. Use `references/issue-create-boundary.md` to keep this skill focused on
+   creation rather than later issue implementation or orchestration.
+7. Use `examples/issue-create-flow.md` when a concrete end-to-end flow helps.
+
+# Outputs
+
+- a created GitHub issue when publication is possible
+- a GitHub-ready issue title and body when publication is not possible
+- optional issue metadata such as labels or assignees when the caller supplied
+  them and tooling allows them
+
+# Guardrails
+
+- do not publish a raw issue body that still needs drafting or formatting
+- do not emit literal `\n` escape sequences in Markdown meant for GitHub
+- do not block the primary task solely because GitHub issue creation is
+  unavailable
+- do not broaden this skill into issue implementation or follow-up comment
+  handling
+
+# Exit Checks
+
+- the issue title and body are clear and GitHub-ready
+- the published or rendered issue artifact matches the intended scope
+- the creation path respected available permissions and tooling constraints
+- the workflow stopped at issue creation or render, not implementation

--- a/skills/issue-create/examples/issue-create-flow.md
+++ b/skills/issue-create/examples/issue-create-flow.md
@@ -1,0 +1,6 @@
+# Example Issue Create Flow
+
+1. Draft the issue body with `issue-write-description`.
+2. Normalize the Markdown with `formatting-github-comment`.
+3. Create the issue with `gh issue create --body-file <path>`.
+4. If GitHub access is missing, keep the title and body as the fallback output.

--- a/skills/issue-create/references/github-issue-creation.md
+++ b/skills/issue-create/references/github-issue-creation.md
@@ -2,8 +2,8 @@
 
 Prefer body-file based publication when working through the GitHub CLI.
 
-- use `gh issue create --title <title> --body-file <path>` for new issues
-- use `gh issue edit <number> --title <title> --body-file <path>` for updates
+- use `gh issue create --body-file <path>` for new issues
+- use `gh issue edit <id> --body-file <path>` for updates
 - use raw Markdown with real newlines, not escaped `\n` sequences
 - verify the rendered issue preserves headings, bullets, and code blocks
 - apply labels or assignees only when they are known and supported by the

--- a/skills/issue-create/references/github-issue-creation.md
+++ b/skills/issue-create/references/github-issue-creation.md
@@ -1,0 +1,10 @@
+# GitHub Issue Creation
+
+Prefer body-file based publication when working through the GitHub CLI.
+
+- use `gh issue create --title <title> --body-file <path>` for new issues
+- use `gh issue edit <number> --title <title> --body-file <path>` for updates
+- use raw Markdown with real newlines, not escaped `\n` sequences
+- verify the rendered issue preserves headings, bullets, and code blocks
+- apply labels or assignees only when they are known and supported by the
+  current repository context

--- a/skills/issue-create/references/issue-create-boundary.md
+++ b/skills/issue-create/references/issue-create-boundary.md
@@ -1,6 +1,7 @@
 # Issue Create Boundary
 
-This skill owns publication of an issue artifact.
+This skill owns publication of an issue artifact, or rendering a ready-to-post
+issue title and body when direct publication is not permitted.
 
 It may compose:
 

--- a/skills/issue-create/references/issue-create-boundary.md
+++ b/skills/issue-create/references/issue-create-boundary.md
@@ -1,0 +1,14 @@
+# Issue Create Boundary
+
+This skill owns publication of an issue artifact.
+
+It may compose:
+
+- `issue-write-description` for issue-body drafting
+- `formatting-github-comment` for final Markdown normalization
+
+It does not own:
+
+- implementing the issue
+- posting delivery/status summary comments after implementation
+- full issue-to-PR orchestration


### PR DESCRIPTION
## Implementation Summary
- Scope: add the `issue-create` skill as the GitHub issue creation composite
- Key changes: add the skill definition, issue creation/publishing guidance, boundary notes, and a concise end-to-end example
- Non-goals: issue implementation, issue summary comments, or broader issue orchestration

## Review Focus
- Generated/copied files and standard imports that can be skimmed: bundled example and reference Markdown files
- Non-obvious code paths and rationale: the skill deliberately stops at issue publication or ready-to-post rendering and composes the already-merged drafting/formatting skills instead of duplicating them

## Validation
- Tests executed: `./gradlew qualityGate`; `npx --yes markdownlint-cli2 "**/*.md" "!**/node_modules/**" --config .markdownlint.json`
- Manual checks: verified the workflow prefers body-file based GitHub publication and has an explicit no-permission fallback
- Residual risks: later issue orchestration skills may compose this skill, but this PR keeps the boundary at creation only

Closes #12
