### PR TITLE
Add quality-sonar skill

### DIFF
--- a/skills/quality-sonar/SKILL.md
+++ b/skills/quality-sonar/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: quality-sonar
+description: >-
+  Evaluate the bounded change set against Sonar or Sonar-like static-analysis
+  findings and quality profiles. Use when CI, SonarQube, SonarLint, or a
+  similar analyzer reports issues for the current scope.
+---
+<!-- markdownlint-disable MD025 -->
+
+# Purpose
+
+Use Sonar or Sonar-like analysis as quality evidence for the bounded change set
+so newly introduced issues are surfaced, classified, and reduced before merge.
+
+# When to Use
+
+- use when SonarQube, SonarLint, or another Sonar-like analyzer reports issues
+  for the current branch, PR, or bounded change set
+- use when a repository relies on Sonar-like quality profiles or rule packs
+- use when specialized profiles exist, such as AI-oriented or language-specific
+  profiles, and they influence which findings matter most
+- use `references/sonar-evidence-order.md` for evidence priority and bounded
+  scope handling
+- use `references/sonar-profile-guidance.md` for profile-selection and
+  specialized-profile guidance
+- use `examples/sonar-review-finding.md` when a concrete review-finding shape
+  helps
+
+# Inputs
+
+- the bounded diff, changed files, or changed methods under review
+- the strongest available Sonar or Sonar-like report for that scope
+- the active quality profile, profile name, or equivalent ruleset if known
+- relevant tests or refactor options for reducing reported issues
+- `references/sonar-evidence-order.md` and
+  `references/sonar-profile-guidance.md`
+
+# Workflow
+
+1. Gather the strongest available Sonar or Sonar-like evidence for the bounded
+   scope, preferring CI or PR-integrated results over manual recollection.
+2. Identify which findings belong to the current change set instead of
+   re-auditing the whole codebase.
+3. When the project exposes a named quality profile, use that profile as the
+   policy baseline and note any specialized profile in effect.
+4. Treat relevant new or changed-scope findings as issues to resolve, justify,
+   or explicitly defer; do not ignore them as generic background noise.
+5. Reduce findings with the narrowest behavior-preserving change available,
+   such as refactoring, clearer null handling, simpler control flow, or focused
+   tests.
+6. Re-run or re-read the strongest available report after changes and record
+   the remaining bounded-scope findings, if any.
+7. Use `examples/sonar-review-finding.md` when reporting the remaining issue or
+   final pass result.
+
+# Outputs
+
+- a bounded-scope pass or fail decision based on Sonar or Sonar-like evidence
+- explicit findings for remaining bounded-scope issues
+- a short note of the profile or rule context when it materially affects the
+  decision
+
+# Guardrails
+
+- do not treat whole-repository legacy noise as proof that the current change
+  is clean
+- do not ignore a specialized active quality profile when one is configured
+- do not claim a Sonar pass without report evidence or an explicitly labeled
+  estimate
+- do not broaden this skill into general code review beyond Sonar-driven
+  quality evidence
+
+# Exit Checks
+
+- the bounded scope is backed by Sonar or Sonar-like evidence, or an explicit
+  missing-evidence note
+- remaining findings are tied to the current scope rather than generic repo
+  debt
+- the active profile context is stated when it materially changes the decision
+- the final result is concise enough for review or gate flow

--- a/skills/quality-sonar/examples/sonar-review-finding.md
+++ b/skills/quality-sonar/examples/sonar-review-finding.md
@@ -1,6 +1,10 @@
 # Example Sonar Review Finding
 
-Medium - `service/report/ReportFormatter.java`: the current change introduces a
-new Sonar issue on the active Java quality profile for nested conditional
-complexity in the export path. Flatten the branching or extract the decision
-logic into a cohesive helper, then re-run the Sonar check for the bounded scope.
+`service/report/ReportFormatter.java` fails `quality-sonar` for the bounded
+scope.
+
+Evidence: the active Java quality profile reports a new Sonar issue for nested
+conditional complexity in the export path.
+
+Next step: flatten the branching or extract the decision logic into a cohesive
+helper, then re-run the Sonar check for the bounded scope.

--- a/skills/quality-sonar/examples/sonar-review-finding.md
+++ b/skills/quality-sonar/examples/sonar-review-finding.md
@@ -1,0 +1,6 @@
+# Example Sonar Review Finding
+
+Medium - `service/report/ReportFormatter.java`: the current change introduces a
+new Sonar issue on the active Java quality profile for nested conditional
+complexity in the export path. Flatten the branching or extract the decision
+logic into a cohesive helper, then re-run the Sonar check for the bounded scope.

--- a/skills/quality-sonar/references/sonar-evidence-order.md
+++ b/skills/quality-sonar/references/sonar-evidence-order.md
@@ -1,0 +1,11 @@
+# Sonar Evidence Order
+
+Prefer evidence in this order:
+
+1. CI or PR-integrated Sonar/Sonar-like report for the current head
+2. local analyzer or IDE result for the same bounded scope
+3. explicitly labeled estimate when no analyzer result is available
+
+Keep the decision bounded to the current change set. A repository with existing
+legacy findings can still fail the current bounded scope if the change adds or
+touches relevant Sonar issues.

--- a/skills/quality-sonar/references/sonar-profile-guidance.md
+++ b/skills/quality-sonar/references/sonar-profile-guidance.md
@@ -1,12 +1,13 @@
 # Sonar Profile Guidance
 
-When a project exposes a quality profile, treat that profile as the effective
-policy baseline for Sonar findings.
+When a project exposes a quality profile, treat the active or selected profile
+for the current analysis as the effective policy baseline for Sonar findings.
 
-If a specialized profile exists, such as an AI-oriented Java profile, use it as
-the strongest available policy signal for the affected language or toolchain.
-If the active profile is unknown, state that gap explicitly instead of
-inventing profile assumptions.
+If a specialized profile exists, such as an AI-oriented Java profile, only use
+it as the strongest policy signal when it is explicitly the active or selected
+profile for the affected language or toolchain. Otherwise, mention it only as
+additional evidence, not as the baseline ruleset. If the active profile is
+unknown, state that gap explicitly instead of inventing profile assumptions.
 
 Use profile context to explain why a finding matters, but keep the remediation
 bounded to the current change.

--- a/skills/quality-sonar/references/sonar-profile-guidance.md
+++ b/skills/quality-sonar/references/sonar-profile-guidance.md
@@ -1,0 +1,12 @@
+# Sonar Profile Guidance
+
+When a project exposes a quality profile, treat that profile as the effective
+policy baseline for Sonar findings.
+
+If a specialized profile exists, such as an AI-oriented Java profile, use it as
+the strongest available policy signal for the affected language or toolchain.
+If the active profile is unknown, state that gap explicitly instead of
+inventing profile assumptions.
+
+Use profile context to explain why a finding matters, but keep the remediation
+bounded to the current change.


### PR DESCRIPTION
## Implementation Summary
- Scope: add the `quality-sonar` skill for bounded-scope Sonar and Sonar-like quality evaluation
- Key changes: add the skill definition, Sonar evidence-order guidance, profile-selection guidance, and a concrete Sonar-style review finding example
- Non-goals: full-codebase Sonar administration or generic non-Sonar code review

## Review Focus
- Generated/copied files and standard imports that can be skimmed: bundled example and reference Markdown files
- Non-obvious code paths and rationale: the skill stays bounded to the current change set and explicitly calls out specialized quality profiles, including AI-oriented profiles when a project exposes them

## Validation
- Tests executed: `./gradlew qualityGate`; `npx --yes markdownlint-cli2 "**/*.md" "!**/node_modules/**" --config .markdownlint.json`
- Manual checks: verified the skill is grounded in the referenced Sonar Java agentic AI profile entrypoint and the existing repo quality-skill style
- Residual risks: profile-specific downstream details may vary by language or Sonar product edition, so the skill keeps profile handling additive and evidence-driven

Closes #34
