### PR TITLE
Add security-secrets skill

### DIFF
--- a/skills/security-secrets/SKILL.md
+++ b/skills/security-secrets/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: security-secrets
+description: >-
+  Detect unsafe handling of security secrets and credentials in the bounded
+  change set. Use when reviewing code, config, docs, CI, or examples for
+  hardcoded secrets, unsafe storage, missing redaction, or VCS exposure risk.
+---
+<!-- markdownlint-disable MD025 -->
+
+# Purpose
+
+Prevent secrets and credentials from being hardcoded, committed, logged, or
+handled with unsafe scope and storage practices in the bounded change set.
+
+# When to Use
+
+- use when reviewing code, configuration, CI, docs, examples, or scripts that
+  may contain credentials or secret material
+- use when checking whether secrets are at risk of being committed to version
+  control
+- use when evaluating whether secret handling follows secure storage and
+  redaction practices
+- use `references/secret-handling-baseline.md` for the core secret-handling
+  rules
+- use `references/vcs-exposure-checks.md` for version-control-specific checks
+- use `examples/secret-review-finding.md` when a concrete security finding
+  helps
+
+# Inputs
+
+- the bounded diff and changed files
+- any configuration, CI, env-file, or documentation changes in scope
+- repository ignore-file behavior when secret files or patterns are involved
+- available secret-management or runtime-injection mechanisms
+- `references/secret-handling-baseline.md` and
+  `references/vcs-exposure-checks.md`
+
+# Workflow
+
+1. Inspect the bounded scope for hardcoded credentials, tokens, keys,
+   certificates, secrets, or secret-like placeholders that look real.
+2. Check whether secret material could be committed, copied into docs/examples,
+   or leaked through ignore-file gaps.
+3. Check whether logs, telemetry, errors, or test artifacts could expose secret
+   values or sensitive payloads.
+4. Prefer secure runtime injection or secret managers over checked-in storage.
+5. When exposure is found, recommend removal from source control, redaction,
+   rotation, and the narrowest safe replacement pattern.
+6. Use `references/vcs-exposure-checks.md` to verify `.gitignore` and commit
+   hygiene expectations.
+7. Use `examples/secret-review-finding.md` when reporting the issue as a review
+   finding.
+
+# Outputs
+
+- a bounded-scope pass or fail decision for secret handling
+- explicit findings for hardcoded, exposed, or weakly handled secrets
+- concise remediation guidance covering removal, redaction, rotation, and safe
+  replacement patterns
+
+# Guardrails
+
+- do not treat committed secrets as a minor quality issue
+- do not recommend storing real secrets in examples or docs
+- do not assume redaction is sufficient when a secret was committed to VCS
+- do not broaden this skill into general authorization or vulnerability review
+
+# Exit Checks
+
+- the bounded scope was checked for committed or hardcoded secret material
+- any logging or documentation exposure risk is called out explicitly
+- VCS exposure risk is covered when secret files or values are involved
+- remediation guidance is concrete and security-safe

--- a/skills/security-secrets/examples/secret-review-finding.md
+++ b/skills/security-secrets/examples/secret-review-finding.md
@@ -1,0 +1,6 @@
+# Example Secret Review Finding
+
+High - `.github/workflows/release.yml`: the current change inlines a bearer
+token in workflow configuration, which risks secret exposure in source control
+and CI logs. Move the value to the platform secret store, remove the tracked
+secret from the file, and rotate the exposed token before merge.

--- a/skills/security-secrets/references/secret-handling-baseline.md
+++ b/skills/security-secrets/references/secret-handling-baseline.md
@@ -1,0 +1,9 @@
+# Secret Handling Baseline
+
+- never commit secrets to source control, docs, examples, logs, or snapshots
+- use secret managers or secure runtime injection where available
+- keep secret scope minimal and environment-specific
+- redact secrets in logs, telemetry, and error messages
+- rotate secrets on exposure or when ownership changes
+
+Treat exposed secrets as a remediation issue, not just a formatting problem.

--- a/skills/security-secrets/references/vcs-exposure-checks.md
+++ b/skills/security-secrets/references/vcs-exposure-checks.md
@@ -1,0 +1,16 @@
+# VCS Exposure Checks
+
+Check whether the bounded scope introduces or weakens any of these protections:
+
+- ignore rules for `.env`, `.env.*`, key stores, certificate/key files, or
+  other secret-bearing artifacts
+- documentation or examples that include real credentials or realistic-looking
+  live tokens
+- scripts or CI config that inline secrets instead of reading from secure
+  secret storage
+
+If a secret has already been committed, remediation should cover:
+
+- removing it from tracked files
+- rotating the secret
+- reviewing whether history cleanup is required in the affected repository


### PR DESCRIPTION
## Implementation Summary
- Scope: add the `security-secrets` skill for bounded-scope secret handling and exposure review
- Key changes: add the skill definition, secret-handling baseline guidance, VCS exposure checks, and a concrete secret-related review finding example
- Non-goals: general auth review or broader vulnerability auditing outside secret handling

## Review Focus
- Generated/copied files and standard imports that can be skimmed: bundled example and reference Markdown files
- Non-obvious code paths and rationale: the skill explicitly treats committed secrets as remediation work and ties secret review to both secure storage and version-control exposure risk

## Validation
- Tests executed: `./gradlew qualityGate`; `npx --yes markdownlint-cli2 "**/*.md" "!**/node_modules/**" --config .markdownlint.json`
- Manual checks: verified the guidance aligns with the existing security baseline and VCS ignore expectations from `ai-rules`
- Residual risks: downstream environments may use different secret stores, so the skill keeps the storage recommendation generic and runtime-safe

Closes #27
