### PR TITLE
Add compliance-dependency skill

### DIFF
--- a/skills/compliance-dependency/SKILL.md
+++ b/skills/compliance-dependency/SKILL.md
@@ -47,8 +47,8 @@ risks that are incompatible with commercial closed-source delivery.
    the current distribution model.
 4. Check maturity, stewardship, maintenance signals, and overlap with existing
    dependencies.
-5. Identify notice, attribution, or `THIRD_PARTY_NOTICES` obligations that the
-   change introduces.
+5. Identify notice, attribution, or third-party notices file obligations that
+   the change introduces.
 6. Escalate conditional or restricted licenses, unknown/custom licenses, and
    weak governance signals instead of silently accepting them.
 7. Use `examples/dependency-compliance-finding.md` when reporting the resulting

--- a/skills/compliance-dependency/SKILL.md
+++ b/skills/compliance-dependency/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: compliance-dependency
+description: >-
+  Evaluate dependency additions and upgrades for compliance and governance
+  risk. Use when selecting, adding, upgrading, or reviewing third-party
+  dependencies for license compatibility, stewardship, transitive risk, and
+  notice obligations.
+---
+<!-- markdownlint-disable MD025 -->
+
+# Purpose
+
+Prevent dependency changes from introducing license, governance, or stewardship
+risks that are incompatible with commercial closed-source delivery.
+
+# When to Use
+
+- use when adding, upgrading, or reviewing direct or significant transitive
+  dependencies
+- use when evaluating whether a dependency is mature and governed well enough
+  for adoption
+- use when a dependency change may affect attribution, notice, or legal review
+  obligations
+- use `references/license-decision-framework.md` for the dependency compliance
+  decision order
+- use `references/dependency-selection-baseline.md` for maturity, stewardship,
+  and selection guidance
+- use `examples/dependency-compliance-finding.md` when a concrete finding helps
+
+# Inputs
+
+- the proposed dependency addition, upgrade, or removal
+- the dependency tree or strongest available transitive dependency view
+- authoritative license information such as SPDX metadata and upstream license
+  files
+- release or distribution context if notice obligations matter
+- `references/license-decision-framework.md` and
+  `references/dependency-selection-baseline.md`
+
+# Workflow
+
+1. Identify the dependency change and its bounded direct and significant
+   transitive impact.
+2. Verify the authoritative license information instead of trusting a single
+   package-registry field.
+3. Classify the license risk as compatible, conditional-review, or blocked for
+   the current distribution model.
+4. Check maturity, stewardship, maintenance signals, and overlap with existing
+   dependencies.
+5. Identify notice, attribution, or `THIRD_PARTY_NOTICES` obligations that the
+   change introduces.
+6. Escalate conditional or restricted licenses, unknown/custom licenses, and
+   weak governance signals instead of silently accepting them.
+7. Use `examples/dependency-compliance-finding.md` when reporting the resulting
+   dependency risk.
+
+# Outputs
+
+- a dependency compliance pass or fail decision for the bounded change
+- explicit license, governance, or notice findings when risk remains
+- a clear escalation or follow-up path for conditional or unknown cases
+
+# Guardrails
+
+- do not approve a dependency based only on registry metadata
+- do not ignore significant transitive license risk
+- do not treat weak governance or unmaintained libraries as neutral by default
+- do not broaden this skill into runtime API usage guidance
+
+# Exit Checks
+
+- direct and significant transitive dependency risk was considered
+- license compatibility and notice obligations are explicit
+- maturity and stewardship signals are part of the decision
+- blocked or conditional cases are escalated clearly

--- a/skills/compliance-dependency/SKILL.md
+++ b/skills/compliance-dependency/SKILL.md
@@ -43,8 +43,10 @@ risks that are incompatible with commercial closed-source delivery.
    transitive impact.
 2. Verify the authoritative license information instead of trusting a single
    package-registry field.
-3. Classify the license risk as compatible, conditional-review, or blocked for
-   the current distribution model.
+3. Classify the license risk as compatible, conditional, or blocked for the
+   current distribution model. Treat conditional cases as requiring escalation
+   before approval because obligations, restrictions, or uncertainty still need
+   resolution.
 4. Check maturity, stewardship, maintenance signals, and overlap with existing
    dependencies.
 5. Identify notice, attribution, or third-party notices file obligations that

--- a/skills/compliance-dependency/examples/dependency-compliance-finding.md
+++ b/skills/compliance-dependency/examples/dependency-compliance-finding.md
@@ -1,0 +1,7 @@
+# Example Dependency Compliance Finding
+
+High - dependency upgrade to `example-lib` introduces an LGPL-3.0 transitive
+artifact with unresolved distribution obligations for the current
+closed-source delivery model. Re-run the dependency tree with authoritative
+license data, escalate the license decision for review, and do not merge the
+upgrade until the notice and compatibility questions are resolved.

--- a/skills/compliance-dependency/references/dependency-selection-baseline.md
+++ b/skills/compliance-dependency/references/dependency-selection-baseline.md
@@ -1,0 +1,16 @@
+# Dependency Selection Baseline
+
+Prefer dependencies that are:
+
+- mature and widely adopted
+- actively maintained with clear stewardship
+- governed by trustworthy organizations or stable communities
+- compatible with the current commercial closed-source distribution model
+
+Avoid dependencies that are:
+
+- unmaintained or weakly governed
+- redundant with existing approved dependencies
+- license-incompatible or operationally unclear
+
+Selection quality and compliance both matter; neither should be ignored.

--- a/skills/compliance-dependency/references/license-decision-framework.md
+++ b/skills/compliance-dependency/references/license-decision-framework.md
@@ -1,0 +1,11 @@
+# License Decision Framework
+
+For each dependency change:
+
+1. identify the authoritative license
+2. classify the risk
+3. confirm obligations such as notice, attribution, or source-disclosure scope
+4. verify compatibility with the current delivery model
+5. record or escalate material decisions when needed
+
+Conditional, unknown, or restricted licenses should not pass silently.


### PR DESCRIPTION
## Summary
- add the `compliance-dependency` skill bundle for dependency license and governance review
- capture license decision order, dependency selection baseline, and a concrete review-finding example
- align dependency approval guidance with the reusable compliance rules distilled from `ai-rules`

## Testing
- ./gradlew qualityGate
- npx --yes markdownlint-cli2 "**/*.md" "!**/node_modules/**" --config .markdownlint.json

Closes #41
