### PR TITLE
Add performance-db skill

### DIFF
--- a/skills/performance-db/SKILL.md
+++ b/skills/performance-db/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: performance-db
+description: >-
+  Review explicit or framework-generated database statements for bounded-scope
+  performance risk. Use when JDBC, JPA, jOOQ, or similar data-access changes
+  may affect query shape, index usage, cardinality, or avoidable round trips.
+---
+<!-- markdownlint-disable MD025 -->
+
+# Purpose
+
+Prevent the bounded change set from introducing slow, unbounded, or avoidably
+expensive database statements.
+
+# When to Use
+
+- use when a change adds or modifies SQL, JDBC, JPA, jOOQ, repository logic,
+  fetch plans, or query-building code
+- use when a framework-generated database statement may change even though no
+  raw SQL file was edited directly
+- use when a statement's performance depends on index coverage, join shape,
+  pagination, or query count
+- use `references/db-statement-review-checklist.md` for evidence order and
+  statement-shape review
+- use `references/index-and-access-path.md` for index, filtering, ordering, and
+  access-path guidance
+- use `examples/db-performance-finding.md` when reporting a remaining
+  performance risk
+
+# Inputs
+
+- the bounded diff and the changed code that creates or triggers the database
+  statement
+- the strongest available statement evidence, such as raw SQL, generated SQL,
+  ORM query description, SQL logs, or an execution plan
+- the expected access pattern, cardinality, and hot-path context for the query
+- the relevant schema information, especially indexes, join keys, and ordering
+  columns
+- `references/db-statement-review-checklist.md`
+- `references/index-and-access-path.md`
+
+# Workflow
+
+1. Identify the concrete database statement or strongest available generated
+   representation for the bounded change; treat implicit ORM statements as
+   first-class statements.
+2. Check whether the current statement shape matches the required result with
+   minimal columns, bounded row count, intentional joins, and stable ordering
+   where pagination or determinism matters.
+3. Look for avoidable performance regressions such as N+1 access, per-row
+   follow-up queries, broad projections, unbounded scans, or work that could be
+   collapsed into a more efficient statement.
+4. Evaluate whether the filter, join, and ordering predicates are supported by
+   appropriate indexes for the stated access pattern instead of assuming the
+   database will optimize the statement automatically.
+5. For hot or high-cardinality paths, prefer plan or SQL-log evidence over
+   intuition, and state any evidence gap explicitly when a confident decision is
+   not possible.
+6. Use `examples/db-performance-finding.md` when reporting a remaining
+   statement-level performance risk or required follow-up.
+
+# Outputs
+
+- a pass or fail result for the bounded database-statement change
+- explicit findings for statement-shape, query-count, or index/access-path
+  risks that remain
+- a concise next step such as narrowing the query, batching, adding a justified
+  index, or validating the plan on realistic data
+
+# Guardrails
+
+- do not review database performance only at the ORM API surface when stronger
+  statement evidence is available
+- do not treat a functionally correct query as performant by default
+- do not invent index recommendations without tying them to concrete filter,
+  join, or ordering predicates
+- do not broaden this skill into full schema design or infrastructure tuning
+
+# Exit Checks
+
+- the bounded statement or strongest available generated representation was
+  inspected directly
+- avoidable N+1, broad projection, unbounded scan, and pagination risks were
+  considered
+- index and access-path suitability were checked against real predicates or an
+  explicit evidence gap was recorded
+- the final result is specific enough to drive a code-review or gate decision

--- a/skills/performance-db/examples/db-performance-finding.md
+++ b/skills/performance-db/examples/db-performance-finding.md
@@ -1,0 +1,14 @@
+# Example DB Performance Finding
+
+`OrderRepository.findRecentForCustomer(...)` fails `performance-db` for the
+bounded scope.
+
+Evidence: the changed statement loads all columns from `orders`, sorts by
+`created_at DESC`, and filters by `customer_id`, but no supporting
+`(customer_id, created_at)` access path is visible for the expected hot-path
+read. The current design also issues one follow-up query per order for line
+items.
+
+Next step: narrow the projection, replace the per-order follow-up reads with a
+batched fetch or explicit join/projection strategy, and validate the final
+statement against the expected index path.

--- a/skills/performance-db/references/db-statement-review-checklist.md
+++ b/skills/performance-db/references/db-statement-review-checklist.md
@@ -1,0 +1,18 @@
+# DB Statement Review Checklist
+
+Prefer the strongest available evidence in this order:
+
+1. actual SQL plus execution plan for the bounded path
+2. actual SQL plus SQL logs or query-count evidence
+3. generated SQL or ORM query description
+4. repository/query-builder code when no stronger statement evidence exists
+
+For each bounded statement:
+
+1. identify the exact result shape the use case needs
+2. verify the statement does not fetch more rows or columns than necessary
+3. check whether the same result can be produced with fewer round trips or a
+   tighter statement shape
+4. check whether loops, serialization, or resolver-style access can trigger
+   repeated follow-up queries
+5. prefer an explicit evidence gap over pretending the query is safe

--- a/skills/performance-db/references/index-and-access-path.md
+++ b/skills/performance-db/references/index-and-access-path.md
@@ -1,0 +1,23 @@
+# Index And Access-Path Guidance
+
+Check index suitability against the real statement shape:
+
+- filter predicates
+- join predicates
+- ordering columns
+- pagination strategy
+
+Useful signals:
+
+- frequent equality or range filters without supporting indexes
+- joins on large tables where the join keys are not indexed appropriately
+- `ORDER BY` clauses that force sorting because the access path cannot support
+  the requested order
+- broad scans on hot paths that should be selective
+
+Index review is not only about "does an index exist". It is about whether the
+existing index actually supports the query's filter, join, and ordering
+behavior for the expected cardinality.
+
+When the statement is hot or high-cardinality, validate the access path with an
+execution plan or the strongest available production-like evidence.


### PR DESCRIPTION
## Summary
- add the `performance-db` skill for bounded-scope statement-level database performance review
- capture evidence-order, query-shape, index/access-path, and N+1 review guidance
- include a concrete example for reporting a remaining database-performance finding

## Testing
- ./gradlew qualityGate
- npx --yes markdownlint-cli2 "**/*.md" "!**/node_modules/**" --config .markdownlint.json

Closes #24
