### PR TITLE
Add release-github skill

### DIFF
--- a/skills/release-github/SKILL.md
+++ b/skills/release-github/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: release-github
+description: >-
+  Publish a repository release on GitHub using a consistent tagged-release
+  flow. Use when a version must be selected, changelog or release notes aligned,
+  and a GitHub Release created from the release commit.
+---
+<!-- markdownlint-disable MD025 -->
+
+# Purpose
+
+Publish a clean GitHub release that keeps version selection, changelog updates,
+annotated tags, and GitHub release notes aligned.
+
+# When to Use
+
+- use when a repository needs a new GitHub release from its default branch
+- use when a version must be chosen explicitly or inferred from merged
+  user-visible changes since the latest tag
+- use when changelog content, tags, and GitHub release notes must describe the
+  same release
+- use `references/version-selection.md` for semantic version bump selection
+- use `references/github-release-flow.md` for the tagged-release sequence and
+  GitHub-specific checks
+- use `examples/github-release-notes.md` when shaping concise release notes
+
+# Inputs
+
+- the repository default branch with all release-bound changes already merged
+- the latest reachable release tag and the merged changes since that tag
+- any explicit target version provided by the user or repository policy
+- the changelog or strongest release-notes source for the repository
+- GitHub access capable of pushing tags and creating releases
+- `references/version-selection.md`
+- `references/github-release-flow.md`
+
+# Workflow
+
+1. Ensure the default branch is current and that the changes intended for the
+   release are already merged instead of releasing from a feature branch.
+2. Determine the target version: use an explicit version when provided;
+   otherwise classify the changes since the latest tag and select the smallest
+   valid semantic-version bump that fits the strongest user-visible change.
+3. Stop if there are no meaningful release changes instead of creating an empty
+   tag.
+4. Update the changelog or release-notes source with the selected version, the
+   release date, and a concise summary of user-visible changes.
+5. Update any versioned release examples or docs that must point at the new
+   tag.
+6. Commit the release-preparation changes on the default branch, create an
+   annotated tag for the release commit, and push both branch and tag.
+7. Create the GitHub Release from the pushed tag using notes that stay aligned
+   with the changelog or release-notes source.
+8. Verify that the tag and release page exist and point at the intended commit.
+
+# Outputs
+
+- the selected release version and release commit
+- aligned changelog or release notes for that version
+- a pushed annotated tag and a published GitHub Release
+- a concise release summary or release URL for follow-up communication
+
+# Guardrails
+
+- do not release from a feature branch or dirty branch state
+- do not guess a version bump without checking the merged change set
+- do not create a release when there are no meaningful release changes
+- do not let GitHub release notes drift from the authoritative changelog or
+  release-notes source
+
+# Exit Checks
+
+- the target version is explicit and justified
+- changelog or release notes, tag, and GitHub Release all reference the same
+  release
+- the release was created from the intended default-branch commit
+- the published result is specific enough for downstream consumers to use

--- a/skills/release-github/examples/github-release-notes.md
+++ b/skills/release-github/examples/github-release-notes.md
@@ -1,0 +1,10 @@
+# Example GitHub Release Notes
+
+## v1.7.0 - 2026-04-11
+
+- added `performance-db` and `security-secrets` skills for bounded database and
+  secret-handling review
+- improved the shared skill catalog with clearer composition and capture-skill
+  guidance
+- aligned release metadata, changelog content, and GitHub release notes for the
+  published tag

--- a/skills/release-github/examples/github-release-notes.md
+++ b/skills/release-github/examples/github-release-notes.md
@@ -2,8 +2,7 @@
 
 ## v1.7.0 - 2026-04-11
 
-- added `performance-db` and `security-secrets` skills for bounded database and
-  secret-handling review
+- added new bounded-scope review skills and supporting references
 - improved the shared skill catalog with clearer composition and capture-skill
   guidance
 - aligned release metadata, changelog content, and GitHub release notes for the

--- a/skills/release-github/references/github-release-flow.md
+++ b/skills/release-github/references/github-release-flow.md
@@ -1,0 +1,19 @@
+# GitHub Release Flow
+
+Keep these release artifacts aligned:
+
+- changelog or authoritative release-notes source
+- annotated Git tag
+- GitHub Release page
+
+Preferred sequence:
+
+1. update release notes source
+2. commit the release-preparation change
+3. create the annotated tag on that commit
+4. push branch and tag
+5. create the GitHub Release from the pushed tag
+6. verify the tag and release page point at the same commit
+
+When repository policy defines a release-note heading or formatting template,
+honor that policy rather than inventing a new layout during release.

--- a/skills/release-github/references/version-selection.md
+++ b/skills/release-github/references/version-selection.md
@@ -1,0 +1,20 @@
+# Version Selection
+
+Select the target version in this order:
+
+1. use the explicit version if the user or repository policy already provides
+   one
+2. otherwise inspect the changes since the latest reachable tag
+
+Choose the semantic-version bump by strongest change type:
+
+- major: breaking changes, removals, renames, incompatible contract changes
+- minor: new user-visible functionality or substantial new capability without a
+  breaking change
+- patch: clarifications, fixes, or small improvements without new surfaced
+  capability
+
+If multiple change types appear, use the highest required bump.
+
+If there are no meaningful release changes, do not create a release just to
+advance the version.


### PR DESCRIPTION
## Summary
- add the `release-github` skill for tagged GitHub releases from the default branch
- capture version-selection guidance and changelog/tag/release-note alignment
- include a concrete release-notes example for GitHub release publishing

## Testing
- ./gradlew qualityGate
- npx --yes markdownlint-cli2 "**/*.md" "!**/node_modules/**" --config .markdownlint.json

Closes #5
