### PR TITLE
Add pr-review-loop skill

### DIFF
--- a/skills/pr-review-loop/SKILL.md
+++ b/skills/pr-review-loop/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pr-review-loop
 description: >-
-  Run the post-push pull-request review loop until no valid findings remain and
+  Run the post-push pull request review loop until no valid findings remain and
   merge gates are satisfied. Use when one or more active PRs must be driven
   through automated review, fixes, thread handling, and final merge readiness.
 ---
@@ -26,7 +26,7 @@ after the latest push has been reviewed.
   classification handling
 - use `../pr-merge/SKILL.md` for final merge gating and merge execution
 - use `references/review-loop-state.md` for the required per-PR state model and
-  merge gate
+  review-readiness gate
 - use `references/review-loop-queue.md` for round-robin queue behavior
 - use `examples/review-loop-status.md` when reporting loop state or completion
 
@@ -63,9 +63,10 @@ after the latest push has been reviewed.
    threads that were actually handled.
 7. If fixes were pushed, restart the same post-push review cycle for that PR
    instead of treating earlier review results as sufficient.
-8. If no fixes were needed, evaluate the hard merge gate from
-   `references/review-loop-state.md`. When merge is allowed, hand the PR to
-   `../pr-merge/SKILL.md`; otherwise report the blocking gate conditions.
+8. If no fixes were needed, evaluate the review-readiness gate from
+   `references/review-loop-state.md`. When that gate passes, hand the PR to
+   `../pr-merge/SKILL.md` for the remaining merge-policy checks and merge
+   execution; otherwise report the blocking gate conditions.
 9. Use `examples/review-loop-status.md` when communicating queue state,
    remaining blockers, or clean completion.
 
@@ -74,7 +75,8 @@ after the latest push has been reviewed.
 - a per-PR status showing review state, remaining blockers, and merge
   readiness
 - handled review threads with explicit valid, invalid, or unresolved treatment
-- merged PRs only when the post-push merge gate is satisfied
+- merged PRs only when post-push review readiness is satisfied and
+  `../pr-merge/SKILL.md` allows merge execution
 
 # Guardrails
 

--- a/skills/pr-review-loop/SKILL.md
+++ b/skills/pr-review-loop/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: pr-review-loop
+description: >-
+  Run the post-push pull-request review loop until no valid findings remain and
+  merge gates are satisfied. Use when one or more active PRs must be driven
+  through automated review, fixes, thread handling, and final merge readiness.
+---
+<!-- markdownlint-disable MD025 -->
+
+# Purpose
+
+Drive active PRs through a repeatable post-push review loop so valid findings
+are handled, review threads converge cleanly, and merge decisions are made only
+after the latest push has been reviewed.
+
+# When to Use
+
+- use when one or more PRs are already open and should be advanced through
+  review to a clean merge gate
+- use when the repository relies on an automated PR reviewer, such as GitHub
+  Copilot review, after each push
+- use when multiple PRs can be progressed round-robin without idle waiting
+- use `../pr-review/SKILL.md` for family-root classification and closure
+  boundaries
+- use `../pr-review-respond/SKILL.md` for thread replies and finding
+  classification handling
+- use `../pr-merge/SKILL.md` for final merge gating and merge execution
+- use `references/review-loop-state.md` for the required per-PR state model and
+  merge gate
+- use `references/review-loop-queue.md` for round-robin queue behavior
+- use `examples/review-loop-status.md` when reporting loop state or completion
+
+# Inputs
+
+- one or more active PRs with their latest head commits
+- the latest push time, automated-review state, review threads, and required
+  checks for each PR
+- repository preferences about whether clean PRs should be merged
+- access to the PR platform APIs needed to request or inspect automated review
+- `../pr-review/SKILL.md`
+- `../pr-review-respond/SKILL.md`
+- `../pr-merge/SKILL.md`
+- `references/review-loop-state.md`
+- `references/review-loop-queue.md`
+
+# Workflow
+
+1. Build the active PR queue and track the current state for each item using
+   the fields in `references/review-loop-state.md`.
+2. Process active items in round-robin order instead of waiting idly on a
+   single PR.
+3. After each push, require fresh review state for that PR head: clear the
+   previous pass assumptions, inspect required checks, inspect unresolved
+   threads, and determine whether a post-push automated review already exists.
+4. If the latest push does not yet have a submitted automated review, request
+   one through the platform API or configured review mechanism, then move on to
+   the next item without blocking.
+5. If checks are still running or a review is still in progress for the latest
+   push, keep the PR active and continue with the next item.
+6. When the latest push has completed review results, apply
+   `../pr-review/SKILL.md` and `../pr-review-respond/SKILL.md` to classify
+   findings, reply to each thread, fix valid issues, and resolve only the
+   threads that were actually handled.
+7. If fixes were pushed, restart the same post-push review cycle for that PR
+   instead of treating earlier review results as sufficient.
+8. If no fixes were needed, evaluate the hard merge gate from
+   `references/review-loop-state.md`. When merge is allowed, hand the PR to
+   `../pr-merge/SKILL.md`; otherwise report the blocking gate conditions.
+9. Use `examples/review-loop-status.md` when communicating queue state,
+   remaining blockers, or clean completion.
+
+# Outputs
+
+- a per-PR status showing review state, remaining blockers, and merge
+  readiness
+- handled review threads with explicit valid, invalid, or unresolved treatment
+- merged PRs only when the post-push merge gate is satisfied
+
+# Guardrails
+
+- do not treat a review that predates the latest push as sufficient for merge
+- do not wait idly on one PR when other active items can progress
+- do not merge while review is still running, checks are incomplete, or threads
+  remain unresolved
+- do not trigger automated review through ad-hoc PR comments when the platform
+  provides a proper API or workflow trigger
+- do not resolve invalid findings without leaving a concise rationale first
+
+# Exit Checks
+
+- every active PR has an explicit current-state summary
+- no PR is marked merge-ready without a completed post-push review for its
+  latest head commit
+- remaining blockers are concrete, not generic
+- merged PRs passed the hard gate in the same evaluation round

--- a/skills/pr-review-loop/SKILL.md
+++ b/skills/pr-review-loop/SKILL.md
@@ -94,4 +94,5 @@ after the latest push has been reviewed.
 - no PR is marked merge-ready without a completed post-push review for its
   latest head commit
 - remaining blockers are concrete, not generic
-- merged PRs passed the hard gate in the same evaluation round
+- merged PRs passed the review-readiness gate in the same evaluation round,
+  and `../pr-merge/SKILL.md` then allowed merge execution

--- a/skills/pr-review-loop/examples/review-loop-status.md
+++ b/skills/pr-review-loop/examples/review-loop-status.md
@@ -1,0 +1,8 @@
+# Example Review Loop Status
+
+- `#71 compliance-dependency`: checks green, no valid findings, no open review
+  threads, waiting only for merge execution
+- `#72 performance-db`: one valid finding fixed and pushed, post-push review
+  requested, checks still running
+- `#73 release-github`: no review submitted yet for the latest push, automated
+  review requested, loop moved on to the next item

--- a/skills/pr-review-loop/references/review-loop-queue.md
+++ b/skills/pr-review-loop/references/review-loop-queue.md
@@ -1,0 +1,16 @@
+# Review Queue Behavior
+
+Use round-robin progression across active PRs:
+
+1. inspect the next item
+2. push fixes if needed
+3. request fresh automated review when the latest push has no post-push review
+4. skip items with running checks or active review generation
+5. continue with the next item instead of waiting
+
+This keeps multiple PRs moving in parallel while preserving the rule that each
+push needs its own fresh review state before merge.
+
+If a PR cannot proceed because of missing permissions, missing branch updates,
+or missing review infrastructure, keep it in the queue with an explicit blocker
+instead of silently dropping it.

--- a/skills/pr-review-loop/references/review-loop-state.md
+++ b/skills/pr-review-loop/references/review-loop-state.md
@@ -1,0 +1,23 @@
+# Review Loop State And Hard Merge Gate
+
+Track each active PR with at least these fields:
+
+- `last-push-at`
+- `last-review-submitted-at`
+- `review-in-progress-after-last-push`
+- `open-review-threads`
+- `new-valid-findings`
+- `required-checks-green`
+- `merge-gate-passed`
+
+The hard merge gate passes only when all of these are true in the same
+evaluation round:
+
+- a review was submitted after the latest push
+- no review is still running for the latest push
+- no open review threads remain
+- no new valid findings remain
+- required checks are green
+
+Treat missing or ambiguous review/check state as gate failure, not as an
+implicit pass.

--- a/skills/pr-review-loop/references/review-loop-state.md
+++ b/skills/pr-review-loop/references/review-loop-state.md
@@ -24,4 +24,4 @@ implicit pass.
 
 This gate only proves that the latest push was reviewed cleanly enough to be
 considered for merge. Repository merge-method policy and final merge execution
-still belong to `../pr-merge/SKILL.md`.
+still belong to `../../pr-merge/SKILL.md`.

--- a/skills/pr-review-loop/references/review-loop-state.md
+++ b/skills/pr-review-loop/references/review-loop-state.md
@@ -1,4 +1,4 @@
-# Review Loop State And Hard Merge Gate
+# Review Loop State And Review-Readiness Gate
 
 Track each active PR with at least these fields:
 
@@ -8,9 +8,9 @@ Track each active PR with at least these fields:
 - `open-review-threads`
 - `new-valid-findings`
 - `required-checks-green`
-- `merge-gate-passed`
+- `review-readiness-gate-passed`
 
-The hard merge gate passes only when all of these are true in the same
+The review-readiness gate passes only when all of these are true in the same
 evaluation round:
 
 - a review was submitted after the latest push
@@ -21,3 +21,7 @@ evaluation round:
 
 Treat missing or ambiguous review/check state as gate failure, not as an
 implicit pass.
+
+This gate only proves that the latest push was reviewed cleanly enough to be
+considered for merge. Repository merge-method policy and final merge execution
+still belong to `../pr-merge/SKILL.md`.


### PR DESCRIPTION
## Summary
- add the `pr-review-loop` composite skill for round-robin post-push review handling across active PRs
- define the per-PR state model, hard merge gate, and queue behavior for automated review loops
- compose the existing `pr-review`, `pr-review-respond`, and `pr-merge` family skills instead of inlining their responsibilities

## Testing
- ./gradlew qualityGate
- npx --yes markdownlint-cli2 "**/*.md" "!**/node_modules/**" --config .markdownlint.json

Closes #3
