### PR TITLE
Add release skill

### DIFF
--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: release
+description: >-
+  Execute the full repository release workflow from final verification through
+  GitHub release and artifact publication. Use when a repository needs the
+  complete release sequence, not only the GitHub tag-and-release step.
+---
+<!-- markdownlint-disable MD025 -->
+
+# Purpose
+
+Run the full release workflow so the final build/test pass, version selection,
+documentation updates, changelog, GitHub release, and registry publications
+stay aligned.
+
+# When to Use
+
+- use when a repository needs its full release process executed end to end
+- use when artifact publication may target Maven Central, the Gradle Plugin
+  Portal, a private artifactory, or another repository-specific release target
+- use when `release-github` is necessary but not sufficient on its own
+- use `../release-github/SKILL.md` for the GitHub tag-and-release part of the
+  flow
+- use `references/release-preconditions.md` for the final verification and
+  release-input requirements
+- use `references/publication-targets.md` for target-registry decisions and
+  skip rules
+- use `examples/release-checklist.md` when reporting the full release run
+
+# Inputs
+
+- the repository default branch with release-bound changes already merged
+- the strongest available final build and test commands or CI evidence
+- the latest release tag and the delta since that release
+- documentation, changelog, and versioned example locations that must be
+  updated
+- the artifact publication targets actually used by the repository
+- `../release-github/SKILL.md`
+- `references/release-preconditions.md`
+- `references/publication-targets.md`
+
+# Workflow
+
+1. Confirm the default branch is current, the release scope is merged, and the
+   repository is in releasable state.
+2. Run or confirm the final build and test pass for the release candidate; do
+   not continue if the final verification is red or missing.
+3. Determine the delta since the latest release and derive the next semantic
+   version from that delta unless the target version is explicit.
+4. Update release-facing documentation, examples, and the changelog so they
+   all point at the selected version and describe the user-visible delta.
+5. Apply `../release-github/SKILL.md` to perform the GitHub release portion of
+   the workflow: tag selection, release notes alignment, tag creation, push,
+   and GitHub Release creation.
+6. Publish release artifacts to each applicable target registry listed in
+   `references/publication-targets.md`, such as Maven Central, the Gradle
+   Plugin Portal, or a private artifactory, and record any target that is
+   intentionally not applicable.
+7. Verify the published artifacts and release metadata so version numbers,
+   tags, changelog entries, and published packages all match.
+8. Use `examples/release-checklist.md` when communicating the completed release
+   steps or any blocked publication target.
+
+# Outputs
+
+- a selected release version and final release checklist
+- aligned documentation, changelog, GitHub release, and publication artifacts
+- explicit publication status for each relevant release target
+- a concise release summary with follow-up blockers when publication was only
+  partially completed
+
+# Guardrails
+
+- do not skip the final build or test verification before release
+- do not publish artifacts whose version, changelog, or tag is out of sync
+- do not assume every repository publishes to Maven Central, the Gradle Plugin
+  Portal, and private artifactory; treat each target as conditional
+- do not declare the release complete while a required publication target is
+  failed or unverified
+
+# Exit Checks
+
+- final build and test evidence are green and explicit
+- the selected version matches the documented delta from the previous release
+- `../release-github/SKILL.md` was applied for the GitHub release portion
+- each repository-relevant publication target is either published successfully
+  or explicitly marked not applicable
+- the final release report is concrete enough for downstream consumers and
+  maintainers

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -19,10 +19,11 @@ stay aligned.
 - use when artifact publication may target Maven Central, the Gradle Plugin
   Portal, a private artifactory, or another repository-specific release target
 - use when `release-github` is necessary but not sufficient on its own
-- use `../release-github/SKILL.md` for the GitHub tag-and-release part of the
-  flow
+- use `../release-github/SKILL.md` for the full GitHub-release workflow,
+  including version selection, docs/changelog alignment, tag creation, and the
+  GitHub Release itself
 - use `references/release-preconditions.md` for the final verification and
-  release-input requirements
+  release input requirements
 - use `references/publication-targets.md` for target-registry decisions and
   skip rules
 - use `examples/release-checklist.md` when reporting the full release run
@@ -45,20 +46,16 @@ stay aligned.
    repository is in releasable state.
 2. Run or confirm the final build and test pass for the release candidate; do
    not continue if the final verification is red or missing.
-3. Determine the delta since the latest release and derive the next semantic
-   version from that delta unless the target version is explicit.
-4. Update release-facing documentation, examples, and the changelog so they
-   all point at the selected version and describe the user-visible delta.
-5. Apply `../release-github/SKILL.md` to perform the GitHub release portion of
-   the workflow: tag selection, release notes alignment, tag creation, push,
-   and GitHub Release creation.
-6. Publish release artifacts to each applicable target registry listed in
+3. Apply `../release-github/SKILL.md` to perform the GitHub-release workflow,
+   including version selection, changelog/docs alignment, release-prep commit,
+   tag creation, push, and GitHub Release creation.
+4. Publish release artifacts to each applicable target registry listed in
    `references/publication-targets.md`, such as Maven Central, the Gradle
    Plugin Portal, or a private artifactory, and record any target that is
    intentionally not applicable.
-7. Verify the published artifacts and release metadata so version numbers,
+5. Verify the published artifacts and release metadata so version numbers,
    tags, changelog entries, and published packages all match.
-8. Use `examples/release-checklist.md` when communicating the completed release
+6. Use `examples/release-checklist.md` when communicating the completed release
    steps or any blocked publication target.
 
 # Outputs

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -20,8 +20,8 @@ stay aligned.
   Portal, a private artifactory, or another repository-specific release target
 - use when `release-github` is necessary but not sufficient on its own
 - use `../release-github/SKILL.md` for the full GitHub-release workflow,
-  including version selection, docs/changelog alignment, tag creation, and the
-  GitHub Release itself
+  including version selection, docs/changelog alignment, the release-prep
+  commit and push, tag creation, and the GitHub Release itself
 - use `references/release-preconditions.md` for the final verification and
   release input requirements
 - use `references/publication-targets.md` for target-registry decisions and

--- a/skills/release/examples/release-checklist.md
+++ b/skills/release/examples/release-checklist.md
@@ -3,7 +3,8 @@
 - final build: pass
 - final tests: pass
 - delta to previous release: reviewed
-- semantic version: `v1.8.0`
+- semantic version: `1.8.0`
+- release tag: `v1.8.0`
 - docs/examples updated: yes
 - changelog updated: yes
 - GitHub release: published

--- a/skills/release/examples/release-checklist.md
+++ b/skills/release/examples/release-checklist.md
@@ -1,0 +1,15 @@
+# Example Release Checklist
+
+- final build: pass
+- final tests: pass
+- delta to previous release: reviewed
+- semantic version: `v1.8.0`
+- docs/examples updated: yes
+- changelog updated: yes
+- GitHub release: published
+- Maven Central: published
+- Gradle Plugin Portal: not applicable
+- private artifactory: published
+
+Overall result: release completed successfully for all repository-relevant
+targets.

--- a/skills/release/references/publication-targets.md
+++ b/skills/release/references/publication-targets.md
@@ -1,0 +1,17 @@
+# Publication Targets
+
+Evaluate publication targets explicitly:
+
+- Maven Central
+- Gradle Plugin Portal
+- private artifactory or repository-specific package registry
+
+For each target:
+
+1. determine whether the repository actually publishes there
+2. publish only after the GitHub release inputs are aligned
+3. verify the published artifact version and availability
+4. record `not applicable` when the repository does not use that target
+
+Do not treat optional targets as mandatory, but do not silently skip required
+targets either.

--- a/skills/release/references/release-preconditions.md
+++ b/skills/release/references/release-preconditions.md
@@ -1,0 +1,13 @@
+# Release Preconditions
+
+Before running the release:
+
+- default branch is current
+- release-bound PRs are merged
+- final build is green
+- final test run is green
+- latest release tag and delta are known
+- changelog and versioned documentation locations are identified
+
+If any of these are missing, stop and surface the missing release input instead
+of guessing.


### PR DESCRIPTION
## Summary
- add the `release` composite skill for the full repository release workflow
- compose final verification, release delta/version work, `release-github`, and target-registry publication decisions
- capture publication target handling and an end-to-end release checklist example

## Testing
- ./gradlew qualityGate
- npx --yes markdownlint-cli2 "**/*.md" "!**/node_modules/**" --config .markdownlint.json

Closes #25
