### PR TITLE
Address #79: align cognitive complexity with legacy tolerance

### DIFF
--- a/skills/quality-cognitive-complexity/SKILL.md
+++ b/skills/quality-cognitive-complexity/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: quality-cognitive-complexity
-description: Enforce a hard cognitive-complexity threshold of at most 15 for the bounded change set.
+description: Apply tiered cognitive-complexity thresholds for new, changed, and legacy methods.
 ---
 <!-- markdownlint-disable MD025 -->
 
 # Purpose
 
-Keep the bounded change set below a hard cognitive-complexity limit so new or
-changed methods remain understandable and reviewable.
+Keep new and changed methods understandable and reviewable by applying the
+project's tiered cognitive-complexity thresholds, including the documented
+legacy-method tolerance when behavior risk makes immediate reduction unsafe.
 
 # When to Use
 
@@ -31,26 +32,40 @@ changed methods remain understandable and reviewable.
 
 1. Gather the strongest available cognitive-complexity evidence for the bounded
    scope.
-2. Treat every relevant method with cognitive complexity greater than `15` as a
-   failing result.
-3. When no tool result is available, make a conservative estimate and label it
+2. Classify every relevant method as new, altered existing, or altered legacy
+   using `references/cognitive-complexity-threshold.md`.
+3. Treat new methods above `15` as failing results.
+4. Treat altered existing methods that do not qualify as legacy as failing
+   results when they exceed `15`.
+5. When an altered legacy method remains between `16` and `20`, require
+   behavior-risk evidence and a documented reduction plan.
+6. When an altered legacy method remains above `20`, require a created or
+   linked follow-up issue with an explicit reduction plan; treat non-legacy
+   methods above `20` as failing results.
+7. When no tool result is available, make a conservative estimate and label it
    explicitly as an estimate.
-4. Reduce complexity by flattening nested control flow, extracting cohesive
+8. Reduce complexity by flattening nested control flow, extracting cohesive
    helpers, and separating orchestration from decision logic.
-5. Re-measure after each refactor until the bounded scope is at or below the
-   threshold.
-6. Use `examples/cognitive-complexity-review-finding.md` when reporting the
+9. Re-measure after each refactor until the bounded scope satisfies the
+   applicable threshold or the legacy-tolerance documentation is complete.
+10. Use `examples/cognitive-complexity-review-finding.md` when reporting the
    remaining finding or final result.
 
 # Outputs
 
-- a pass or fail result for the bounded scope against the `<= 15` threshold
+- a pass or fail result for the bounded scope against the applicable tiered
+  threshold
 - method-level findings with evidence or explicitly labeled estimates
 - a concise reduction direction when the threshold is violated
+- a documented reduction plan when relying on the altered-legacy tolerance
 
 # Guardrails
 
-- do not treat scores above `15` as acceptable for the bounded scope
+- do not introduce new methods above cognitive complexity `15`
+- do not treat altered legacy scores above `15` as acceptable without behavior
+  risk evidence and a documented reduction plan
+- do not leave altered legacy methods above `20` without a failing result or a
+  linked follow-up issue with an explicit reduction plan
 - do not split code mechanically without improving cohesion or readability
 - do not hide complexity in helper names, boolean flags, or branch-heavy
   parameter behavior
@@ -60,6 +75,12 @@ changed methods remain understandable and reviewable.
 
 - every relevant method is supported by tool evidence or an explicitly labeled
   estimate
-- no relevant method exceeds cognitive complexity `15` without a failing result
+- every relevant method is classified as new, altered existing, or altered
+  legacy
+- no new method exceeds cognitive complexity `15`
+- no altered existing method that fails legacy classification exceeds cognitive
+  complexity `15`
+- every altered legacy method above `15` has the required tolerance or
+  follow-up documentation, or a failing result
 - refactors preserve behavior and improve readability rather than only moving
   branches elsewhere

--- a/skills/quality-cognitive-complexity/examples/cognitive-complexity-review-finding.md
+++ b/skills/quality-cognitive-complexity/examples/cognitive-complexity-review-finding.md
@@ -1,11 +1,13 @@
-# Example Cognitive Complexity Finding
+# Example Cognitive Complexity Legacy Tolerance
 
-The bounded change still fails `quality-cognitive-complexity`.
+The bounded change relies on the altered-legacy tolerance in
+`quality-cognitive-complexity`.
 
 - `InvoiceSyncService#synchronizeBatch`: cognitive complexity `19`
-- threshold: `<= 15`
+- classification: altered legacy method
+- applicable threshold: temporary tolerance up to `20` with reduction plan
 - evidence source: CI `cognitive-java-check`
 
-Suggested next step: extract the variant-specific reconciliation branches into
-named helpers and flatten the nested authorization/error checks with guard
-clauses before re-running the metric.
+Reduction plan: extract the variant-specific reconciliation branches into named
+helpers and flatten the nested authorization/error checks with guard clauses
+before the next release-bound change to this service.

--- a/skills/quality-cognitive-complexity/references/cognitive-complexity-threshold.md
+++ b/skills/quality-cognitive-complexity/references/cognitive-complexity-threshold.md
@@ -3,12 +3,26 @@
 Distilled from the project's cognitive-complexity guidance and the
 `quality-cognitive-complexity` issue contract.
 
-- Hard threshold for the bounded scope: cognitive complexity must be `<= 15`.
+- Enforced limit for new methods: cognitive complexity must be `<= 15`.
+- Encouraged limit for altered existing methods: cognitive complexity should be
+  `<= 15`.
+- Temporary tolerance for altered legacy methods: complexity up to `20` is
+  acceptable only when behavior risk is high and the PR includes a documented
+  reduction plan.
+- Legacy method means a method that already existed before the current change
+  and had cognitive complexity above the encouraged target at change start.
+- Classify legacy status from the strongest available baseline evidence:
+  pre-change revision on the target branch, prior CI or static-analysis report
+  for that revision, or an explicitly labeled estimate when no tool evidence
+  exists.
+- If an altered legacy method remains above `20`, create or link a follow-up
+  issue with an explicit reduction plan.
 - Prefer evidence in this order:
   CI or Sonar-like report, IDE/static-analysis result, then conservative
   estimate when no tool result exists.
 - Strong reduction levers include early returns, named extracted methods with a
   single responsibility, and separating orchestration from detailed decision
   logic.
-- Do not preserve a complexity violation in the bounded scope by calling it
-  legacy tolerance; this skill uses a hard gate for the current change.
+- Do not use legacy tolerance for newly introduced methods.
+- Do not use legacy tolerance for altered methods without behavior-risk
+  evidence and a concrete reduction plan.


### PR DESCRIPTION
## Summary

- Adopt the ai-rules tiered cognitive-complexity model for new, altered existing, and altered legacy methods.
- Add the legacy-method classification path, tolerance requirements, and follow-up/reduction-plan expectations.
- Update the example to show documented altered-legacy tolerance instead of a hard `<= 15` failure.

## Finding classification

- Valid: the previous skill enforced a hard `<= 15` rule for the bounded scope and directly contradicted `ai-rules/DESIGN/COGNITIVE_COMPLEXITY.md` legacy-method tolerance.
- Valid: the skill lacked a legacy classification step and did not require a documented reduction plan when relying on tolerance.

## Validation

- `git diff --check`
- changed markdown line-length check, max 120 chars
- `./gradlew.bat qualityGate`

Closes #79