### PR TITLE
Address #80: add PR merge authority gates

### DIFF
--- a/skills/pr-merge/SKILL.md
+++ b/skills/pr-merge/SKILL.md
@@ -10,7 +10,8 @@ description: >-
 # Purpose
 
 Enforce the final merge gate so a PR is merged only after the latest push is
-fully reviewed, all conversations are resolved, and required checks are green.
+fully reviewed, all conversations are resolved, required checks are green, and
+merge authority is explicit.
 
 # When to Use
 
@@ -30,38 +31,63 @@ fully reviewed, all conversations are resolved, and required checks are green.
 - unresolved review threads or conversations
 - required status checks for the current head commit
 - repository merge permissions and policies
+- PR creator, intended merger, and explicit user merge instruction
+- linked main issue evidence such as `Closes #<id>` in the PR body
 - `references/merge-gate.md` and `references/post-push-review.md`
 
 # Workflow
 
 1. Read the latest push state, review state, thread state, and required checks
    for the current PR head.
-2. Verify that a completed review exists after the latest push, not only before
+2. Verify protected-branch discipline: the PR targets the protected branch from
+   a feature branch and does not require direct protected-branch pushes.
+3. Verify merge authority before evaluating readiness: identify the PR creator,
+   intended merger, explicit user merge instruction, and any owner-confirmed
+   self-merge exception.
+4. Block self-merge when the intended merger created or substantially authored
+   the PR. Treat the actor as substantially authoring the PR when they created
+   the implementation branch, authored the main implementation commit, or
+   authored most commits in the PR. Allow the exception only when the user
+   explicitly instructs the merge and confirms in the current session that they
+   are a repository owner authorizing it.
+5. Verify that the PR body links the main issue before merge, such as with
+   `Closes #<id>`.
+6. Verify that a completed review exists after the latest push, not only before
    it.
-3. Verify that all required checks are green for the current head commit.
-4. Verify that no required review conversations remain unresolved.
-5. Verify that the merge method respects repository policy and never requires a
-   force or admin bypass.
-6. Merge only when every gate in `references/merge-gate.md` is satisfied in the
+7. Verify that all required checks are green for the current head commit.
+8. Verify that no required review conversations remain unresolved.
+9. Verify that the merge method respects repository policy and never requires a
+   force, admin-bypass, or skipped required gate.
+10. Merge only when every gate in `references/merge-gate.md` is satisfied in the
    same evaluation round.
-7. Use `examples/merge-decision.md` when a concrete decision summary helps.
+11. Use `examples/merge-decision.md` when a concrete decision summary helps.
 
 # Outputs
 
 - an explicit merge-ready or not-ready decision
 - a merged PR when policy, permission, and all gates allow it
 - a concrete list of blocking gate failures when merge is not yet allowed
+- explicit merge-authority evidence when the decision is merge-ready
 
 # Guardrails
 
 - do not merge without a review pass after the latest push
+- do not merge without explicit user merge instruction
+- do not merge a PR you created or substantially authored unless the user gives
+  the specific merge instruction and explicitly confirms repository owner
+  authorization for the self-merge exception in the current session
 - do not merge while review conversations remain unresolved
 - do not merge with failing or missing required checks
-- do not force or bypass a merge gate
+- do not force, admin-bypass, or otherwise bypass a merge gate
+- do not merge before the PR body links the main issue
 - do not broaden this skill into full review-response orchestration
 
 # Exit Checks
 
+- protected-branch discipline is satisfied by a feature branch and PR
+- merge authority is explicit and any self-merge exception has owner
+  confirmation
+- the PR body links the main issue
 - the latest push is covered by a completed review pass
 - required checks are green on the current head
 - review threads are resolved according to repository policy

--- a/skills/pr-merge/examples/merge-decision.md
+++ b/skills/pr-merge/examples/merge-decision.md
@@ -5,4 +5,7 @@ Merge-ready:
 - latest push has a completed review pass
 - all required checks are green
 - no review threads remain unresolved
-- merge can proceed without force or bypass
+- protected-branch discipline is satisfied by a feature branch and PR
+- PR body links the main issue with `Closes #42`
+- merge authority is valid for the requested merger
+- merge can proceed without force, admin-bypass, or skipped required gates

--- a/skills/pr-merge/references/merge-gate.md
+++ b/skills/pr-merge/references/merge-gate.md
@@ -5,6 +5,12 @@ Treat the PR as merge-ready only when all of the following are true:
 - a completed review exists after the latest push
 - no required review threads or conversations remain unresolved
 - all required checks are green on the current head commit
+- protected-branch discipline is satisfied by a feature branch and PR
+- merge authority is valid for the acting user and instruction context
+- any self-merge exception has explicit user instruction and repository owner
+  confirmation in the current session
+- the PR body links the main issue, for example with `Closes #<id>`
 - the chosen merge method respects repository policy
+- the merge does not require force, admin-bypass, or skipped required gates
 
 If any item is false or unknown, do not merge.


### PR DESCRIPTION
## Summary

- Add merge-authority inputs and workflow checks to `pr-merge`.
- Make self-merge restrictions, owner-confirmation exceptions, issue linking, and protected-branch discipline explicit merge gates.
- Extend the merge-gate reference and example merge decision with the new hard gates.

## Finding classification

- Valid: the previous skill assumed merge authority and did not check PR creator versus intended merger.
- Valid: self-merge requires explicit user instruction plus repository-owner confirmation before bypassing the restriction.
- Valid: issue-link presence should be checked before merge so linked issues close automatically.
- Valid: protected-branch discipline and admin-bypass language should be explicit in the merge gate.

## Validation

- `git diff --check`
- changed markdown line-length check, max 120 chars
- `./gradlew.bat qualityGate`

Closes #80