### PR TITLE
Address #81: add PR issue link guidance

### DIFF
--- a/skills/pr-write-description/SKILL.md
+++ b/skills/pr-write-description/SKILL.md
@@ -18,6 +18,8 @@ validation, and residual risk easy to scan before review starts.
 - use when updating a PR description after scope or validation changes
 - use when another workflow needs a concise reviewer-facing implementation
   summary
+- use `../issue-write-summary-comment/SKILL.md` when the linked issue also
+  needs a product-owner, reviewer, and QA summary comment
 - use `references/pr-description-template.md` for the canonical reviewer-facing
   section layout
 - use `references/reviewer-focus.md` to decide what reviewers may skim versus
@@ -28,52 +30,72 @@ validation, and residual risk easy to scan before review starts.
 
 # Inputs
 
-- the issue or implementation concern being delivered
+- the issue or implementation concern being delivered, including the linked
+  issue id when available
 - the bounded scope of the PR
 - the key changes and explicit non-goals
 - generated, copied, or otherwise low-risk files reviewers may skim
 - non-obvious logic, decisions, or tradeoffs reviewers should inspect closely
 - tests executed, manual checks, and residual risks
+- whether a companion issue summary comment is required for product-owner,
+  reviewer, or QA readers
+- `../issue-write-summary-comment/SKILL.md`
 - `references/pr-description-template.md` and
   `references/reviewer-focus.md`
 
 # Workflow
 
 1. Identify the single issue or concern the PR is meant to deliver.
-2. Summarize the scope, key changes, and explicit non-goals in a short
+2. Add the issue-closing link expected by the repository, such as
+   `Closes #ISSUE_ID`, when the PR has a linked issue.
+3. Summarize the scope, key changes, and explicit non-goals in a short
    implementation summary.
-3. Call out files or change categories reviewers may skim, such as generated
+4. Call out files or change categories reviewers may skim, such as generated
    files, copied templates, or standard imports.
-4. Highlight non-obvious logic, tradeoffs, and review focus areas that deserve
+5. Highlight non-obvious logic, tradeoffs, and review focus areas that deserve
    close inspection.
-5. Record concrete validation evidence, including tests run, manual checks, and
+6. Record concrete validation evidence, including tests run, manual checks, and
    any remaining residual risk.
-6. Use `references/pr-description-template.md` as the baseline shape and
+7. If the linked issue needs a PO, reviewer, or QA audience summary, delegate
+   that issue comment to `../issue-write-summary-comment/SKILL.md` instead of
+   adding the whole audience summary to the PR body.
+8. Use `references/pr-description-template.md` as the baseline shape and
    `references/reviewer-focus.md` when deciding what belongs in review focus
    versus the implementation summary.
-7. Use `examples/pull-request-description.md` when a concrete GitHub-ready
+9. Use `examples/pull-request-description.md` when a concrete GitHub-ready
    example helps.
-8. Hand the final draft to `formatting-github-comment` when Markdown
-   normalization is still needed before posting.
+10. Hand the final draft to `formatting-github-comment` when Markdown
+    normalization is still needed before posting, applying repository-specific
+    formatting rules only when they apply to the target repository.
 
 # Outputs
 
 - a reviewer-focused PR description with implementation summary, review focus,
   and validation sections
+- an issue-closing link such as `Closes #ISSUE_ID` when the PR has a linked
+  issue
 - explicit note of non-goals and residual risk
+- a handoff to `../issue-write-summary-comment/SKILL.md` when the linked issue
+  needs a PO, reviewer, or QA audience update
 - a concise artifact that can be posted directly to GitHub after formatting
 
 # Guardrails
 
 - do not restate the entire diff file-by-file
 - do not hide important review focus behind generic summary prose
+- do not omit the issue-closing link when a PR has a linked issue
 - do not omit residual risk just because checks are green
+- do not turn the PR description into the PO/QA issue summary; use
+  `../issue-write-summary-comment/SKILL.md` for that audience
 - do not broaden this skill into PR review-thread handling or merge decisions
 - do not emit literal `\n` escape sequences in Markdown meant for GitHub
 
 # Exit Checks
 
 - the PR scope is clear and tied to one implementation concern
+- the PR body links the issue when a linked issue exists
+- any required PO, reviewer, or QA issue-summary follow-up is delegated to
+  `../issue-write-summary-comment/SKILL.md`
 - reviewers can tell what to skim and what to inspect closely
 - tests, manual checks, and residual risks are explicit
 - the description is concise enough to work as a GitHub PR body

--- a/skills/pr-write-description/examples/pull-request-description.md
+++ b/skills/pr-write-description/examples/pull-request-description.md
@@ -1,5 +1,7 @@
 # Example Pull Request Description
 
+Closes #ISSUE_ID
+
 ## Implementation Summary
 - Scope: add the `pr-write-description` skill and its supporting references
 - Key changes: define the reviewer-facing PR body shape, review-focus guidance,

--- a/skills/pr-write-description/references/pr-description-template.md
+++ b/skills/pr-write-description/references/pr-description-template.md
@@ -4,6 +4,9 @@ Use this template when a PR description needs a predictable reviewer-facing
 shape.
 
 ```md
+<!-- Include only when the PR has a linked issue. -->
+Closes #ISSUE_ID
+
 ## Implementation Summary
 - Scope:
 - Key changes:


### PR DESCRIPTION
## Summary

- Require PR descriptions to include an issue-closing link when a linked issue exists.
- Cross-reference `../issue-write-summary-comment/SKILL.md` for the PO, reviewer, and QA issue-summary audience.
- Update the PR description template and example with a `Closes #ISSUE_ID` link.

## Finding classification

- Valid: the previous skill did not require an issue link in the PR body when a linked issue exists.
- Valid: the previous skill did not point callers to the PO/QA issue-summary workflow.
- Valid: formatting expectations should remain repository-specific after content is decided.
- Valid: Copilot's markdownlint finding on the raw angle-bracket placeholder was correct; fixed by replacing `#<id>` with `#ISSUE_ID`.

## Validation

- `git diff --check`
- changed markdown line-length check, max 120 chars
- `npx --yes markdownlint-cli2 "**/*.md" "!**/node_modules/**" --config .markdownlint.json`
- `./gradlew.bat qualityGate`

Closes #81