### PR TITLE
Address #82: add planning ruleset gates

### DIFF
--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -19,6 +19,8 @@ implicit.
 - use when the user explicitly asks for a plan
 - use when questions or discovered constraints can materially change the
   implementation path
+- use when repository or downstream rulesets must be read before implementation
+  planning can be trusted
 - use `references/decision-complete-plan.md` to make sure the plan is
   decision-complete
 - use `references/decision-complete-planning.md` for planning behavior and
@@ -32,6 +34,8 @@ implicit.
 
 - the user request and success criteria
 - relevant repository context, constraints, and existing implementation shape
+- applicable repository rulesets, including complete ai-rules and downstream
+  extension entrypoints when present
 - unresolved product or technical tradeoffs
 - any user answers that materially affect the plan
 - `references/decision-complete-plan.md`,
@@ -43,24 +47,30 @@ implicit.
 
 # Workflow
 
-1. Explore the repository and surrounding context before asking questions that
-   could be answered by inspection.
-2. State the implementation goal, success criteria, key constraints, and
+1. Read the complete applicable rulesets before any other planning task,
+   including ai-rules and downstream extension rulesets when they govern the
+   target repository.
+2. Explore the repository, issue history, semantic parent and sibling docs,
+   architecture constraints, external dependencies, and blockers before asking
+   questions that could be answered by inspection.
+3. State the implementation goal, success criteria, key constraints, and
    important assumptions.
-3. Ask only the questions that materially change the plan or lock important
+4. Ask only the questions that materially change the plan or lock important
    tradeoffs.
-4. Produce a decision-complete plan covering approach, dependencies, edge
+5. Produce a decision-complete plan covering approach, dependencies, edge
    cases, verification, and acceptance signals.
-5. If a user answer has significant impact on the plan, present the altered
+6. If a user answer has significant impact on the plan, present the altered
    plan before starting implementation instead of switching directly into
    coding.
-6. Use `references/decision-complete-plan.md` to confirm scope, decisions, and
+7. Use `references/decision-complete-plan.md` to confirm scope, decisions, and
    verification are explicit.
-7. Use `references/decision-complete-planning.md` and
+8. Use `references/decision-complete-planning.md` and
    `references/workflow-order.md` to refine planning behavior and sequencing.
-8. Use `examples/implementation-plan.md` when a concrete output shape or
+9. Use `examples/implementation-plan.md` when a concrete output shape or
    verification section is helpful.
-9. Apply any target-specific note such as `targets/codex.md` only after the
+10. Re-read the complete applicable rulesets at the end and verify the plan
+    still conforms; if not, update the plan before presenting it as complete.
+11. Apply any target-specific note such as `targets/codex.md` only after the
    canonical plan is stable.
 
 # Outputs
@@ -68,6 +78,7 @@ implicit.
 - a decision-complete implementation plan
 - explicit assumptions and chosen defaults
 - a concrete verification strategy and acceptance criteria
+- identified external dependencies, blockers, and dependency-first ordering
 - an updated plan when later user input materially changes the intended
   implementation path
 - optional reuse of `examples/implementation-plan.md` as a concrete shape
@@ -76,6 +87,9 @@ implicit.
 # Guardrails
 
 - do not start implementation when important plan decisions are still open
+- do not omit the first complete-ruleset read when a governing ruleset exists
+- do not mark a plan complete before re-reading all applicable rulesets and
+  confirming conformance
 - do not ask questions that can be resolved by repository exploration
 - do not leave critical behavior, interfaces, or test strategy implicit
 - do not treat a materially changed plan as unchanged after new answers arrive
@@ -83,6 +97,10 @@ implicit.
 # Exit Checks
 
 - the plan is implementation-ready and leaves no critical decisions open
+- the first task reads the complete applicable rulesets before other
+  planning or implementation tasks
+- the final task re-reads the complete applicable rulesets and verifies
+  conformance
 - important assumptions are explicit
 - verification steps and acceptance signals are concrete
 - any answer that materially changed the approach is reflected in the latest

--- a/skills/plan/examples/implementation-plan.md
+++ b/skills/plan/examples/implementation-plan.md
@@ -8,9 +8,11 @@
 
 ## Key Changes
 
+- first task reads the complete applicable rulesets before planning work
 - create `SKILL.md` with required frontmatter and sections
 - add a small reference note and one example file
 - update only files required for the issue
+- final task re-reads the applicable rulesets and verifies conformance
 
 ## Test Plan
 

--- a/skills/plan/references/decision-complete-plan.md
+++ b/skills/plan/references/decision-complete-plan.md
@@ -5,9 +5,14 @@ A strong implementation plan should make these elements explicit:
 - goal and success criteria
 - in-scope and out-of-scope items
 - target files, interfaces, or subsystems
+- applicable rulesets and semantic parent/sibling docs
 - key design decisions and chosen defaults
+- external dependencies, blockers, and dependency-first ordering
 - important risks, edge cases, and mitigations
 - verification steps and acceptance criteria
 
 Repository exploration comes before clarification questions when the answer can
 be discovered locally.
+
+When governing rulesets exist, the plan must start with a complete-ruleset read
+task and end with a complete-ruleset conformance re-read.

--- a/skills/plan/references/decision-complete-planning.md
+++ b/skills/plan/references/decision-complete-planning.md
@@ -2,8 +2,13 @@
 
 Distilled from the project's planning guidance.
 
-- Explore first and ask only high-impact clarifying questions.
+- Read complete governing rulesets before any other planning task.
+- Then explore the repository and ask only high-impact clarifying questions.
+- Research semantic parent/sibling docs, architecture constraints, codebase
+  history, external dependencies, and blockers before finalizing the plan.
 - Keep the plan dependency-aware and implementation-ready.
 - Make assumptions explicit instead of letting them hide in execution.
 - Define verification before implementation starts.
 - If new information changes the plan materially, refresh the plan first.
+- End by re-reading governing rulesets and correcting any plan
+  non-conformance before presenting the plan as complete.

--- a/skills/plan/references/workflow-order.md
+++ b/skills/plan/references/workflow-order.md
@@ -2,11 +2,14 @@
 
 Implementation work should follow a stable execution order:
 
-- plan first
+- read complete governing rulesets before any other planning task
+- plan first with dependency and blocker research
 - create a dedicated issue branch
 - implement the bounded change
 - open a PR or MR
 - handle review and validation
+- re-read governing rulesets before final completion when one or more
+  governing rulesets exist
 - merge only after the review gate is clean
 
 This keeps the scope aligned to one concern and prevents implementation from


### PR DESCRIPTION
## Summary

- Add first and final complete-ruleset gates to the `plan` skill workflow and exit checks.
- Expand planning research to include semantic parent/sibling docs, architecture constraints, issue history, external dependencies, and blockers.
- Update planning references and example shape to carry the same ruleset-read and conformance expectations.

## Finding classification

- Valid: the previous skill omitted the mandatory first complete-ruleset-read planning step.
- Valid: the previous skill omitted the final complete-ruleset conformance re-read.
- Valid: dependency/blocker and research coverage was narrower than the ai-rules planning baseline.

## Validation

- `git diff --check`
- changed markdown line-length check, max 120 chars
- `./gradlew.bat qualityGate`

Closes #82