### PR TITLE
Address #83: expand TypeScript convention coverage

### DIFF
--- a/skills/conventions-typescript/SKILL.md
+++ b/skills/conventions-typescript/SKILL.md
@@ -1,23 +1,27 @@
 ---
 name: conventions-typescript
 description: >-
-  Apply the default TypeScript multiline layout and trailing-comma conventions
-  for lists, arguments, and parameters.
+  Apply TypeScript type-safety, naming, runtime-boundary, and layout
+  conventions for implementation and review work.
 ---
 <!-- markdownlint-disable MD025 -->
 
 # Purpose
 
-Apply the default TypeScript formatting conventions for multiline lists,
-arguments, parameters, and similar comma-separated structures.
+Apply the default TypeScript conventions for strict configuration, type
+strategy, runtime boundaries, naming, error handling, decorators, module design,
+and multiline layout.
 
 # When to Use
 
 - use when implementing or reviewing TypeScript code that introduces or edits
-  argument lists, parameter lists, array literals, object literals, tuple-like
-  lists, or similar comma-separated structures
+  types, APIs, runtime boundary handling, async/error handling, naming, module
+  structure, or comma-separated layout
+- use when reviewing `tsconfig` or CI type-checking defaults
 - use when a TypeScript structure reaches four or more elements and the layout
   should switch to the multiline default
+- use `references/typescript-safety-defaults.md` for strict compiler, typing,
+  boundary, naming, enum, error, and decorator defaults
 - use `references/typescript-layout-defaults.md` for the exact multiline and
   trailing-comma rules
 - use `examples/multiline-arguments.md` when showing the expected TypeScript
@@ -25,30 +29,54 @@ arguments, parameters, and similar comma-separated structures.
 
 # Inputs
 
-- the changed TypeScript files and the affected comma-separated structures
+- the changed TypeScript files, compiler settings, public APIs, and affected
+  comma-separated structures
+- whether strict compiler options and CI type checking are enabled
+- domain types, ad-hoc object shapes, boundary payloads, casts, and `any` or
+  `unknown` usage in the changed scope
+- naming, enum/literal-union, error-handling, async, decorator, and JSDoc
+  decisions in the changed scope
 - whether the structure has reached four or more elements
 - whether the surrounding project formatter or linter already enforces the same
   TypeScript layout
+- `references/typescript-safety-defaults.md`
 - `references/typescript-layout-defaults.md`
 
 # Workflow
 
-1. Identify every changed TypeScript argument list, parameter list, or other
+1. Verify strict TypeScript configuration and CI type-checking expectations
+   using `references/typescript-safety-defaults.md`.
+2. Review changed types and public signatures for precise domain types, named
+   boundary contracts, and local-only ad-hoc objects.
+3. Reject broad `any` usage except at isolated boundaries that immediately
+   narrow to safe types; prefer `unknown` for untrusted input.
+4. Verify runtime validation for untrusted external data before domain use.
+5. Check explicit nullability, safe optionality, and justified non-null
+   assertions.
+6. Check TypeScript naming, enum/literal-union choices, async error handling,
+   and decorator/JSDoc ordering.
+7. Identify every changed TypeScript argument list, parameter list, or other
    comma-separated structure in scope.
-2. If the structure has four or more elements, switch it to multiline layout
+8. If the structure has four or more elements, switch it to multiline layout
    with one element per line.
-3. In multiline mode, put the opening and closing delimiters on their own lines
+9. In multiline mode, put the opening and closing delimiters on their own lines
    rather than sharing a line with the first or last element.
-4. In multiline mode, keep a trailing comma after the last element whenever the
+10. In multiline mode, keep a trailing comma after the last element whenever the
    TypeScript syntax supports it.
-5. If the project formatter or linter already enforces the same TypeScript
+11. If the project formatter or linter already enforces the same TypeScript
    layout, align the change with that tooling rather than hand-formatting
    against it.
-6. Use `examples/multiline-arguments.md` when communicating the expected
+12. Use `examples/multiline-arguments.md` when communicating the expected
    TypeScript layout.
 
 # Outputs
 
+- strict TypeScript configuration and CI type checking preserved or explicit
+  blockers surfaced
+- precise domain types, safe narrowing, explicit runtime boundary validation,
+  and safe nullability decisions
+- TypeScript naming, enum/literal-union, async error-handling, and decorator
+  ordering that follow the shared defaults
 - TypeScript comma-separated structures that follow the multiline layout
   default for four or more elements
 - trailing commas on multiline TypeScript structures where supported
@@ -57,6 +85,16 @@ arguments, parameters, and similar comma-separated structures.
 
 # Guardrails
 
+- do not weaken `strict` type checking or required TypeScript compiler defaults
+  without documenting the project constraint
+- do not allow broad `any` leakage; isolate unavoidable `any` at boundaries and
+  narrow immediately
+- do not trust runtime payloads because TypeScript types exist
+- do not leave non-null assertions, unsafe casts, or optional lifecycle fields
+  unjustified
+- do not let shared or domain-shaped ad-hoc objects remain unnamed contracts
+- do not use heterogeneous enums or serialized enums without explicit string
+  values
 - do not keep four-or-more-element TypeScript structures on one line when the
   multiline default should apply
 - do not place the first or last multiline element on the same line as the
@@ -68,6 +106,13 @@ arguments, parameters, and similar comma-separated structures.
 
 # Exit Checks
 
+- strict compiler and CI type-checking defaults are preserved or blockers are
+  explicit
+- untrusted data is validated at runtime boundaries before domain use
+- public APIs and shared domain data use named, precise types
+- `any`, casts, assertions, and optional fields are justified and narrowed
+- naming, enum/literal-union, async error-handling, and decorator/JSDoc ordering
+  follow TypeScript defaults
 - every relevant TypeScript structure with four or more elements uses one
   element per line
 - multiline TypeScript delimiters are on their own lines

--- a/skills/conventions-typescript/references/typescript-safety-defaults.md
+++ b/skills/conventions-typescript/references/typescript-safety-defaults.md
@@ -1,0 +1,63 @@
+# TypeScript Safety Defaults
+
+Use these defaults when implementing or reviewing TypeScript changes.
+
+## Compiler and CI
+
+- Keep `strict` enabled.
+- Treat type errors as merge-blocking in CI.
+- Keep `noImplicitOverride`, `noUncheckedIndexedAccess`, and
+  `exactOptionalPropertyTypes` enabled unless a documented project constraint
+  prevents it.
+- Keep `skipLibCheck` disabled by default; enable it only with explicit
+  rationale.
+
+## Type Strategy
+
+- Prefer precise domain types over broad primitives and ad-hoc objects.
+- Use named types for exported signatures, cross-module contracts, DTOs, event
+  payloads, persistence models, and reused test fixtures.
+- Keep ad-hoc objects local, short-lived, and mechanical.
+- Promote ad-hoc objects when they are reused, exported, shared, nested, or
+  domain-semantic.
+- Avoid `any`; when unavoidable at a boundary, isolate and narrow immediately.
+- Prefer `unknown` for untrusted inputs and narrow with type guards.
+- Model state variants with discriminated unions instead of boolean flags.
+- Use `readonly` for immutable APIs and value objects.
+
+## Runtime Boundaries
+
+- TypeScript types do not validate runtime data.
+- Validate HTTP, queue, environment, filesystem, and other external payloads at
+  boundaries.
+- Convert validated payloads into internal domain types before deeper logic.
+- Do not expose transport DTOs as internal domain models by default.
+
+## Nullability and Optionality
+
+- Keep `null` and `undefined` handling explicit.
+- Avoid non-null assertions unless a documented invariant exists.
+- Prefer control-flow narrowing and guard functions over assertions.
+- Use optional properties intentionally; avoid optional fields for required
+  lifecycle states.
+
+## Naming, Enums, and Errors
+
+- Use `camelCase` for variables, parameters, properties, functions, and local
+  runtime constants.
+- Use `PascalCase` for types, interfaces, classes, enums, namespaces, and enum
+  members.
+- Use `UPPER_SNAKE_CASE` only for shared true constants.
+- Prefer literal unions when no runtime enum object is required.
+- Avoid heterogeneous enums.
+- Prefer explicit string values for externally persisted or serialized enums.
+- Throw `Error` subclasses with actionable context; do not throw raw strings or
+  untyped objects.
+- Preserve `cause` chains when wrapping errors.
+- Ensure rejected promises are observed and handled.
+
+## Decorators and JSDoc
+
+- For decorated classes, place JSDoc immediately above the top-most decorator.
+- Keep decorators contiguous and directly above the class declaration.
+- Do not place JSDoc between a decorator and the class declaration.


### PR DESCRIPTION
Closes #83

## Summary
- Broaden `conventions-typescript` from layout-only guidance into the TypeScript convention entrypoint for strict configuration, type strategy, runtime boundaries, naming, async/error handling, decorators, and layout.
- Add `references/typescript-safety-defaults.md` with concrete defaults for compiler settings, domain typing, runtime validation, nullability, enums, errors, and decorator/JSDoc ordering.

## Finding Classification
- Valid: the existing TypeScript convention skill only covered multiline layout and trailing commas.
- Valid: mandatory TypeScript safety, naming, structure, runtime-boundary, async/error, enum, and decorator rules were not represented in the skill catalog.
- Resolution: expanded the existing TypeScript convention skill and added a focused reference instead of creating separate overlapping convention skills.

## Validation
- `git diff --check -- skills/conventions-typescript/SKILL.md skills/conventions-typescript/references/typescript-safety-defaults.md`
- markdown line-length check for changed files
- `./gradlew.bat qualityGate`