### PR TITLE
Address #84: clarify exit gate composition and ranking

### DIFF
--- a/skills/gates-exit/SKILL.md
+++ b/skills/gates-exit/SKILL.md
@@ -30,8 +30,12 @@ and passed.
 # Inputs
 
 - the bounded diff, changed files, and implementation goal
+- confirmation that the complete applicable ai-rules and downstream rulesets
+  have been read before implementation/gate evaluation
 - the repository build and test commands or the strongest equivalent CI/local
   evidence
+- the behavior changes in the bounded scope and the tests added or updated for
+  each behavior change
 - the relevant technologies, languages, and data-access paths touched by the
   bounded change
 - the child skills listed in `references/gate-mapping.md` when they apply
@@ -40,51 +44,95 @@ and passed.
 
 # Workflow
 
-1. Identify the bounded scope and determine which languages, frameworks,
+## Composed Skills
+
+This is a composite skill. It conditionally orchestrates the following children
+when they materially apply to the bounded scope:
+
+- Correctness-Gate:
+  `../correctness-equals-hashcode/SKILL.md`,
+  `../correctness-comparable/SKILL.md`, and
+  `../correctness-jpa/SKILL.md`
+- Design-Gate:
+  `../design-validation/SKILL.md` and
+  `../design-value-object/SKILL.md`
+- Performance-Gate:
+  `../performance-db/SKILL.md`
+- Convention-Gate:
+  `../conventions-java/SKILL.md`,
+  `../conventions-typescript/SKILL.md`, and relevant leaf convention skills
+- Quality-Gate:
+  `../quality-crap/SKILL.md`,
+  `../quality-cognitive-complexity/SKILL.md`, and
+  `../quality-sonar/SKILL.md`
+
+## Gate Evaluation
+
+1. Verify that the complete applicable ai-rules and downstream rulesets were
+   read before implementation and exit-gate evaluation. If not, read them before
+   continuing or mark the gate evaluation blocked.
+2. Identify the bounded scope and determine which languages, frameworks,
    persistence paths, and quality signals are relevant.
-2. Evaluate the mandatory gates in the order from
+3. Evaluate the mandatory gates in the order from
    `references/gate-order-and-rerun.md` and record a result for every gate
    instead of stopping at the first failure.
-3. For Build-Gate and Test-Gate, use the strongest available repository build
-   and test evidence; if execution is blocked, record the blocker explicitly
-   rather than pretending the gate passed.
-4. For Correctness-Gate, apply the relevant correctness skills from
+4. For Build-Gate and Test-Gate, attempt the applicable repository commands or
+   verify equivalent post-change CI execution before marking either gate passed;
+   if execution is blocked, record the blocker explicitly rather than pretending
+   the gate passed.
+5. For Test-Gate, map every behavior change to an added or updated automated
+   test. If a behavior change lacks feasible test coverage, mark the gate failed
+   or blocked with the exact risk rationale instead of passing it.
+6. For Correctness-Gate, apply the relevant correctness skills from
    `references/gate-mapping.md`, such as
    `../correctness-equals-hashcode/SKILL.md`,
    `../correctness-comparable/SKILL.md`, and
    `../correctness-jpa/SKILL.md`, based on the bounded scope.
-5. For Design-Gate, apply the relevant design skills from
+7. For Design-Gate, apply the relevant design skills from
    `references/gate-mapping.md`, especially
    `../design-validation/SKILL.md` and
    `../design-value-object/SKILL.md`, when their boundaries are in scope.
-6. For Performance-Gate, apply `../performance-db/SKILL.md` when database
+8. For Performance-Gate, apply `../performance-db/SKILL.md` when database
    statements or data-access performance are in scope, and record why the gate
    is not applicable when the bounded change does not affect performance
    surfaces.
-7. For Convention-Gate, apply the relevant umbrella or leaf convention skills,
+9. For Convention-Gate, apply the relevant umbrella or leaf convention skills,
    such as `../conventions-java/SKILL.md` or
    `../conventions-typescript/SKILL.md`, based on the changed technology.
-8. For Quality-Gate, apply the relevant quality skills from
+10. For Quality-Gate, apply the relevant quality skills from
    `references/gate-mapping.md`, especially
    `../quality-crap/SKILL.md`,
    `../quality-cognitive-complexity/SKILL.md`, and
    `../quality-sonar/SKILL.md`, using the strongest available evidence.
-9. Aggregate the gate results into one bounded-scope decision. If any gate
-   fails or remains blocked, fix only the bounded findings and then restart the
-   full gate sequence from gate 1 instead of resuming midway.
-10. Use `examples/exit-gate-report.md` when communicating the final per-gate
+11. Aggregate failed or blocked findings by severity before reporting them:
+    correctness/regression, security/privacy/compliance, data integrity/error
+    handling, architecture/boundaries, performance/scalability, observability,
+    then maintainability/readability/test adequacy.
+12. Aggregate the gate results into one bounded-scope decision. If any gate
+    fails or remains blocked, fix only the bounded findings and then restart the
+    full gate sequence from gate 1 instead of resuming midway.
+13. Use `examples/exit-gate-report.md` when communicating the final per-gate
     status and overall outcome.
 
 # Outputs
 
 - a result for each mandatory exit gate, including pass, fail, blocked, or
   not-applicable with explicit rationale
+- test-coverage mapping for each behavior change or an explicit failed/blocked
+  rationale when coverage is missing
+- failed or blocked findings reported in severity order
 - an overall exit-gate decision for the bounded change
 - a concise rerun requirement when any gate failed or remained blocked
 
 # Guardrails
 
+- do not evaluate exit gates before the applicable ruleset read gate is
+  satisfied or explicitly blocked
 - do not stop the evaluation after the first failed gate
+- do not mark Build-Gate or Test-Gate passed without attempted local execution
+  or equivalent post-change CI evidence
+- do not mark Test-Gate passed for behavior changes without added or updated
+  test coverage unless the gate is explicitly failed or blocked
 - do not broaden the implementation scope just to clean unrelated code so a
   gate looks green
 - do not skip a mandatory gate without an explicit blocked or not-applicable
@@ -95,9 +143,16 @@ and passed.
 
 # Exit Checks
 
+- the applicable ruleset read gate was satisfied before exit-gate evaluation,
+  or the evaluation is explicitly blocked
 - every mandatory gate has an explicit recorded result
 - specialized child skills were used where they materially supported a gate
+- build and test gates were actually executed locally or backed by equivalent
+  post-change CI evidence before being marked passed
+- each behavior change has added or updated test coverage, or Test-Gate is
+  failed/blocked with rationale
 - any blocked or not-applicable gate has a concrete rationale
+- failed and blocked findings are reported in severity order
 - the overall decision matches the full set of gate results
 - after any fix, the final reported result comes from a full rerun of the gate
   sequence

--- a/skills/gates-exit/examples/exit-gate-report.md
+++ b/skills/gates-exit/examples/exit-gate-report.md
@@ -2,6 +2,8 @@
 
 - Build-Gate: pass
 - Test-Gate: pass
+  Behavior changes are covered by updated service tests for order syncing and
+  validation.
 - Correctness-Gate: fail
   `OrderEntity.equals(...)` still treats two unsaved entities with null ids as
   equal.
@@ -10,6 +12,13 @@
 - Convention-Gate: pass
 - Quality-Gate: fail
   `OrderService.sync(...)` still exceeds the CRAP threshold.
+
+Severity-ranked failures:
+
+1. correctness and regression risk:
+   `OrderEntity.equals(...)` can merge distinct unsaved entities.
+2. maintainability, readability, and test adequacy:
+   `OrderService.sync(...)` still exceeds the CRAP threshold.
 
 Overall result: fail. Fix the bounded correctness and quality findings, then
 rerun all exit gates from Build-Gate onward.

--- a/skills/gates-exit/references/gate-mapping.md
+++ b/skills/gates-exit/references/gate-mapping.md
@@ -1,6 +1,8 @@
 # Gate Mapping
 
-Map the mandatory gates to the strongest available skills and evidence:
+Map the mandatory gates to the strongest available skills and evidence. Child
+skills are conditional composition points; use them when they materially apply
+to the bounded scope.
 
 - Build-Gate: repository build command, CI build job, or equivalent local build
   evidence
@@ -27,3 +29,17 @@ Map the mandatory gates to the strongest available skills and evidence:
 Not every child skill applies to every change. The gate runner should select
 only the relevant skills for the bounded scope and explain when a gate is
 not-applicable because the affected surface is absent.
+
+For Test-Gate, every behavior change must map to an added or updated automated
+test. If the mapping is missing and cannot be added in the bounded scope, mark
+Test-Gate failed or blocked with an explicit risk rationale.
+
+Report failed and blocked findings in this severity order:
+
+1. correctness and regression risk
+2. security, privacy, and compliance
+3. data integrity and error handling
+4. architecture and boundary violations
+5. performance and scalability risks
+6. observability and operational readiness
+7. maintainability, readability, and test adequacy

--- a/skills/gates-exit/references/gate-order-and-rerun.md
+++ b/skills/gates-exit/references/gate-order-and-rerun.md
@@ -11,7 +11,9 @@ Mandatory exit gates:
 7. Quality-Gate
 
 Evaluate every gate in the sequence above for the bounded change. Do not stop
-the run at the first failure.
+the run at the first failure. Before marking Build-Gate or Test-Gate passed,
+attempt the applicable local command or verify equivalent post-change CI
+evidence.
 
 If one or more gates fail or are blocked and the implementation is changed to
 address them, the next attempt must start again from gate 1 so the final


### PR DESCRIPTION
Closes #84

## Summary
- Declare `gates-exit` as a composite skill and list the conditional child skills it orchestrates.
- Add the ruleset-read prerequisite, mandatory build/test execution evidence, and behavior-change test mapping to the gate workflow.
- Add severity-ranked aggregation for failed or blocked findings and update the example report.

## Finding Classification
- Valid: the skill orchestrated child skills but did not declare composition explicitly.
- Valid: the ruleset read gate was missing from the exit-gate prerequisites.
- Valid: Build-Gate and Test-Gate could be read as accepting available evidence without first attempting execution or confirming equivalent post-change CI.
- Valid: behavior-change test coverage expectations were too vague.
- Valid: failed/blocked aggregation did not preserve the canonical review severity order.
- Resolution: updated the composite contract, mapping/reference docs, workflow guardrails, exit checks, and example output.

## Validation
- `git diff --check -- skills/gates-exit/SKILL.md skills/gates-exit/references/gate-mapping.md skills/gates-exit/references/gate-order-and-rerun.md skills/gates-exit/examples/exit-gate-report.md`
- markdown line-length check for changed files
- `./gradlew.bat qualityGate`