### PR TITLE
Address #85: add GitHub comment formatting guardrails

### DIFF
--- a/skills/formatting-github-comment/SKILL.md
+++ b/skills/formatting-github-comment/SKILL.md
@@ -81,8 +81,9 @@ act on.
 - do not exceed 120 characters per Markdown source line; wrap long list items
 - do not omit the single trailing newline from Markdown files
 - do not save Markdown as UTF-8 with BOM
-- do not leave raw angle-bracket placeholders such as `<id>` in prose; wrap
-  placeholders in code spans like `<id>` or fenced code blocks
+- do not leave raw angle-bracket placeholders such as &lt;id&gt; in prose
+  without backticks; wrap placeholders in code spans like `<id>` or fenced code
+  blocks
 - do not leave multiple consecutive blank lines after bulk edits
 - do not emit literal `\n` escape sequences in Markdown meant for GitHub
 - do not publish GitHub CLI bodies with escaped inline strings when a raw

--- a/skills/formatting-github-comment/SKILL.md
+++ b/skills/formatting-github-comment/SKILL.md
@@ -30,7 +30,14 @@ act on.
 - the communication goal
 - the intended audience and context
 - the raw points, findings, or status details to include
+- the GitHub artifact type, especially whether the output is an issue body, PR
+  description, review reply, or status comment
+- whether the Markdown will be published through GitHub CLI or another API
 - any formatting constraints such as brevity, required headings, or code blocks
+- PR description fields already selected by the caller, especially from
+  `../pr-write-description/SKILL.md` or
+  `../pr-write-description/references/pr-description-template.md` when the
+  target artifact is a PR summary or description
 - optional use of `references/markdown-comment-formatting.md` and the example
   files when the target artifact already matches one of those shapes
 
@@ -44,8 +51,16 @@ act on.
 4. Use Markdown features only when they improve readability, such as short
    headings, flat lists, inline code, fenced code blocks, and links.
 5. Keep line wrapping, spacing, and code spans consistent so the comment reads
-   cleanly in GitHub.
-6. Reuse `references/markdown-comment-formatting.md` for general formatting,
+   cleanly in GitHub: wrap Markdown source lines at 120 characters or less, end
+   the file with one trailing newline, and keep content UTF-8 without BOM.
+6. If publishing through GitHub CLI, write the body as raw UTF-8 Markdown and
+   use `--body-file <path>` rather than escaped inline strings. Preflight the
+   body for literal `\n` markers before publishing.
+7. For PR descriptions and summaries, preserve and clearly format any PR fields
+   or sections already provided by the input, draft, or
+   `../pr-write-description/references/pr-description-template.md`; defer
+   required-field selection to `../pr-write-description/SKILL.md`.
+8. Reuse `references/markdown-comment-formatting.md` for general formatting,
    `examples/github-comment.md` for full comments, and
    `examples/review-thread-reply.md` for short thread replies when they fit the
    target artifact type.
@@ -63,7 +78,15 @@ act on.
 - do not over-format simple messages with unnecessary headings or nesting
 - do not hide the main action behind long narrative prose
 - do not rely on formatting that is fragile or hard to edit later
+- do not exceed 120 characters per Markdown source line; wrap long list items
+- do not omit the single trailing newline from Markdown files
+- do not save Markdown as UTF-8 with BOM
+- do not leave raw angle-bracket placeholders such as `<id>` in prose; wrap
+  placeholders in code spans like `<id>` or fenced code blocks
+- do not leave multiple consecutive blank lines after bulk edits
 - do not emit literal `\n` escape sequences in Markdown meant for GitHub
+- do not publish GitHub CLI bodies with escaped inline strings when a raw
+  UTF-8 `--body-file` flow is available
 - do not mention `@copilot` in PR comments
 
 # Exit Checks
@@ -71,5 +94,11 @@ act on.
 - the main point is understandable in one pass
 - the Markdown uses only flat, readable structure
 - code spans and code blocks are syntactically correct
+- lines are wrapped to 120 characters or less
+- Markdown has exactly one trailing newline and no UTF-8 BOM
+- placeholder tokens are code-formatted instead of raw angle-bracket prose
+- no literal `\n` markers or accidental multi-blank-line runs remain
+- PR descriptions preserve applicable fields from the provided draft or
+  `../pr-write-description/references/pr-description-template.md`
 - the result is concise enough for GitHub discussion flow
 - the output shape matches the intended GitHub artifact

--- a/skills/formatting-github-comment/references/markdown-comment-formatting.md
+++ b/skills/formatting-github-comment/references/markdown-comment-formatting.md
@@ -4,7 +4,21 @@ Distilled from internal formatting guidance and recent GitHub review feedback
 patterns.
 
 - Keep lines wrapped so long comments stay readable in diffs and source view.
+- Keep Markdown source lines at or under 120 characters and wrap long list
+  items.
+- End Markdown files with exactly one trailing newline.
+- Save Markdown as UTF-8 without BOM.
 - Keep Markdown structurally simple and avoid fragile formatting.
 - Keep inline code on one line so renderers do not split or mangle it.
 - Prefer a short paragraph or flat bullets over deeply nested structure.
 - Use exact identifiers and links when the comment needs traceability.
+- Wrap placeholder tokens in code spans, for example `<id>`, instead of raw
+  angle-bracket prose.
+- After bulk edits, check for multiple consecutive blank lines before posting
+  or committing.
+- When posting with GitHub CLI, prefer a raw UTF-8 Markdown file and
+  `--body-file <path>`; do not pass escaped inline bodies containing literal
+  `\n` markers.
+- For PR summaries and descriptions, preserve and clearly format the fields
+  already selected by the input, draft, or
+  `../../pr-write-description/references/pr-description-template.md`.

--- a/skills/formatting-github-comment/references/markdown-comment-formatting.md
+++ b/skills/formatting-github-comment/references/markdown-comment-formatting.md
@@ -12,8 +12,8 @@ patterns.
 - Keep inline code on one line so renderers do not split or mangle it.
 - Prefer a short paragraph or flat bullets over deeply nested structure.
 - Use exact identifiers and links when the comment needs traceability.
-- Wrap placeholder tokens in code spans, for example `<id>`, instead of raw
-  angle-bracket prose.
+- Wrap placeholder tokens in code spans, for example `<id>`, instead of
+  unformatted placeholders without backticks, such as &lt;id&gt;.
 - After bulk edits, check for multiple consecutive blank lines before posting
   or committing.
 - When posting with GitHub CLI, prefer a raw UTF-8 Markdown file and


### PR DESCRIPTION
Closes #85

## Summary
- Add GitHub artifact inputs and GitHub CLI publishing workflow guidance for raw UTF-8 `--body-file` bodies.
- Add Markdown hygiene guardrails for 120-character wrapping, one trailing newline, UTF-8 without BOM, code-formatted placeholders, MD012-style blank-line checks, and literal `\n` prevention.
- Cross-reference the in-repo PR description skill/template while keeping this skill formatting-only.

## Finding Classification
- Valid: explicit 120-character wrapping, single trailing newline, UTF-8 without BOM, placeholder formatting, and MD012-style checks were missing.
- Valid: literal `\n` prevention existed as a guardrail but lacked a concrete GitHub CLI publishing workflow.
- Valid: PR summary/description formatting needed to preserve selected PR fields without taking over content-authoring decisions.
- Valid: Copilot's dead-link findings for `CORE/GITHUB.md` were correct; fixed by using in-repo `pr-write-description` references.
- Invalid: frontmatter normalization was already satisfied in this repository because `description` is a single-line string.
- Resolution: updated the skill contract and formatting reference while preserving the skill's formatting-only scope.

## Validation
- `git diff --check -- skills/formatting-github-comment/SKILL.md skills/formatting-github-comment/references/markdown-comment-formatting.md`
- markdown line-length check for changed files
- no-BOM/trailing-newline check for changed files
- `npx --yes markdownlint-cli2 "**/*.md" "!**/node_modules/**" --config .markdownlint.json`
- `./gradlew.bat qualityGate`