### PR TITLE
Address #86: tighten PR review loop guardrails

### DIFF
--- a/skills/pr-review-loop/SKILL.md
+++ b/skills/pr-review-loop/SKILL.md
@@ -28,71 +28,104 @@ after the latest push has been reviewed.
 - use `references/review-loop-state.md` for the required per-PR state model and
   review-readiness gate
 - use `references/review-loop-queue.md` for round-robin queue behavior
+- use `references/copilot-review-trigger.md` when strict GitHub Copilot review
+  re-triggering is required
 - use `examples/review-loop-status.md` when reporting loop state or completion
 
 # Inputs
 
 - one or more active PRs with their latest head commits
+- session entry preferences when already answered:
+  `RUN_REVIEW_LOOP`, `IMPLEMENT_AFTER_PLAN`, and `MERGE_AFTER_CLEAN_LOOP`
 - the latest push time, automated-review state, review threads, and required
   checks for each PR
 - repository preferences about whether clean PRs should be merged
 - access to the PR platform APIs needed to request or inspect automated review
+- the main linked issue for each PR and whether the PR body contains an
+  issue-closing link
+- the intended bounded scope for each PR, used to detect unrelated bundled
+  changes
 - `../pr-review/SKILL.md`
 - `../pr-review-respond/SKILL.md`
 - `../pr-merge/SKILL.md`
 - `references/review-loop-state.md`
 - `references/review-loop-queue.md`
+- `references/copilot-review-trigger.md`
 
 # Workflow
 
-1. Build the active PR queue and track the current state for each item using
+1. Capture session entry preferences once when the user prompt did not already
+   answer them: `RUN_REVIEW_LOOP`, `IMPLEMENT_AFTER_PLAN`, and
+   `MERGE_AFTER_CLEAN_LOOP`. Do not ask again in the same session.
+2. If `RUN_REVIEW_LOOP=false`, report that the loop is intentionally skipped
+   for this session and stop before mutating PR state.
+3. Build the active PR queue and track the current state for each item using
    the fields in `references/review-loop-state.md`.
-2. Process active items in round-robin order instead of waiting idly on a
+4. Process active items in round-robin order instead of waiting idly on a
    single PR.
-3. After each push, require fresh review state for that PR head: clear the
+5. After each push, require fresh review state for that PR head: clear the
    previous pass assumptions, inspect required checks, inspect unresolved
    threads, and determine whether a post-push automated review already exists.
-4. If the latest push does not yet have a submitted automated review, request
+6. If the latest push does not yet have a submitted automated review, request
    one through the platform API or configured review mechanism, then move on to
-   the next item without blocking.
-5. If checks are still running or a review is still in progress for the latest
+   the next item without blocking. For strict GitHub Copilot review loops, use
+   `references/copilot-review-trigger.md`.
+7. If checks are still running or a review is still in progress for the latest
    push, keep the PR active and continue with the next item.
-6. When the latest push has completed review results, apply
+8. When the latest push has completed review results, apply
    `../pr-review/SKILL.md` and `../pr-review-respond/SKILL.md` to classify
    findings, reply to each thread, fix valid issues, and resolve only the
    threads that were actually handled.
-7. If fixes were pushed, restart the same post-push review cycle for that PR
-   instead of treating earlier review results as sufficient.
-8. If no fixes were needed, evaluate the review-readiness gate from
-   `references/review-loop-state.md`. When that gate passes, hand the PR to
-   `../pr-merge/SKILL.md` for the remaining merge-policy checks and merge
-   execution; otherwise report the blocking gate conditions.
-9. Use `examples/review-loop-status.md` when communicating queue state,
+9. If fixes were pushed, restart the same post-push review cycle for that PR
+   instead of treating earlier review results as sufficient, and explicitly
+   re-trigger automated review for the new head commit.
+10. If no fixes were needed, verify the PR remains focused on the linked issue
+   and the PR body contains the issue-closing link, then evaluate the
+   review-readiness gate from `references/review-loop-state.md`.
+11. When the review-readiness gate passes and
+   `MERGE_AFTER_CLEAN_LOOP=true`, hand the PR to `../pr-merge/SKILL.md` for
+   the remaining merge-policy checks and merge execution; otherwise report the
+   blocking gate conditions or clean-but-unmerged status.
+12. Use `examples/review-loop-status.md` when communicating queue state,
    remaining blockers, or clean completion.
 
 # Outputs
 
 - a per-PR status showing review state, remaining blockers, and merge
   readiness
+- captured session preferences or explicit note that the loop was skipped
 - handled review threads with explicit valid, invalid, or unresolved treatment
+- issue-link and focused-scope status for each PR
 - merged PRs only when post-push review readiness is satisfied and
   `../pr-merge/SKILL.md` allows merge execution
 
 # Guardrails
 
+- do not ask session entry preference questions more than once per session
+- do not bundle unrelated repository changes into a PR being advanced through
+  the loop
 - do not treat a review that predates the latest push as sufficient for merge
 - do not wait idly on one PR when other active items can progress
+- do not use fixed wait timers as merge gates; use review/check/timeline state
 - do not merge while review is still running, checks are incomplete, or threads
   remain unresolved
 - do not trigger automated review through ad-hoc PR comments when the platform
   provides a proper API or workflow trigger
+- do not mention `@copilot` in PR comments
+- do not delete review comments to make threads disappear; resolve handled
+  threads and preserve the history
 - do not resolve invalid findings without leaving a concise rationale first
+- do not merge a PR that lacks the required issue-closing link
 
 # Exit Checks
 
 - every active PR has an explicit current-state summary
+- session entry preferences were captured once or were already supplied by the
+  user prompt
 - no PR is marked merge-ready without a completed post-push review for its
   latest head commit
+- each merge-ready PR is focused on its linked issue and has an issue-closing
+  link in the PR body
 - remaining blockers are concrete, not generic
 - merged PRs passed the review-readiness gate in the same evaluation round,
   and `../pr-merge/SKILL.md` then allowed merge execution

--- a/skills/pr-review-loop/examples/review-loop-status.md
+++ b/skills/pr-review-loop/examples/review-loop-status.md
@@ -1,7 +1,7 @@
 # Example Review Loop Status
 
-- `#71 compliance-dependency`: checks green, no valid findings, no open review
-  threads, waiting only for merge execution
+- `#71 compliance-dependency`: checks green, issue link present, focused scope,
+  no valid findings, no open review threads, waiting only for merge execution
 - `#72 performance-db`: one valid finding fixed and pushed, post-push review
   requested, checks still running
 - `#73 release-github`: no review submitted yet for the latest push, automated

--- a/skills/pr-review-loop/references/copilot-review-trigger.md
+++ b/skills/pr-review-loop/references/copilot-review-trigger.md
@@ -1,0 +1,31 @@
+# Copilot Review Trigger
+
+Use this reference when strict GitHub Copilot review is the configured
+automated review mechanism.
+
+After every fix push, explicitly request a fresh Copilot review for the PR head
+commit through the GitHub API. Do not use PR comments or `@copilot` mentions.
+
+1. Capture the raw pull request node id:
+
+   ```sh
+   PR_ID="$(gh pr view <PR_NUMBER> --json id --jq .id)"
+   ```
+
+2. Request review from the Copilot review bot with the mutation supplied inline:
+
+   ```sh
+   gh api graphql \
+     -f query='mutation RequestCopilotReview($pr: ID!, $bots: String!) {
+       requestReviewsByLogin(
+         input: { pullRequestId: $pr, botLogins: [$bots], union: true }
+       ) {
+         clientMutationId
+       }
+     }' \
+     -f pr="$PR_ID" \
+     -f bots="copilot-pull-request-reviewer"
+   ```
+
+3. Verify a new review request or submitted review appears for the latest head
+   commit before treating the PR as reviewed.

--- a/skills/pr-review-loop/references/review-loop-queue.md
+++ b/skills/pr-review-loop/references/review-loop-queue.md
@@ -11,6 +11,14 @@ Use round-robin progression across active PRs:
 This keeps multiple PRs moving in parallel while preserving the rule that each
 push needs its own fresh review state before merge.
 
+Treat review generation latency as operational state, not a fixed timer. Do
+not merge because an arbitrary wait elapsed; merge only from explicit
+review/check/thread state.
+
+For strict GitHub Copilot review loops, re-trigger review through the platform
+API described in `copilot-review-trigger.md` after every fix push. Do not use
+PR comments or `@copilot` mentions as the trigger.
+
 If a PR cannot proceed because of missing permissions, missing branch updates,
 or missing review infrastructure, keep it in the queue with an explicit blocker
 instead of silently dropping it.

--- a/skills/pr-review-loop/references/review-loop-state.md
+++ b/skills/pr-review-loop/references/review-loop-state.md
@@ -8,6 +8,8 @@ Track each active PR with at least these fields:
 - `open-review-threads`
 - `new-valid-findings`
 - `required-checks-green`
+- `issue-link-present`
+- `pr-scope-focused`
 - `review-readiness-gate-passed`
 
 The review-readiness gate passes only when all of these are true in the same
@@ -18,6 +20,9 @@ evaluation round:
 - no open review threads remain
 - no new valid findings remain
 - required checks are green
+- the PR body links the main issue with an issue-closing link
+- the PR scope remains focused on the linked issue without unrelated bundled
+  repository changes
 
 Treat missing or ambiguous review/check state as gate failure, not as an
 implicit pass.


### PR DESCRIPTION
Closes #86

## Summary
- Add one-time session entry preferences to the PR review loop contract.
- Add focused-scope and issue-link gates to review readiness before merge handoff.
- Add guardrails against deleting review comments, fixed wait timers, unrelated PR bundling, and PR-comment review triggers.
- Add `references/copilot-review-trigger.md` with the API-based GitHub Copilot re-review flow for strict Copilot loops.

## Finding Classification
- Valid: the skill did not preserve the session preference pattern for `RUN_REVIEW_LOOP`, `IMPLEMENT_AFTER_PLAN`, and `MERGE_AFTER_CLEAN_LOOP`.
- Valid: the skill lacked explicit guardrails for never deleting review comments, fixed wait timers, and unrelated PR bundling.
- Valid: the automated-review re-trigger step needed a concrete API-based Copilot path for strict ai-rules use.
- Valid: merge readiness did not require the PR body to link the main issue.
- Resolution: updated the skill contract, state model, queue behavior, example status, and added the Copilot trigger reference.

## Validation
- `git diff --check -- skills/pr-review-loop`
- markdown line-length check for changed files
- `npx --yes markdownlint-cli2 "**/*.md" "!**/node_modules/**" --config .markdownlint.json`
- `./gradlew.bat qualityGate`