### PR TITLE
Address #87: require release version reference scan

### DIFF
--- a/skills/release-github/SKILL.md
+++ b/skills/release-github/SKILL.md
@@ -27,6 +27,7 @@ annotated tags, and GitHub release notes aligned.
 # Inputs
 
 - the repository default branch with all release-bound changes already merged
+- confirmation that no open release-bound PRs remain
 - the latest reachable release tag and the merged changes since that tag
 - any explicit target version provided by the user or repository policy
 - the changelog or strongest release-notes source for the repository
@@ -36,8 +37,8 @@ annotated tags, and GitHub release notes aligned.
 
 # Workflow
 
-1. Ensure the default branch is current and that the changes intended for the
-   release are already merged instead of releasing from a feature branch.
+1. Ensure the default branch is current, all release-bound PRs are merged, and
+   no open release-bound PRs remain; do not release from a feature branch.
 2. Determine the target version: use an explicit version when provided;
    otherwise classify the changes since the latest tag and select the smallest
    valid semantic-version bump that fits the strongest user-visible change.
@@ -45,13 +46,19 @@ annotated tags, and GitHub release notes aligned.
    tag.
 4. Update the changelog or release-notes source with the selected version, the
    release date, and a concise summary of user-visible changes.
-5. Update any versioned release examples or docs that must point at the new
-   tag.
-6. Commit the release-preparation changes on the default branch, create an
+5. Run `git grep -F "<previous-tag>"` before creating the release commit,
+   replacing `<previous-tag>` with the actual latest released version tag, for
+   example `v1.2.3`. Update every versioned release example or documentation
+   reference found so it points at the new tag.
+6. Stage the changelog or release-notes source and all versioned-example
+   updates together.
+7. Commit the release-preparation changes on the default branch, create an
    annotated tag for the release commit, and push both branch and tag.
-7. Create the GitHub Release from the pushed tag using notes that stay aligned
-   with the changelog or release-notes source.
-8. Verify that the tag and release page exist and point at the intended commit.
+8. Create the GitHub Release from the pushed tag using notes that stay aligned
+   with the changelog or release-notes source. If both exist, treat the
+   changelog as authoritative unless repository policy explicitly says
+   otherwise.
+9. Verify that the tag and release page exist and point at the intended commit.
 
 # Outputs
 
@@ -63,15 +70,25 @@ annotated tags, and GitHub release notes aligned.
 # Guardrails
 
 - do not release from a feature branch or dirty branch state
+- do not release while open release-bound PRs remain
 - do not guess a version bump without checking the merged change set
 - do not create a release when there are no meaningful release changes
+- do not skip the previous-tag `git grep` scan before the release-preparation
+  commit
 - do not let GitHub release notes drift from the authoritative changelog or
   release-notes source
 
 # Exit Checks
 
 - the target version is explicit and justified
+- the default branch includes all release-bound PRs and no open release-bound
+  PRs remain
 - changelog or release notes, tag, and GitHub Release all reference the same
   release
+- `git grep -F "<previous-tag>"` was run with the actual latest released tag and
+  every relevant versioned example or documentation reference was updated or
+  explicitly ruled out
+- all changelog/release-notes and versioned-example updates were staged in the
+  release-preparation commit before tagging
 - the release was created from the intended default-branch commit
 - the published result is specific enough for downstream consumers to use

--- a/skills/release-github/references/github-release-flow.md
+++ b/skills/release-github/references/github-release-flow.md
@@ -3,17 +3,27 @@
 Keep these release artifacts aligned:
 
 - changelog or authoritative release-notes source
+- versioned release examples and documentation references
 - annotated Git tag
 - GitHub Release page
 
 Preferred sequence:
 
-1. update release notes source
-2. commit the release-preparation change
-3. create the annotated tag on that commit
-4. push branch and tag
-5. create the GitHub Release from the pushed tag
-6. verify the tag and release page point at the same commit
+1. verify the default branch is current and no release-bound PRs remain open
+2. update release-notes source
+3. run `git grep -F "<previous-tag>"`, replacing `<previous-tag>` with the
+   actual latest released tag, for example `v1.2.3`
+4. update every relevant versioned example or documentation reference to the new
+   tag
+5. commit the release-preparation change
+6. create the annotated tag on that commit
+7. push branch and tag
+8. create the GitHub Release from the pushed tag
+9. verify the tag and release page point at the same commit
 
 When repository policy defines a release-note heading or formatting template,
 honor that policy rather than inventing a new layout during release.
+
+If a repository has both a changelog and a separate release-notes source, decide
+which source is authoritative before creating the GitHub Release and keep the
+other one aligned or explicitly out of scope.


### PR DESCRIPTION
Closes #87

## Summary
- Tighten release preflight to require the default branch to include all release PRs and have no open release-bound PRs.
- Make `git grep "<previous-tag>"` mandatory before the release-preparation commit.
- Require every relevant versioned example or documentation reference to be updated or explicitly ruled out before tagging.
- Document the changelog versus release-notes source decision when both exist.

## Finding Classification
- Valid: versioned-example updates were treated too softly and did not require a previous-tag grep.
- Valid: release preflight did not explicitly require all release PRs to be merged and no release-bound PRs to remain open.
- Valid extension: allowing a separate release-notes source is acceptable when the authoritative source decision is explicit and alignment is preserved.
- Resolution: updated the release workflow, guardrails, exit checks, and release-flow reference.

## Validation
- `git diff --check -- skills/release-github/SKILL.md skills/release-github/references/github-release-flow.md`
- markdown line-length check for changed files
- `npx --yes markdownlint-cli2 "**/*.md" "!**/node_modules/**" --config .markdownlint.json`
- `./gradlew.bat qualityGate`