### PR TITLE
Address #88: tighten Java Optional guardrail

### DIFF
--- a/skills/conventions-java/SKILL.md
+++ b/skills/conventions-java/SKILL.md
@@ -76,8 +76,8 @@ are still kept in this bundle.
   `conventions-lombok`, `conventions-early-return`, or `conventions-ternary`
 - do not add Lombok when the user or project explicitly forbids it, or when
   the bounded Java change does not materially benefit from it
-- do not use `Optional` for Java fields, parameters, or serialization models
-  without an explicit bounded justification
+- do not use `Optional` for Java fields, method parameters, or serialization
+  models unless there is a strong documented reason
 - do not keep literal-template string concatenation with `+` when
   `String.format(...)` is the clearer Java default
 - do not replace hot-loop or append-heavy string construction with
@@ -92,6 +92,6 @@ are still kept in this bundle.
 - Java literal-template strings use `String.format(...)` unless a hot-loop or
   append-heavy exception justifies `StringBuilder`
 - `Optional` usage stays limited to meaningful Java return-value absence unless
-  an explicit bounded exception was required
+  a strong documented reason justifies a bounded exception
 - the final result preserves the child-skill guardrails rather than replacing
   them

--- a/skills/conventions-java/references/java-convention-defaults.md
+++ b/skills/conventions-java/references/java-convention-defaults.md
@@ -10,7 +10,8 @@ Distilled from issue `#13` plus the shared Java baseline in `ai-rules`.
 - In tight loops or append-heavy Java paths, prefer `StringBuilder` over
   `String.format(...)`.
 - Use `Optional<T>` only when return-value absence is semantically meaningful;
-  do not default to `Optional` fields, parameters, or serialization models.
+  do not use `Optional` for fields, method parameters, or serialization models
+  unless there is a strong documented reason.
 - When Lombok would materially reduce bounded Java boilerplate and no explicit
   project or user rule forbids it, prefer applying `conventions-lombok`
   instead of keeping handwritten constructors, accessors, or loggers.


### PR DESCRIPTION
Closes #88

## Summary
- Tighten the Java `Optional` guardrail to require a strong documented reason for fields, method parameters, or serialization models.
- Align the Java defaults reference with the same wording.

## Finding Classification
- Valid: the previous wording was softer than the source Java rule and could be read as allowing any bounded justification.
- Resolution: updated the skill guardrail and reference to require a strong documented reason.

## Validation
- `git diff --check -- skills/conventions-java/SKILL.md skills/conventions-java/references/java-convention-defaults.md`
- markdown line-length check for changed files
- `npx --yes markdownlint-cli2 "**/*.md" "!**/node_modules/**" --config .markdownlint.json`
- `./gradlew.bat qualityGate`