### PR TITLE
Address #89: clarify issue implementation composition

### DIFF
--- a/skills/issue-implement/SKILL.md
+++ b/skills/issue-implement/SKILL.md
@@ -32,6 +32,8 @@ completed, verified through exit gates, and summarized back on the issue.
 - the issue title, description, acceptance criteria, and relevant follow-up
   comments
 - the bounded repository context needed to implement the issue
+- evidence that the applicable ruleset-read gate and final conformance plan
+  checks are satisfied, usually through `../plan/SKILL.md`
 - the repository build/test commands and any gate-relevant evidence sources
 - any applicable child skills needed for the issue's domain-specific work
 - `../plan/SKILL.md`
@@ -41,26 +43,49 @@ completed, verified through exit gates, and summarized back on the issue.
 
 # Workflow
 
+## Composed Skills
+
+This is a composite skill. It orchestrates:
+
+- `../plan/SKILL.md` for the decision-complete plan, ruleset-read gate, and
+  final conformance re-read
+- `../gates-exit/SKILL.md` for mandatory exit-gate verification after the
+  bounded implementation
+- `../issue-write-summary-comment/SKILL.md` for the issue-level delivery or
+  blocked-status summary
+
+## Implementation Flow
+
 1. Read the issue carefully and restate the bounded goal, acceptance criteria,
    and explicit non-goals for the implementation.
-2. Apply `../plan/SKILL.md` when a decision-complete implementation plan is
-   still needed before coding starts.
-3. Implement the issue using the relevant domain-specific skills and repository
+2. Verify that a decision-complete implementation plan exists and that it
+   satisfies the applicable ruleset-read and final conformance-read contract
+   from `../plan/SKILL.md`.
+3. Apply `../plan/SKILL.md` before coding when the plan is missing, incomplete,
+   or lacks ruleset-read/conformance evidence. If the precondition cannot be
+   established, stop with `BLOCKED: <reason>`.
+4. Implement the issue using the relevant domain-specific skills and repository
    context while keeping the change set bounded to the issue goal.
-4. Apply `../gates-exit/SKILL.md` to evaluate the mandatory exit gates before
-   declaring the issue complete.
-5. If any exit gate fails or is blocked, fix only the bounded implementation
+5. Apply `../gates-exit/SKILL.md` to evaluate the mandatory exit gates before
+   declaring the issue complete, including that skill's ruleset, build/test,
+   test-coverage mapping, and child-skill composition contract.
+6. If any exit gate fails or is blocked, fix only the bounded implementation
    findings and rerun the full exit-gate sequence from the beginning.
-6. When the implementation is conformant, use
+7. When the implementation is conformant, use
    `../issue-write-summary-comment/SKILL.md` to prepare the issue-level delivery
    summary, validation status, QA notes, and open follow-ups if any remain.
-7. Use `examples/issue-implementation-status.md` when communicating the final
+8. If a precondition or exit gate cannot be satisfied, use
+   `../issue-write-summary-comment/SKILL.md` to report `BLOCKED: <reason>` with
+   the concrete missing precondition, failed gate, or unavailable dependency.
+9. Use `examples/issue-implementation-status.md` when communicating the final
    implemented or still-blocked state.
 
 # Outputs
 
 - a bounded implementation result for the issue
 - explicit exit-gate evidence showing whether the issue is conformant
+- `BLOCKED: <reason>` when mandatory preconditions or exit gates cannot be
+  satisfied
 - a concise issue summary comment describing delivery, validation, and open
   follow-ups
 
@@ -68,6 +93,8 @@ completed, verified through exit gates, and summarized back on the issue.
 
 - do not broaden the scope beyond the issue's goal just to clean unrelated
   code
+- do not start implementation without a decision-complete plan that satisfies
+  the applicable ruleset-read gate
 - do not skip exit gates and still claim the issue is implemented
 - do not treat a partially fixed or gate-blocked result as complete
 - do not close out the issue without a concise delivery summary or explicit
@@ -75,6 +102,8 @@ completed, verified through exit gates, and summarized back on the issue.
 
 # Exit Checks
 
+- the plan and ruleset-read/conformance-read preconditions are satisfied or the
+  result is explicitly `BLOCKED`
 - the implemented result stays within the issue boundary
 - `../gates-exit/SKILL.md` passed for the final implementation state
 - any remaining blocker is explicit rather than hidden behind vague progress

--- a/skills/issue-implement/examples/issue-implementation-status.md
+++ b/skills/issue-implement/examples/issue-implementation-status.md
@@ -7,3 +7,11 @@
 - follow-up: none
 
 Overall result: issue implemented and ready for final summary/comment handling.
+
+Blocked shape:
+
+- implementation scope: not started
+- exit gates: blocked
+- validation: not run because the required plan/ruleset-read precondition is
+  missing
+- blocker: `BLOCKED: decision-complete plan is missing`

--- a/skills/issue-implement/references/implementation-boundary.md
+++ b/skills/issue-implement/references/implementation-boundary.md
@@ -9,3 +9,7 @@ Keep the implementation bounded to the issue:
   inventing hidden scope
 
 Completion requires conformant behavior, not just code changes.
+
+If mandatory preconditions are missing, such as a decision-complete plan with
+ruleset-read evidence or an issue branch/PR prerequisite, stop with
+`BLOCKED: <reason>` instead of silently continuing.


### PR DESCRIPTION
Closes #89

## Summary
- Make the `issue-implement` skill's composed dependencies explicit.
- Require decision-complete planning with ruleset-read and final conformance evidence before implementation starts.
- Add `BLOCKED: <reason>` as the documented outcome when mandatory preconditions or exit gates cannot be satisfied.
- Tighten the gates-exit dependency wording and blocked-status summary path.

## Finding Classification
- Valid: ruleset-read delegation was implicit and could be bypassed by invoking `issue-implement` directly.
- Valid: `gates-exit` needed a clearer dependency contract after its own contract was tightened.
- Valid: the `BLOCKED` terminal outcome was missing from outputs and workflow.
- Valid: composition with `plan`, `gates-exit`, and `issue-write-summary-comment` needed an explicit declaration.

## Validation
- `git diff --check -- skills/issue-implement/SKILL.md skills/issue-implement/references/implementation-boundary.md skills/issue-implement/examples/issue-implementation-status.md`
- changed markdown line-length check
- `npx --yes markdownlint-cli2 "**/*.md" "!**/node_modules/**" --config .markdownlint.json`
- `./gradlew.bat qualityGate`