### PR TITLE
Address #90: clarify GitHub issue creation scope

### DIFF
--- a/skills/issue-create/SKILL.md
+++ b/skills/issue-create/SKILL.md
@@ -2,25 +2,28 @@
 name: issue-create
 description: >-
   Create GitHub issues from structured intent by composing issue drafting and
-  GitHub-ready formatting. Use when a workflow needs to publish or prepare a
-  concise GitHub issue body and title for implementation, backlog, or
-  follow-up work.
+  mandatory GitHub-ready formatting. Use when a workflow needs to publish or
+  prepare a concise GitHub issue body and title for implementation, backlog, or
+  follow-up work. This skill is GitHub-only.
 ---
 <!-- markdownlint-disable MD025 -->
 
 # Purpose
 
 Create a GitHub issue, or a GitHub-ready issue artifact when permissions are
-missing, without forcing the caller to manually combine drafting, formatting,
-and publish steps.
+missing, without forcing the caller to manually combine drafting, mandatory
+GitHub formatting, and publish steps.
+
+This skill is intentionally scoped to GitHub issues. It does not create GitLab
+issues, Jira tickets, Confluence pages, or other tracker artifacts.
 
 # When to Use
 
 - use when a workflow needs to open a GitHub issue for implementation, backlog,
   or follow-up work
 - use when the issue body still needs drafting through `issue-write-description`
-- use when the issue body needs final GitHub Markdown normalization through
-  `formatting-github-comment`
+- always use `formatting-github-comment` for final GitHub Markdown
+  normalization before publishing or rendering the issue body
 - use when GitHub issue creation is available and the issue should be published
 - use `references/github-issue-creation.md` for CLI creation/update mechanics
 - use `references/issue-create-boundary.md` to keep this skill scoped to issue
@@ -30,7 +33,7 @@ and publish steps.
 
 # Inputs
 
-- the repository and target issue tracker context
+- the GitHub repository and target issue context
 - the issue title or raw title idea
 - the problem, intended outcome, scope, and important notes for the issue body
 - optional labels, assignees, or other issue metadata
@@ -41,11 +44,12 @@ and publish steps.
 # Workflow
 
 1. Confirm the target concern should exist as a GitHub issue rather than only
-   as a local note or PR comment.
+   as a local note, PR comment, GitLab issue, Jira ticket, or Confluence page.
 2. Draft the issue title and body with `issue-write-description` when the issue
    content is still raw or incomplete.
-3. Normalize the final Markdown with `formatting-github-comment` when the
-   rendered body still needs GitHub-ready structure.
+3. Normalize the final Markdown with `formatting-github-comment` before every
+   publication or ready-to-post artifact, even when the draft already appears
+   formatted.
 4. Create or update the GitHub issue with the strongest available mechanism,
    preferring body-file based publication from
    `references/github-issue-creation.md`.
@@ -66,6 +70,10 @@ and publish steps.
 
 - do not publish a raw issue body that still needs drafting or formatting
 - do not emit literal `\n` escape sequences in Markdown meant for GitHub
+- do not create GitLab issues, Jira tickets, Confluence pages, or other
+  non-GitHub tracker artifacts
+- do not create Confluence pages; Confluence content remains outside this
+  skill's write scope
 - do not block the primary task solely because GitHub issue creation is
   unavailable
 - do not broaden this skill into issue implementation or follow-up comment
@@ -74,6 +82,8 @@ and publish steps.
 # Exit Checks
 
 - the issue title and body are clear and GitHub-ready
+- the final body passed through `formatting-github-comment` before publication
+  or ready-to-post output
 - the published or rendered issue artifact matches the intended scope
 - the creation path respected available permissions and tooling constraints
 - the workflow stopped at issue creation or render, not implementation

--- a/skills/issue-create/examples/issue-create-flow.md
+++ b/skills/issue-create/examples/issue-create-flow.md
@@ -1,6 +1,12 @@
 # Example Issue Create Flow
 
 1. Draft the issue body with `issue-write-description`.
-2. Normalize the Markdown with `formatting-github-comment`.
+2. Normalize the Markdown with `formatting-github-comment` before publishing.
 3. Create the issue with `gh issue create --body-file <path>`.
 4. If GitHub access is missing, keep the title and body as the fallback output.
+
+Out-of-scope target:
+
+- request: create a Jira ticket or Confluence page
+- result: stop and report that `issue-create` only prepares or publishes
+  GitHub issues

--- a/skills/issue-create/references/issue-create-boundary.md
+++ b/skills/issue-create/references/issue-create-boundary.md
@@ -3,6 +3,9 @@
 This skill owns publication of an issue artifact, or rendering a ready-to-post
 issue title and body when direct publication is not permitted.
 
+The artifact is GitHub-only. Requests to create GitLab issues, Jira tickets,
+Confluence pages, or other tracker artifacts are out of scope for this skill.
+
 It may compose:
 
 - `issue-write-description` for issue-body drafting
@@ -13,3 +16,5 @@ It does not own:
 - implementing the issue
 - posting delivery/status summary comments after implementation
 - full issue-to-PR orchestration
+- creating non-GitHub tracker artifacts
+- creating or editing Confluence pages


### PR DESCRIPTION
Closes #90

## Summary
- Make `issue-create` explicitly GitHub-only for this catalog release.
- Require `formatting-github-comment` normalization before every publication or ready-to-post issue artifact.
- Add guardrails and boundary examples for GitLab, Jira, Confluence, and other non-GitHub tracker requests.

## Finding Classification
- Valid: the skill needed an explicit GitHub-only scope decision instead of implying coverage for GitLab, Jira, or Confluence.
- Valid: GitHub Markdown normalization should be mandatory before publication to satisfy the newline/formatting requirements.
- Valid: Confluence page creation needed an explicit out-of-scope guardrail.

## Validation
- `git diff --check -- skills/issue-create/SKILL.md skills/issue-create/references/issue-create-boundary.md skills/issue-create/examples/issue-create-flow.md`
- changed markdown line-length check
- `npx --yes markdownlint-cli2 "**/*.md" "!**/node_modules/**" --config .markdownlint.json`
- `./gradlew.bat qualityGate`