### PR TITLE
Address #91: add issue description formatting guardrails

### DIFF
--- a/skills/issue-write-description/SKILL.md
+++ b/skills/issue-write-description/SKILL.md
@@ -55,8 +55,8 @@ design document.
 
 # Outputs
 
-- a GitHub-ready issue description with problem, outcome, scope, and relevant
-  constraints
+- a GitHub Markdown issue description with problem, outcome, scope, and
+  relevant constraints
 - optional acceptance or validation notes when they materially affect later
   work
 - a concise issue body that can be posted directly after formatting
@@ -67,6 +67,9 @@ design document.
 - do not leave the problem statement implicit
 - do not omit key scope boundaries or non-goals when they materially matter
 - do not emit literal `\n` escape sequences in Markdown meant for GitHub
+- do not exceed 120 characters per Markdown source line; wrap long list items
+  and paragraphs
+- do not omit the single trailing newline when producing a Markdown issue body
 - do not broaden this skill into issue creation, assignment, or implementation
   workflow
 
@@ -76,3 +79,5 @@ design document.
 - scope boundaries and key assumptions are explicit
 - the issue body is concise enough for GitHub discussion flow
 - the Markdown is safe to publish through `gh issue create` or `gh issue edit`
+- GitHub Markdown source lines stay at or below 120 characters
+- the issue body ends with exactly one trailing newline when written to a file

--- a/skills/issue-write-description/references/github-issue-publishing.md
+++ b/skills/issue-write-description/references/github-issue-publishing.md
@@ -5,6 +5,8 @@ When posting or updating a GitHub issue body from the CLI:
 - prefer `gh issue create --body-file <path>` for new issues
 - prefer `gh issue edit <id> --body-file <path>` for updates
 - block publish if the body still contains literal `\n` escape sequences
+- keep Markdown source lines at or below 120 characters before publishing
+- ensure the body file ends with exactly one trailing newline
 - verify the rendered issue keeps headings, bullets, and code blocks intact
 
 Use raw Markdown with real newlines instead of escaped JSON-style strings.


### PR DESCRIPTION
Closes #91

## Summary
- Pin `issue-write-description` outputs to GitHub Markdown issue bodies.
- Add line-length and single-trailing-newline guardrails and exit checks.
- Carry the same publishing constraints into the GitHub issue publishing reference.

## Finding Classification
- Valid: the skill needed explicit line-length and trailing-newline rules for generated GitHub Markdown.
- Valid: the outputs should state the GitHub Markdown format assumption rather than staying generic.

## Validation
- `git diff --check -- skills/issue-write-description/SKILL.md skills/issue-write-description/references/github-issue-publishing.md`
- changed markdown line-length check
- `npx --yes markdownlint-cli2 "**/*.md" "!**/node_modules/**" --config .markdownlint.json`
- `./gradlew.bat qualityGate`