### PR TITLE
Address #92: clarify issue summary links and validation

### DIFF
--- a/skills/issue-write-summary-comment/SKILL.md
+++ b/skills/issue-write-summary-comment/SKILL.md
@@ -31,9 +31,11 @@ validated, and what follow-up attention remains for non-implementer readers.
 # Inputs
 
 - what was delivered or changed
+- linked PRs/MRs or an explicit note that no PR/MR is linked
 - acceptance criteria or scope status
-- validation status, executed tests, and manual checks
-- QA notes, test focus, and open risks or follow-ups
+- validation status, executed tests, manual checks, happy-path coverage, and
+  error/negative-path coverage
+- QA notes and open risks
 - `references/issue-summary-template.md` and
   `references/audience-focus.md`
 
@@ -41,35 +43,46 @@ validated, and what follow-up attention remains for non-implementer readers.
 
 1. State what was delivered in plain language instead of repeating commit
    history.
-2. Summarize acceptance or scope status at the level relevant to the issue.
-3. Record validation status, including tests run and important manual checks.
-4. Add QA focus and open risks only when they help downstream readers act.
-5. Use `references/issue-summary-template.md` to keep the comment short and
+2. List the related PRs/MRs explicitly, or state that no PR/MR is linked when
+   the issue outcome did not use one.
+3. Summarize acceptance or scope status at the level relevant to the issue.
+4. Record validation status, including tests run, important manual checks, and
+   happy-path plus error/negative-path coverage.
+5. Add QA notes and open risks only when they help downstream readers act.
+6. Use `references/issue-summary-template.md` to keep the comment short and
    structured.
-6. Use `references/audience-focus.md` when deciding whether a detail belongs in
+7. Use `references/audience-focus.md` when deciding whether a detail belongs in
    the issue summary or in a more technical PR discussion.
-7. Use `examples/issue-summary-comment.md` when a concrete GitHub-ready shape
+8. Use `examples/issue-summary-comment.md` when a concrete GitHub-ready shape
    helps.
-8. Hand the final draft to `formatting-github-comment` when Markdown
+9. Hand the final draft to `formatting-github-comment` when Markdown
    normalization is still needed before posting.
 
 # Outputs
 
 - a short GitHub issue comment describing delivery status, validation, QA
-  focus, and open follow-ups
+  notes, and open risks
+- explicit related PR/MR links or an explicit no-linked-PR/MR note
 - a comment shape suitable for product owners, reviewers, and QA readers
 
 # Guardrails
 
 - do not turn the issue comment into a second PR description
+- do not omit the related PR/MR list when delivery is tied to code review or
+  merge work
 - do not omit validation status when delivery is claimed
-- do not hide open risks or follow-ups behind vague status language
+- do not omit tests run, manual checks, or open risks; write `none` only when
+  that is accurate and not misleading
+- do not hide open risks behind vague status language
 - do not emit literal `\n` escape sequences in Markdown meant for GitHub
 - do not broaden this skill into issue creation or PR review handling
 
 # Exit Checks
 
-- the comment states what was delivered and how it was validated
+- the comment states what was delivered, which PRs/MRs are related, and how it
+  was validated
+- validation evidence distinguishes tests, manual checks, and happy-path plus
+  error/negative-path coverage when relevant
 - QA focus and follow-up items are explicit when they exist
 - the summary stays concise enough for issue discussion flow
 - the result is ready for GitHub posting after formatting

--- a/skills/issue-write-summary-comment/examples/issue-summary-comment.md
+++ b/skills/issue-write-summary-comment/examples/issue-summary-comment.md
@@ -1,11 +1,14 @@
 # Example Issue Summary Comment
 
+- Related PRs/MRs: #42
 - Delivered: added `issue-write-summary-comment` with a canonical summary
   template, audience guidance, and one GitHub-ready example
 - Acceptance criteria status: issue-summary comments can now reuse one concise
   structure for delivery, validation, and follow-ups
-- Validation status: `./gradlew qualityGate` and markdownlint passed locally
-- QA notes / test focus: verify later workflows keep issue comments shorter than
-  the matching PR descriptions
-- Open risks or follow-ups: issue creation and PR-to-issue orchestration remain
-  separate skills
+- Validation status: tests run: `./gradlew qualityGate` and markdownlint;
+  manual checks: reviewed the rendered Markdown shape; happy-path: delivered
+  issue summary; error/negative-path: no blocked-state example yet
+- QA notes: verify later workflows keep issue comments shorter than the matching
+  PR descriptions
+- Open risks: issue creation and PR-to-issue orchestration remain separate
+  skills

--- a/skills/issue-write-summary-comment/references/audience-focus.md
+++ b/skills/issue-write-summary-comment/references/audience-focus.md
@@ -6,10 +6,14 @@ Prefer:
 
 - plain delivery language over commit-by-commit detail
 - validation signals that QA or reviewers can trust quickly
+- validation evidence that distinguishes tests run, manual checks, happy-path
+  coverage, and error/negative-path coverage
+- explicit related PR/MR links when the issue was resolved through review
 - explicit follow-ups when work is intentionally deferred
 
 Avoid:
 
 - deep implementation rationale better suited to the PR description
 - diff-level technical noise
+- vague validation summaries that hide untested happy paths or error paths
 - vague status phrases such as "done" with no validation context

--- a/skills/issue-write-summary-comment/references/issue-summary-template.md
+++ b/skills/issue-write-summary-comment/references/issue-summary-template.md
@@ -3,12 +3,17 @@
 Use this shape when the issue comment needs a predictable delivery summary.
 
 ```md
+- Related PRs/MRs: <links | none>
 - Delivered:
 - Acceptance criteria status:
 - Validation status:
-- QA notes / test focus:
-- Open risks or follow-ups:
+- QA notes:
+- Open risks:
 ```
 
 Omit a line only when it is genuinely not applicable and that omission will not
 mislead the reader.
+
+Use `none` only when there is no meaningful entry for that line. Do not leave
+the related PR/MR line implicit when the issue was implemented through code
+review.


### PR DESCRIPTION
Closes #92

## Summary
- Require explicit related PR/MR links, or an explicit no-linked-PR/MR note, in issue summary comments.
- Align the summary template with the Delivered / Acceptance criteria status / Validation status / QA notes / Open risks shape while retaining the PR/MR linkage line.
- Clarify validation evidence for tests, manual checks, happy-path coverage, and error/negative-path coverage.

## Finding Classification
- Valid: issue summaries needed explicit related PR/MR linkage.
- Valid: the template should align with the PO/reviewer/QA delivery summary shape.
- Valid: validation evidence needed to distinguish happy-path and error/negative-path coverage.
- Valid: delivery summaries should not omit tests run, manual checks, or residual-risk entries.

## Validation
- `git diff --check -- skills/issue-write-summary-comment/SKILL.md skills/issue-write-summary-comment/references/issue-summary-template.md skills/issue-write-summary-comment/references/audience-focus.md skills/issue-write-summary-comment/examples/issue-summary-comment.md`
- changed markdown line-length check
- `npx --yes markdownlint-cli2 "**/*.md" "!**/node_modules/**" --config .markdownlint.json`
- `./gradlew.bat qualityGate`