### PR TITLE
Address #94: clarify PR review gate and severity inheritance

### DIFF
--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: pr-review
-description: Define the family-root responsibility boundaries for handling PR review findings and review conversations safely.
+description: >-
+  Define the family-root responsibility boundaries for handling PR review
+  findings and review conversations safely.
 ---
 <!-- markdownlint-disable MD025 -->
 
@@ -28,6 +30,7 @@ handling review conversations, and deciding whether a thread may be resolved.
 
 - the PR or MR diff and current review state
 - active review comments and threads
+- evidence that the applicable review ruleset-read gate has been satisfied
 - repository or session rules about who may resolve conversations
 - relevant tests, checks, and changed files
 - `references/review-family-guardrails.md`,
@@ -36,34 +39,46 @@ handling review conversations, and deciding whether a thread may be resolved.
 
 # Workflow
 
-1. Read the review state, changed scope, and active conversations.
-2. Determine whether the current actor is responsible for handling or resolving
+1. Verify that the applicable review ruleset-read gate has been satisfied
+   before classifying or resolving findings. If evidence is missing, read the
+   applicable review rules before continuing or stop with an explicit
+   unresolved precondition.
+2. Read the review state, changed scope, and active conversations.
+3. Determine whether the current actor is responsible for handling or resolving
    each thread.
-3. If conversation-resolution rules are missing or unclear, ask the
+4. If conversation-resolution rules are missing or unclear, ask the
    user or maintainer whether the current actor may resolve review
    conversations and keep the thread open until that authority is clarified.
-4. Classify each finding as valid, invalid, or unresolved.
-5. Ensure each resolved thread has a final explanatory reply describing how it
+5. Classify each finding as valid, invalid, or unresolved.
+6. Inherit severity ranking from the active child review skill when findings
+   include severity, and aggregate those severities without redefining them in
+   this root skill.
+7. Ensure each resolved thread has a final explanatory reply describing how it
    was handled or why it was not addressed.
-6. Delegate detailed finding-writing, response, loop, or merge behavior to the
+8. Delegate detailed finding-writing, response, loop, or merge behavior to the
    specialized child skills when those are available.
-7. Use `references/review-family-guardrails.md` and
+9. Use `references/review-family-guardrails.md` and
    `references/review-boundary.md` to keep the root skill scoped correctly.
-8. Use `references/pr-review-loop-source.md` only for closure semantics that
+10. Use `references/pr-review-loop-source.md` only for closure semantics that
    belong in the root skill.
-9. Reuse `examples/thread-resolution.md` and
+11. Reuse `examples/thread-resolution.md` and
    `examples/resolution-comment.md` when they fit the current thread shape.
 
 # Outputs
 
 - a classified review state for the active findings
+- inherited child-skill severity ranking when severity-bearing findings are
+  present
 - concise thread responses or closure decisions
 - an explicit list of unresolved items when ownership or evidence is missing
 
 # Guardrails
 
 - do not resolve review conversations unless responsibility is clear
+- do not classify review findings before the applicable review ruleset-read gate
+  is satisfied
 - do not resolve review conversations when closure authority is unknown
+- do not redefine the severity model when a child review skill already owns it
 - do not close a thread without a final comment explaining the outcome
 - do not broaden this skill into full merge-loop orchestration
 - do not duplicate detailed finding-writing or fix-response behavior that
@@ -72,6 +87,9 @@ handling review conversations, and deciding whether a thread may be resolved.
 # Exit Checks
 
 - every handled thread has a classification
+- the applicable review ruleset-read gate was satisfied before review
+  classification
+- severity-bearing findings preserve the child skill's severity model
 - every resolved thread has a final rationale comment
 - unclear ownership or unresolved responsibility are surfaced explicitly
 - missing closure authority is surfaced explicitly and leaves the thread open

--- a/skills/pr-review/references/review-boundary.md
+++ b/skills/pr-review/references/review-boundary.md
@@ -3,6 +3,8 @@
 The family-root `pr-review` skill establishes the shared review contract:
 
 - classify findings clearly
+- require the applicable review ruleset-read gate before classification
+- aggregate child-skill severity output without redefining the severity model
 - respect ownership rules before resolving conversations
 - leave a final explanatory comment before closing a thread
 - separate the root responsibility contract from specialized subflows such as

--- a/skills/pr-review/references/review-family-guardrails.md
+++ b/skills/pr-review/references/review-family-guardrails.md
@@ -3,6 +3,9 @@
 Distilled from the review, code review, and PR review loop guidance sources.
 
 - classify findings explicitly instead of treating all comments the same
+- satisfy the applicable review ruleset-read gate before classifying findings
+- inherit severity ranking from the active child review skill when severity is
+  present
 - keep evidence and rationale visible in the thread
 - resolve conversations only when ownership and closure conditions are met
 - keep unresolved or ambiguous findings visible


### PR DESCRIPTION
Closes #94

## Summary
- Add the review ruleset-read gate as an explicit input, workflow precondition, guardrail, and exit check.
- Clarify that severity ranking is inherited from active child review skills and aggregated by the root skill without redefining it.
- Carry both rules into the shared PR review references.

## Finding Classification
- Valid: `pr-review` needed an explicit ruleset-read gate reference before classification/resolution work.
- Valid: severity ranking inheritance from child review skills needed to be stated in the root workflow/output contract.

## Validation
- `git diff --check -- skills/pr-review/SKILL.md skills/pr-review/references/review-family-guardrails.md skills/pr-review/references/review-boundary.md`
- changed markdown line-length check
- `npx --yes markdownlint-cli2 "**/*.md" "!**/node_modules/**" --config .markdownlint.json`
- `./gradlew.bat qualityGate`