### PR TITLE
Address #95: tighten PR review response handling

### DIFF
--- a/skills/pr-review-respond/SKILL.md
+++ b/skills/pr-review-respond/SKILL.md
@@ -31,47 +31,75 @@ an explicit response, and an appropriate fix or rationale.
 
 - the review findings and active review threads
 - the changed scope and relevant evidence
+- evidence that the applicable review ruleset-read gate has been satisfied
 - repository or session rules for resolving conversations
 - available tests or focused reproduction steps
+- `../plan/SKILL.md` for ruleset-read gate evidence when a parent workflow has
+  not already supplied it
+- `../compliance-dependency/SKILL.md` for dependency license and transitive
+  impact evidence
 - `references/finding-classification.md` and
   `references/regression-test-expectations.md`
 
 # Workflow
 
-1. Classify each finding as valid, invalid, or unresolved based on the current
-   code, rules, and evidence.
-2. For valid findings, apply a bounded fix when appropriate and prefer adding a
+1. Verify that the applicable review ruleset-read gate has been satisfied
+   before classifying findings or replying to threads, using parent workflow
+   evidence or `../plan/SKILL.md`. If evidence is missing, stop with an explicit
+   unresolved precondition.
+2. Classify each finding as valid, invalid, or unresolved based on the current
+   code, rules, and evidence, using this priority order when triaging:
+   correctness, security, compliance, data integrity, architecture,
+   performance, observability, then maintainability. Interpret this consistently
+   with `../pr-review-write/references/severity-order.md`.
+3. For dependency-related findings, verify the dependency need, security risk,
+   license compatibility, and relevant transitive impact through
+   `../compliance-dependency/SKILL.md` before classifying.
+4. For valid findings, apply a bounded fix when appropriate and prefer adding a
    focused regression test or proof of behavior.
-3. For invalid findings, explain the concrete rationale instead of dismissing
+5. For invalid findings, explain the concrete rationale instead of dismissing
    the concern vaguely.
-4. For unresolved findings, explain what evidence, clarification, or follow-up
+6. For unresolved findings, explain what evidence, clarification, or follow-up
    is still needed and keep the thread open until that gap is closed.
-5. Reply to every thread with the classification and concise outcome.
-6. Resolve handled threads only when repository or session rules allow the
+7. Reply to every thread with the classification, concise outcome, checks run,
+   and anything that remains unverified.
+8. Resolve handled threads only when repository or session rules allow the
    current actor to resolve them.
-7. Use `references/regression-test-expectations.md` to keep fixes and tests
+9. Use `references/regression-test-expectations.md` to keep fixes and tests
    proportional to the finding.
-8. Use the bundled examples when a valid or invalid response shape helps.
+10. Use the bundled examples when a valid or invalid response shape helps.
 
 # Outputs
 
 - a classification for each handled review finding
 - bounded fixes and regression evidence for valid findings when appropriate
 - concise replies on every addressed review thread
+- checks run and explicit verification gaps for each addressed finding or
+  response batch
 - explicit missing-evidence or follow-up requests for unresolved findings
 
 # Guardrails
 
 - do not leave actionable review comments unanswered
+- do not classify or reply before the applicable ruleset-read gate is satisfied
+- do not delete review comments; resolve or leave threads open according to
+  repository rules
 - do not classify a finding as invalid without concrete rationale
+- do not classify dependency-related findings without checking dependency need,
+  security risk, license compatibility, and relevant transitive impact
 - do not silently treat unresolved findings as valid or invalid
 - do not skip regression evidence when a valid finding changes behavior
+- do not omit what was verified and what remains unverified
 - do not broaden this skill into the full review loop or final merge decision
 
 # Exit Checks
 
+- the applicable review ruleset-read gate was satisfied before classification
 - every handled thread has an explicit classification
+- higher-priority findings were triaged in the documented priority order
 - valid findings have a fix, a justified deferral, or clear blocking reason
 - invalid findings have a factual rationale
 - unresolved findings state what is still needed before closure
+- dependency-related findings include dependency and license/security rationale
+- replies state checks run and remaining verification gaps
 - replies are concise and suitable for PR review flow

--- a/skills/pr-review-respond/references/finding-classification.md
+++ b/skills/pr-review-respond/references/finding-classification.md
@@ -8,3 +8,24 @@ Use these states:
 - `unresolved`: available evidence is insufficient to classify confidently
 
 Every handled finding should move into one of these states explicitly.
+
+When multiple findings compete for attention, triage them in this priority
+order:
+
+Canonical severity guidance lives in
+`skills/pr-review-write/references/severity-order.md`. The ordering below is
+the response-triage view of that guidance; if the two ever appear to differ,
+follow `severity-order.md` and interpret this list consistently with it.
+
+1. correctness
+2. security
+3. compliance
+4. data integrity
+5. architecture
+6. performance
+7. observability
+8. maintainability
+
+For dependency-related findings, validate dependency need and security risk, and
+use `skills/compliance-dependency/SKILL.md` as the source of truth for assessing
+license compatibility and relevant transitive impact before choosing a state.


### PR DESCRIPTION
Closes #95

## Summary
- Add the applicable ruleset-read gate before review response classification or replies.
- Add the review priority order: correctness, security, compliance, data integrity, architecture, performance, observability, maintainability.
- Require dependency-need, security, license, and transitive-impact checks for dependency-related findings.
- Forbid deleting review comments and require checks-run plus verification-gap reporting.

## Finding Classification
- Valid: `pr-review-respond` needed an explicit ruleset-read gate.
- Valid: severity/priority ordering should be encoded in classification guidance.
- Valid: review comments should be resolved or left open, not deleted.
- Valid: dependency-related findings need dependency and license/security validation.
- Valid: thread replies need verification transparency, including remaining gaps.

## Validation
- `git diff --check -- skills/pr-review-respond/SKILL.md skills/pr-review-respond/references/finding-classification.md`
- changed markdown line-length check
- `npx --yes markdownlint-cli2 "**/*.md" "!**/node_modules/**" --config .markdownlint.json`
- `./gradlew.bat qualityGate`