### PR TITLE
Address #96: clarify PR review finding coverage

### DIFF
--- a/skills/pr-review-write/SKILL.md
+++ b/skills/pr-review-write/SKILL.md
@@ -27,40 +27,62 @@ an implementer to act on.
 
 - the changed files or diff under review
 - the concrete issue being reported
+- evidence that the applicable review ruleset-read gate has been satisfied
 - supporting evidence, such as failing behavior, missing tests, or policy gaps
 - the impacted file or location
 - `references/finding-shape.md` and `references/severity-order.md`
 
 # Workflow
 
-1. Confirm the finding is concrete enough to point to a specific file, path, or
+1. Verify that the applicable review ruleset-read gate has been satisfied
+   before writing a reviewer-facing finding.
+2. Confirm the finding is concrete enough to point to a specific file, path, or
    reviewable scope.
-2. Classify the severity using the priority direction from
+3. Classify the severity using the priority direction from
    `references/severity-order.md`.
-3. Write the finding with the canonical shape from
+4. Confirm the orchestrating review workflow owns full-review coverage across
+   top-risk categories, semantic parent-rule violations, dependency/tooling
+   additions, test or verification gaps, and concise output.
+5. For dependency or tooling additions, include dependency need, overlap with
+   existing tools, license compatibility, and security or transitive-risk
+   considerations in the finding.
+6. Write the finding with the canonical shape from
    `references/finding-shape.md`: severity, impacted location, concrete issue,
    why it matters, and actionable remediation.
-4. Keep the wording factual and decision-useful instead of vague or rhetorical.
-5. Use `examples/review-finding.md` when a concrete review comment shape helps.
-6. Hand the final wording to `formatting-github-comment` when GitHub Markdown
+7. Keep the wording factual and decision-useful instead of vague or rhetorical.
+8. Use `examples/review-finding.md` when a concrete review comment shape helps.
+9. Hand the final wording to `formatting-github-comment` when GitHub Markdown
    normalization is still needed.
 
 # Outputs
 
 - a reviewer-facing finding anchored to a concrete location or scope
 - explicit severity and risk rationale
+- dependency/tooling rationale when the finding concerns new dependencies or
+  tools
 - actionable remediation guidance for the implementer
 
 # Guardrails
 
 - do not spend review effort on style nits before higher-risk issues
+- do not write findings before the applicable review ruleset-read gate is
+  satisfied
+- do not let this leaf skill replace the orchestrator's full-review coverage
+  checklist
 - do not write vague findings without a concrete problem statement
+- do not report dependency/tooling findings without dependency need, overlap,
+  license, and security or transitive-risk rationale
 - do not omit why the issue matters
+- do not blur critical risk and low-impact nits into the same priority
 - do not broaden this skill into response handling, fixes, or merge decisions
 
 # Exit Checks
 
+- the applicable review ruleset-read gate was satisfied before writing
 - the finding is concrete and severity-ranked
+- full-review coverage remains owned by the orchestrating review workflow
+- dependency/tooling findings include need, overlap, license, and security or
+  transitive-risk rationale
 - the risk and remediation are explicit
 - the wording is concise enough for PR review flow
 - the comment is ready for GitHub or MR review posting

--- a/skills/pr-review-write/references/finding-shape.md
+++ b/skills/pr-review-write/references/finding-shape.md
@@ -9,3 +9,15 @@ Each finding should include:
 - actionable remediation guidance
 
 Prefer one finding per distinct problem so implementers can respond cleanly.
+
+When the finding concerns a dependency or tooling addition, include:
+
+- why the new dependency or tool is needed
+- whether an existing project dependency or tool already covers the need
+- license compatibility
+- security or transitive-risk considerations
+
+Full-review coverage belongs to the orchestrating review workflow. This leaf
+skill writes individual findings, but it should preserve coverage context when
+the orchestrator identified top-risk categories, semantic parent-rule
+violations, dependency/tooling additions, or test and verification gaps.

--- a/skills/pr-review-write/references/severity-order.md
+++ b/skills/pr-review-write/references/severity-order.md
@@ -9,3 +9,10 @@ Prioritize findings in this order:
 5. performance and scalability
 6. observability and operational readiness
 7. maintainability, readability, and test adequacy
+
+Avoid these high-risk review pitfalls:
+
+- style-only feedback while missing correctness, security, or compliance
+  defects
+- vague findings without actionable remediation
+- failing to distinguish critical risk from low-impact nits


### PR DESCRIPTION
Closes #96

## Summary
- Add the applicable review ruleset-read gate before writing findings.
- Clarify that full review coverage belongs to the orchestrating review workflow while this leaf skill preserves coverage context.
- Add dependency/tooling finding requirements for need, overlap, license compatibility, and security/transitive risk.
- Document high-risk review pitfalls in severity guidance.

## Finding Classification
- Valid: `pr-review-write` needed an explicit ruleset-read gate reference.
- Valid: full review coverage checklist ownership should be acknowledged without turning this leaf skill into the orchestrator.
- Valid: dependency/tooling findings need explicit need, license, overlap, and security/transitive-risk guidance.
- Valid: high-risk review pitfalls should be named so finding writers avoid style-only or vague feedback.

## Validation
- `git diff --check -- skills/pr-review-write/SKILL.md skills/pr-review-write/references/finding-shape.md skills/pr-review-write/references/severity-order.md`
- changed markdown line-length check
- `npx --yes markdownlint-cli2 "**/*.md" "!**/node_modules/**" --config .markdownlint.json`
- `./gradlew.bat qualityGate`