### PR TITLE
Address #97: clarify skill capture boundaries

### DIFF
--- a/skills/skill-new/SKILL.md
+++ b/skills/skill-new/SKILL.md
@@ -41,7 +41,9 @@ important context.
 - when the skill would be triggered or used
 - rough workflow or responsibilities for the future skill
 - related skills, dependencies, or adjacent existing skills
-- source context or notes from the originating task
+- source context or notes from the originating task, limited to observations
+  rather than design decisions or implementation plans; include related lessons
+  learned here when known and relevant
 - `references/public-skill-triage.md` and
   `references/backlog-target-selection.md`
 
@@ -75,6 +77,8 @@ important context.
 # Guardrails
 
 - do not implement the proposed skill
+- do not use `source-context-or-notes` for design decisions, implementation
+  plans, or claims that the proposed skill was implemented
 - do not create a central backlog item for a purely local, repo-specific need
 - do not make GitHub the only supported storage target
 - do not silently change the canonical field set between renderings
@@ -83,6 +87,8 @@ important context.
 # Exit Checks
 
 - the candidate is captured with the full canonical backlog-entry field set
+- source context or notes are observational and do not contain implementation
+  claims
 - the chosen storage target matches access and publication constraints
 - the rendered record stays aligned with the canonical template
 - the workflow stops after capture rather than drifting into implementation

--- a/skills/skill-new/targets/github-issue.md
+++ b/skills/skill-new/targets/github-issue.md
@@ -13,6 +13,6 @@
 
 ## Notes
 - Constraints / assumptions: the skill should remain tool-agnostic and usable
-  beyond one repository
+  beyond one repository; no related lessons learned are currently known
 - Validation / acceptance notes: publish as a GitHub issue in `ai-skills` when
   access exists; otherwise keep the same record as local Markdown

--- a/skills/skill-new/targets/local-backlog-entry.md
+++ b/skills/skill-new/targets/local-backlog-entry.md
@@ -12,5 +12,6 @@ Rough workflow or responsibilities: inspect dependency deltas, identify policy
 or license concerns, and produce review findings or a clean pass result
 Related skills or dependencies: security-secrets, quality-sonar
 Source context or notes: captured during a repository review on a locked-down
-company laptop without GitHub issue permissions
+company laptop without GitHub issue permissions; related lessons learned: none
+known
 Status: idea


### PR DESCRIPTION
Closes #97

## Summary
- Clarify that `source-context-or-notes` is observational and must not contain design decisions, implementation plans, or implementation claims.
- Add related lessons learned as an optional captured field when known and relevant.
- Reflect the lessons-learned hint in both GitHub issue and local Markdown target examples.

## Finding Classification
- Valid: `source-context-or-notes` needed an explicit capture-only boundary.
- Valid: relevant lessons learned should be referenced when known, without making them mandatory for every capture.

## Validation
- `git diff --check -- skills/skill-new/SKILL.md skills/skill-new/targets/github-issue.md skills/skill-new/targets/local-backlog-entry.md`
- changed markdown line-length check
- `npx --yes markdownlint-cli2 "**/*.md" "!**/node_modules/**" --config .markdownlint.json`
- `./gradlew.bat qualityGate`