### PR TITLE
Address #98: clarify skill improvement capture scope

### DIFF
--- a/skills/skill-improve/SKILL.md
+++ b/skills/skill-improve/SKILL.md
@@ -20,6 +20,9 @@ during unrelated daily work.
   reusable improvement to an existing skill
 - use when the target skill belongs to the public `ai-skills` catalog and the
   improvement should be proposed centrally for everyone
+- use local-only capture when the improvement belongs to a downstream-project
+  extension, private policy, or repo-specific skill rather than the central
+  catalog
 - use when GitHub access is unavailable and the same canonical improvement
   record must be preserved as local Markdown instead
 - use `references/improvement-triage.md` to decide whether the observed gap is
@@ -36,12 +39,15 @@ during unrelated daily work.
 # Inputs
 
 - the existing skill id or name
+- evidence that the target skill already exists; otherwise use `skill-new` for
+  a new skill candidate
 - the observed gap, defect, or missing guidance
 - why the improvement is reusable beyond the current task
 - when the missing behavior matters or gets triggered
 - the rough improvement proposal or expected change in behavior
 - related skills, dependencies, or adjacent skill families
-- source context or notes from the originating task
+- source context or notes from the originating task, including where the entry
+  should feed the later catalog update lifecycle when known
 - `references/improvement-triage.md` and
   `references/backlog-target-selection.md`
 
@@ -49,21 +55,28 @@ during unrelated daily work.
 
 1. Confirm the observation is a reusable improvement to an existing skill
    rather than only a local workaround or private policy difference.
-2. Use `references/improvement-triage.md` to decide whether the proposal should
-   be captured centrally.
-3. Normalize the improvement with `skill-template`, using `change-type:
-   improve` and recording the target skill, motivation, reusability rationale,
+2. Confirm this is an improvement rather than a new-skill candidate: the target
+   skill exists by id or name and the proposal changes its behavior, guidance,
+   examples, or references.
+3. Use `references/improvement-triage.md` to decide whether the proposal should
+   be captured centrally or kept as a downstream-project/local extension.
+4. Normalize the improvement with `skill-template`, using
+   `change-type: improve` and recording the target skill, motivation,
+   reusability rationale,
    trigger conditions, rough improvement shape, related skills, source
    context, and status.
-4. Choose the storage target with
+5. Choose the storage target with
    `references/backlog-target-selection.md`: GitHub issue when the improvement
    belongs in the public `ai-skills` backlog and access exists, otherwise local
    Markdown.
-5. Render the canonical improvement entry for the chosen target without
+6. In source context or notes, include how the entry should feed the catalog
+   update lifecycle, such as later triage, implementation PR,
+   changelog/release-note entry, or explicit deferral.
+7. Render the canonical improvement entry for the chosen target without
    changing the underlying semantics.
-6. Hand GitHub-bound Markdown to `formatting-github-comment` when the rendered
+8. Hand GitHub-bound Markdown to `formatting-github-comment` when the rendered
    issue body still needs final normalization.
-7. Stop after the improvement proposal is captured and return any current
+9. Stop after the improvement proposal is captured and return any current
    implementation work to the normal agent workflow outside this skill.
 
 # Outputs
@@ -76,6 +89,8 @@ during unrelated daily work.
 
 - do not implement the skill improvement inside this capture workflow
 - do not create a central backlog item for a purely repo-local private skill
+- do not use `change-type: improve` when the target skill does not already
+  exist; use `skill-new` instead
 - do not make GitHub the only supported storage target
 - do not let central backlog capture block the current task
 - do not silently change the canonical field set between renderings
@@ -83,6 +98,9 @@ during unrelated daily work.
 # Exit Checks
 
 - the proposal targets an existing skill and uses `change-type: improve`
+- the record explains whether the improvement belongs centrally in `ai-skills`
+  or only in a downstream/local extension
+- the update-lifecycle handoff is explicit enough for later triage
 - the chosen storage target matches access and publication constraints
 - the rendered record stays aligned with the canonical template
 - the workflow stops after capture and returns implementation to normal flow

--- a/skills/skill-improve/examples/local-skill-improvement-entry.md
+++ b/skills/skill-improve/examples/local-skill-improvement-entry.md
@@ -14,5 +14,6 @@ finding, drafts the response, and leaves merge or loop orchestration to later
 skills
 Related skills or dependencies: pr-review, pr-review-write, pr-review-loop
 Source context or notes: captured while handling review findings on a company
-laptop without permission to create a central GitHub issue
+laptop without permission to create a central GitHub issue; transfer upstream to
+`ai-skills` issue triage when central GitHub access is available
 Status: idea

--- a/skills/skill-improve/examples/public-skill-improvement-issue.md
+++ b/skills/skill-improve/examples/public-skill-improvement-issue.md
@@ -13,6 +13,7 @@
 
 ## Notes
 - Constraints / assumptions: the improvement should preserve the current
-  `pr-review` boundary and stay tool-agnostic
+  `pr-review` boundary, stay tool-agnostic, and feed central catalog triage,
+  follow-up implementation, and release notes
 - Validation / acceptance notes: publish as a GitHub issue in `ai-skills` when
   access exists; otherwise keep the same record as local Markdown

--- a/skills/skill-improve/references/improvement-triage.md
+++ b/skills/skill-improve/references/improvement-triage.md
@@ -10,3 +10,11 @@ following are true:
 
 Prefer local-only capture or no separate backlog item when the observation is
 purely private, one-off, or already covered by existing skill guidance.
+
+Use `change-type: improve` only when the target skill already exists and the
+proposal changes its behavior, guidance, examples, or references. If no target
+skill exists yet, capture the idea through `skill-new` instead.
+
+For central `ai-skills` improvements, note how the captured entry should feed a
+later catalog update lifecycle: issue triage, implementation PR, changelog or
+release-note entry, and release verification.


### PR DESCRIPTION
Closes #98

## Summary
- Clarify central `ai-skills` improvement capture versus downstream-project/local extensions.
- Add improve-vs-new guidance: `improve` requires an existing target skill in active use; otherwise use `skill-new`.
- Record how an improvement backlog entry feeds later catalog update work such as triage, implementation PRs, release notes, and release verification.

## Finding Classification
- Valid: `skill-improve` needed clearer central-vs-downstream filing guidance.
- Valid: the skill needed explicit improve-vs-new examples and boundaries.
- Valid: improvement capture should mention the later update lifecycle handoff.

## Validation
- `git diff --check -- skills/skill-improve/SKILL.md skills/skill-improve/references/improvement-triage.md skills/skill-improve/examples/public-skill-improvement-issue.md skills/skill-improve/examples/local-skill-improvement-entry.md`
- changed markdown line-length check
- `npx --yes markdownlint-cli2 "**/*.md" "!**/node_modules/**" --config .markdownlint.json`
- `./gradlew.bat qualityGate`