### PR TITLE
Address #101: track equals/hashCode optional follow-up

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -655,6 +655,9 @@ The following review-derived items are intentionally not implemented in 0.1.0.
   `SKILL.md` guardrail note that `TreeMap` and `TreeSet` containers can behave
   incorrectly when `compareTo` and `equals` diverge. This item needs future
   review and triage before implementation.
+- Source issue #101, `correctness-equals-hashcode`: consider requiring a
+  regression-test step when equality or hash-code behavior changes. This item
+  needs future review and triage before implementation.
 
 ## Non-Goals for v1
 


### PR DESCRIPTION
Closes #101

## Summary
- add an `Optional Future Improvements` entry for `correctness-equals-hashcode`
- track the regression-test-step follow-up for future review and triage
- leave the skill unchanged because the review issue found no required fixes

## Finding Classification
- No actionable findings were reported.
- Optional follow-up: valid as future work only; tracked in `spec.md` and left for later review and triage before implementation.

## Validation
- `git diff --check -- spec.md`
- markdown line-length check for `spec.md`
- `npx --yes markdownlint-cli2 **/*.md !**/node_modules/** --config .markdownlint.json`
- `./gradlew.bat qualityGate`