### PR TITLE
Address #102: track JPA optional follow-up

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -658,6 +658,10 @@ The following review-derived items are intentionally not implemented in 0.1.0.
 - Source issue #101, `correctness-equals-hashcode`: consider requiring a
   regression-test step when equality or hash-code behavior changes. This item
   needs future review and triage before implementation.
+- Source issue #102, `correctness-jpa`: consider a sibling skill for broader
+  JPA lifecycle or fetch concerns, such as cascade rules, lazy loading,
+  transaction scope, or entity leakage across API boundaries. This item needs
+  future review and triage before implementation.
 
 ## Non-Goals for v1
 


### PR DESCRIPTION
Closes #102

## Summary
- add an `Optional Future Improvements` entry for `correctness-jpa`
- track the broader JPA lifecycle/fetch-coverage gap as future triage work
- leave the existing skill unchanged because the review issue found no required fixes

## Finding Classification
- No actionable findings were reported.
- Optional follow-up: valid as future work only; tracked in `spec.md` and left for later review and triage before implementation.

## Validation
- `git diff --check -- spec.md`
- markdown line-length check for `spec.md`
- `npx --yes markdownlint-cli2 **/*.md !**/node_modules/** --config .markdownlint.json`
- `./gradlew.bat qualityGate`