### PR TITLE
Address #103: track CRAP optional follow-up

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -662,6 +662,10 @@ The following review-derived items are intentionally not implemented in 0.1.0.
   JPA lifecycle or fetch concerns, such as cascade rules, lazy loading,
   transaction scope, or entity leakage across API boundaries. This item needs
   future review and triage before implementation.
+- Source issue #103, `quality-crap`: consider documenting that CRAP is a
+  catalog extension rather than an `ai-rules` mandate, and cross-linking the
+  cognitive-complexity threshold context. This item needs future review and
+  triage before implementation.
 
 ## Non-Goals for v1
 


### PR DESCRIPTION
Closes #103

## Summary
- add an `Optional Future Improvements` entry for `quality-crap`
- track the CRAP-as-extension note and cognitive-complexity cross-link as future triage work
- leave the existing skill unchanged because the review issue found no required fixes

## Finding Classification
- No actionable findings were reported.
- Optional follow-up: valid as future work only; tracked in `spec.md` and left for later review and triage before implementation.

## Validation
- `git diff --check -- spec.md`
- markdown line-length check for `spec.md`
- `npx --yes markdownlint-cli2 **/*.md !**/node_modules/** --config .markdownlint.json`
- `./gradlew.bat qualityGate`