### PR TITLE
Address #109: track validation optional follow-up

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -683,6 +683,10 @@ The following review-derived items are intentionally not implemented in 0.1.0.
 - Source issue #108, `conventions-ternary`: no optional follow-up is currently
   identified. Any future implementation item needs future review and triage
   before implementation.
+- Source issue #109, `design-validation`: consider explicit `SOLID.md`
+  responsibility guidance for extracted validators, and clarify boundary versus
+  domain validation placement. This item needs future review and triage before
+  implementation.
 
 ## Non-Goals for v1
 


### PR DESCRIPTION
Closes #109

## Summary
- add an `Optional Future Improvements` entry for `design-validation`
- track validator responsibility and boundary-versus-domain placement notes for future triage
- leave the existing skill unchanged because the review issue found no required fixes

## Finding Classification
- No actionable findings were reported.
- Optional follow-up: valid as future work only; tracked in `spec.md` and left for later review and triage before implementation.

## Validation
- `git diff --check -- spec.md`
- markdown line-length check for `spec.md`
- `npx --yes markdownlint-cli2 **/*.md !**/node_modules/** --config .markdownlint.json`
- `./gradlew.bat qualityGate`