### PR TITLE
Address #119: add internal catalog validation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,5 +34,8 @@ jobs:
       - name: Test
         run: corepack pnpm test
 
+      - name: Validate catalog
+        run: corepack pnpm validate
+
       - name: Package dry run
         run: corepack pnpm pack:dry-run

--- a/README.md
+++ b/README.md
@@ -43,10 +43,13 @@ Use Corepack-managed pnpm for repository development:
 
 ```bash
 corepack pnpm install
+corepack pnpm validate
 corepack pnpm build
 corepack pnpm test
 corepack pnpm pack:dry-run
 ```
 
 The npm package is configured to publish the compiled CLI, canonical `skills/`
-catalog, `README.md`, `spec.md`, and `LICENSE`.
+catalog, `README.md`, `spec.md`, and `LICENSE`. `pnpm validate` is an internal
+catalog gate for build and release verification; it is not exposed as a public
+`ai-skills` command.

--- a/package.json
+++ b/package.json
@@ -17,9 +17,10 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "tsc -p tsconfig.json && node --test test/*.test.mjs",
+    "validate": "node tools/validate-catalog.mjs",
     "lint:md": "markdownlint-cli2 \"**/*.md\" \"!**/node_modules/**\" --config .markdownlint.json",
     "pack:dry-run": "npm pack --dry-run",
-    "prepack": "tsc -p tsconfig.json"
+    "prepack": "node tools/validate-catalog.mjs && tsc -p tsconfig.json"
   },
   "engines": {
     "node": ">=20.11"

--- a/test/catalog-validation.test.mjs
+++ b/test/catalog-validation.test.mjs
@@ -31,8 +31,10 @@ test("accepts a valid catalog skill", async (t) => {
 test("reports representative invalid skill metadata and structure", async (t) => {
   const skillsDir = await createTempSkillsDir(t);
   const skillDir = path.join(skillsDir, "bad-skill");
+  const uppercaseSkillDir = path.join(skillsDir, "ai-skills-Bad");
 
   await fs.mkdir(skillDir, { recursive: true });
+  await fs.mkdir(uppercaseSkillDir, { recursive: true });
   await fs.writeFile(
     path.join(skillDir, "SKILL.md"),
     [
@@ -46,11 +48,18 @@ test("reports representative invalid skill metadata and structure", async (t) =>
       "# Workflow"
     ].join("\n")
   );
+  await fs.writeFile(
+    path.join(uppercaseSkillDir, "SKILL.md"),
+    validSkillMarkdown("ai-skills-Bad")
+  );
 
   const result = await validateCatalog({ skillsDir });
   const messages = result.errors.map((error) => error.message);
 
-  assert.ok(messages.includes("canonical skill id must start with ai-skills-"));
+  assert.equal(
+    messages.filter((message) => message.includes("lowercase kebab-case")).length,
+    2
+  );
   assert.ok(messages.includes("frontmatter description is required"));
   assert.ok(messages.includes("frontmatter name must match directory name bad-skill"));
   assert.ok(messages.includes("missing required section: When to Use"));

--- a/test/catalog-validation.test.mjs
+++ b/test/catalog-validation.test.mjs
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { validateCatalog } from "../tools/validate-catalog.mjs";
+
+const repoRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const validatorScript = path.join(repoRoot, "tools", "validate-catalog.mjs");
+
+test("accepts a valid catalog skill", async (t) => {
+  const skillsDir = await createTempSkillsDir(t);
+  const skillDir = path.join(skillsDir, "ai-skills-example");
+
+  await fs.mkdir(path.join(skillDir, "references"), { recursive: true });
+  await fs.writeFile(path.join(skillDir, "references", "example.md"), "# Example\n");
+  await fs.writeFile(
+    path.join(skillDir, "SKILL.md"),
+    validSkillMarkdown("ai-skills-example", "- use `references/example.md` when needed\n")
+  );
+
+  const result = await validateCatalog({ skillsDir });
+
+  assert.equal(result.skillCount, 1);
+  assert.deepEqual(result.errors, []);
+});
+
+test("reports representative invalid skill metadata and structure", async (t) => {
+  const skillsDir = await createTempSkillsDir(t);
+  const skillDir = path.join(skillsDir, "bad-skill");
+
+  await fs.mkdir(skillDir, { recursive: true });
+  await fs.writeFile(
+    path.join(skillDir, "SKILL.md"),
+    [
+      "---",
+      "name: wrong-name",
+      "---",
+      "# Purpose",
+      "",
+      "A broken skill.",
+      "",
+      "# Workflow"
+    ].join("\n")
+  );
+
+  const result = await validateCatalog({ skillsDir });
+  const messages = result.errors.map((error) => error.message);
+
+  assert.ok(messages.includes("canonical skill id must start with ai-skills-"));
+  assert.ok(messages.includes("frontmatter description is required"));
+  assert.ok(messages.includes("frontmatter name must match directory name bad-skill"));
+  assert.ok(messages.includes("missing required section: When to Use"));
+});
+
+test("reports missing SKILL.md and broken local references", async (t) => {
+  const skillsDir = await createTempSkillsDir(t);
+  const missingSkillDir = path.join(skillsDir, "ai-skills-missing-file");
+  const brokenRefDir = path.join(skillsDir, "ai-skills-broken-reference");
+
+  await fs.mkdir(missingSkillDir, { recursive: true });
+  await fs.mkdir(brokenRefDir, { recursive: true });
+  await fs.writeFile(
+    path.join(brokenRefDir, "SKILL.md"),
+    validSkillMarkdown("ai-skills-broken-reference", "- use `references/missing.md`\n")
+  );
+
+  const result = await validateCatalog({ skillsDir });
+  const messages = result.errors.map((error) => error.message);
+
+  assert.ok(messages.some((message) => message.startsWith("required file is missing")));
+  assert.ok(messages.includes("local catalog reference does not exist: references/missing.md"));
+});
+
+test("exits non-zero for invalid catalog state", async (t) => {
+  const skillsDir = await createTempSkillsDir(t);
+
+  await fs.mkdir(path.join(skillsDir, "ai-skills-invalid"), { recursive: true });
+
+  const result = spawnSync(
+    process.execPath,
+    [validatorScript, "--skills-dir", skillsDir],
+    {
+      cwd: repoRoot,
+      encoding: "utf8"
+    }
+  );
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /required file is missing/);
+});
+
+async function createTempSkillsDir(t) {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "ai-skills-validation-"));
+  const skillsDir = path.join(tempDir, "skills");
+
+  t.after(async () => {
+    await fs.rm(tempDir, { force: true, recursive: true });
+  });
+
+  await fs.mkdir(skillsDir);
+  await fs.writeFile(path.join(skillsDir, ".gitkeep"), "");
+
+  return skillsDir;
+}
+
+function validSkillMarkdown(skillId, whenToUseExtra = "") {
+  return [
+    "---",
+    `name: ${skillId}`,
+    "description: >-",
+    "  Test skill.",
+    "---",
+    "",
+    "# Purpose",
+    "",
+    "Describe the purpose.",
+    "",
+    "# When to Use",
+    "",
+    "- use for tests",
+    whenToUseExtra.trimEnd(),
+    "",
+    "# Inputs",
+    "",
+    "- test input",
+    "",
+    "# Workflow",
+    "",
+    "1. Do the work.",
+    "",
+    "# Outputs",
+    "",
+    "- test output",
+    "",
+    "# Guardrails",
+    "",
+    "- stay scoped",
+    "",
+    "# Exit Checks",
+    "",
+    "- validation passes",
+    ""
+  ].join("\n");
+}

--- a/tools/validate-catalog.mjs
+++ b/tools/validate-catalog.mjs
@@ -1,0 +1,425 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+export const REQUIRED_SECTIONS = [
+  "Purpose",
+  "When to Use",
+  "Inputs",
+  "Workflow",
+  "Outputs",
+  "Guardrails",
+  "Exit Checks"
+];
+
+const REFERENCE_SEGMENTS = new Set([
+  "examples",
+  "references",
+  "scripts",
+  "targets",
+  "templates"
+]);
+
+const IGNORED_SKILLS_ENTRIES = new Set([
+  ".gitkeep"
+]);
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+export async function validateCatalog(options = {}) {
+  const skillsDir = path.resolve(options.skillsDir ?? path.join(repoRoot, "skills"));
+  const errors = [];
+  const entries = await readDirectory(skillsDir, errors);
+
+  if (entries.length === 0) {
+    return {
+      errors,
+      skillCount: 0
+    };
+  }
+
+  let skillCount = 0;
+
+  for (const entry of entries) {
+    const location = path.join("skills", entry.name);
+
+    if (IGNORED_SKILLS_ENTRIES.has(entry.name)) {
+      continue;
+    }
+
+    if (!entry.isDirectory()) {
+      errors.push({
+        location,
+        message: "unexpected non-directory entry in skills root"
+      });
+      continue;
+    }
+
+    skillCount += 1;
+    await validateSkillDirectory(skillsDir, entry.name, errors);
+  }
+
+  return {
+    errors,
+    skillCount
+  };
+}
+
+export function formatValidationResult(result) {
+  if (result.errors.length === 0) {
+    return `Catalog validation passed for ${result.skillCount} skill(s).`;
+  }
+
+  return result.errors
+    .map((error) => `${error.location}: ${error.message}`)
+    .join("\n");
+}
+
+async function readDirectory(directory, errors) {
+  try {
+    const entries = await fs.readdir(directory, { withFileTypes: true });
+    return entries.sort((left, right) => left.name.localeCompare(right.name));
+  } catch (error) {
+    errors.push({
+      location: directory,
+      message: `cannot read directory: ${error.message}`
+    });
+    return [];
+  }
+}
+
+async function validateSkillDirectory(skillsDir, skillId, errors) {
+  const skillDir = path.join(skillsDir, skillId);
+  const skillMarkdown = path.join(skillDir, "SKILL.md");
+  const skillLocation = path.join("skills", skillId);
+
+  if (!skillId.startsWith("ai-skills-")) {
+    errors.push({
+      location: skillLocation,
+      message: "canonical skill id must start with ai-skills-"
+    });
+  }
+
+  const markdown = await readRequiredFile(skillMarkdown, errors);
+
+  if (markdown !== undefined) {
+    validateSkillMarkdown(skillId, skillMarkdown, markdown, errors);
+  }
+
+  await validateLocalReferences(skillsDir, skillDir, errors);
+}
+
+async function readRequiredFile(filePath, errors) {
+  try {
+    return await fs.readFile(filePath, "utf8");
+  } catch (error) {
+    errors.push({
+      location: relativeToRepo(filePath),
+      message: `required file is missing or unreadable: ${error.message}`
+    });
+    return undefined;
+  }
+}
+
+function validateSkillMarkdown(skillId, skillMarkdown, markdown, errors) {
+  const parsed = parseFrontmatter(markdown);
+  const skillLocation = relativeToRepo(skillMarkdown);
+
+  if (!parsed.ok) {
+    errors.push({
+      location: skillLocation,
+      message: parsed.message
+    });
+    return;
+  }
+
+  requireFrontmatterField(parsed.fields, "name", skillLocation, errors);
+  requireFrontmatterField(parsed.fields, "description", skillLocation, errors);
+
+  if (parsed.fields.name !== undefined && parsed.fields.name !== skillId) {
+    errors.push({
+      location: skillLocation,
+      message: `frontmatter name must match directory name ${skillId}`
+    });
+  }
+
+  validateSectionOrder(parsed.body, skillLocation, errors);
+}
+
+function parseFrontmatter(markdown) {
+  const lines = markdown.replaceAll("\r\n", "\n").split("\n");
+
+  if (lines[0]?.trim() !== "---") {
+    return {
+      ok: false,
+      message: "SKILL.md must start with YAML frontmatter"
+    };
+  }
+
+  const closingIndex = lines.findIndex((line, index) => index > 0 && line.trim() === "---");
+
+  if (closingIndex === -1) {
+    return {
+      ok: false,
+      message: "YAML frontmatter must be closed with ---"
+    };
+  }
+
+  return {
+    ok: true,
+    fields: parseYamlFields(lines.slice(1, closingIndex)),
+    body: lines.slice(closingIndex + 1)
+  };
+}
+
+function parseYamlFields(lines) {
+  const fields = {};
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+
+    if (line.trim().length === 0 || line.trimStart().startsWith("#") || /^\s/.test(line)) {
+      continue;
+    }
+
+    const match = /^([A-Za-z][A-Za-z0-9_-]*):(?:\s*(.*))?$/.exec(line);
+
+    if (match === null) {
+      continue;
+    }
+
+    const [, key, rawValue = ""] = match;
+    fields[key] = parseYamlValue(rawValue, lines, index);
+  }
+
+  return fields;
+}
+
+function parseYamlValue(rawValue, lines, currentIndex) {
+  const trimmedValue = rawValue.trim();
+
+  if (/^[>|][+-]?$/.test(trimmedValue)) {
+    const blockLines = [];
+
+    for (let index = currentIndex + 1; index < lines.length; index += 1) {
+      const line = lines[index];
+
+      if (line.length > 0 && !/^\s/.test(line)) {
+        break;
+      }
+
+      if (line.trim().length > 0) {
+        blockLines.push(line.trim());
+      }
+    }
+
+    return blockLines.join("\n");
+  }
+
+  return trimmedValue.replace(/^["']|["']$/gu, "");
+}
+
+function requireFrontmatterField(fields, fieldName, location, errors) {
+  const fieldValue = fields[fieldName];
+
+  if (typeof fieldValue !== "string" || fieldValue.trim().length === 0) {
+    errors.push({
+      location,
+      message: `frontmatter ${fieldName} is required`
+    });
+  }
+}
+
+function validateSectionOrder(bodyLines, location, errors) {
+  const headings = bodyLines
+    .map((line, index) => {
+      const match = /^# (.+)$/u.exec(line);
+
+      return match === null
+        ? undefined
+        : {
+            line: index + 1,
+            title: match[1].trim()
+          };
+    })
+    .filter((heading) => heading !== undefined);
+
+  let previousIndex = -1;
+
+  for (const section of REQUIRED_SECTIONS) {
+    const sectionIndex = headings.findIndex((heading) => heading.title === section);
+
+    if (sectionIndex === -1) {
+      errors.push({
+        location,
+        message: `missing required section: ${section}`
+      });
+      continue;
+    }
+
+    if (sectionIndex < previousIndex) {
+      errors.push({
+        location,
+        message: `section is out of order: ${section}`
+      });
+    }
+
+    previousIndex = sectionIndex;
+  }
+}
+
+async function validateLocalReferences(skillsDir, skillDir, errors) {
+  const markdownFiles = await findMarkdownFiles(skillDir);
+
+  for (const markdownFile of markdownFiles) {
+    const markdown = await fs.readFile(markdownFile, "utf8");
+
+    for (const reference of findLocalReferences(markdown)) {
+      await validateLocalReference(skillsDir, markdownFile, reference, errors);
+    }
+  }
+}
+
+async function findMarkdownFiles(directory) {
+  const entries = await fs.readdir(directory, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const entryPath = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...await findMarkdownFiles(entryPath));
+    } else if (entry.isFile() && entry.name.endsWith(".md")) {
+      files.push(entryPath);
+    }
+  }
+
+  return files.sort();
+}
+
+function findLocalReferences(markdown) {
+  const references = new Set();
+  const patterns = [
+    /!?\[[^\]]*\]\(([^)]+)\)/gu,
+    /`([^`\n]+)`/gu
+  ];
+
+  for (const pattern of patterns) {
+    for (const match of markdown.matchAll(pattern)) {
+      const candidate = normalizeReference(match[1]);
+
+      if (candidate !== undefined && targetsCatalogAsset(candidate)) {
+        references.add(candidate);
+      }
+    }
+  }
+
+  return [...references].sort();
+}
+
+function normalizeReference(candidate) {
+  const withoutTitle = candidate.trim().split(/\s+/u)[0];
+  const withoutAnchor = withoutTitle.split("#")[0];
+  const normalized = withoutAnchor.replace(/^<|>$/gu, "").replace(/[),.;:]+$/u, "");
+
+  if (
+    normalized.length === 0
+    || normalized.startsWith("#")
+    || /^[a-z][a-z0-9+.-]*:/iu.test(normalized)
+  ) {
+    return undefined;
+  }
+
+  return normalized;
+}
+
+function targetsCatalogAsset(reference) {
+  return reference
+    .split(/[\\/]+/u)
+    .some((segment) => REFERENCE_SEGMENTS.has(segment));
+}
+
+async function validateLocalReference(skillsDir, sourceFile, reference, errors) {
+  const resolvedReference = reference.startsWith("skills/")
+    ? path.resolve(path.dirname(skillsDir), reference)
+    : path.resolve(path.dirname(sourceFile), reference);
+
+  if (!isPathInside(skillsDir, resolvedReference)) {
+    errors.push({
+      location: relativeToRepo(sourceFile),
+      message: `local catalog reference leaves skills directory: ${reference}`
+    });
+    return;
+  }
+
+  try {
+    const stat = await fs.stat(resolvedReference);
+
+    if (!stat.isFile()) {
+      errors.push({
+        location: relativeToRepo(sourceFile),
+        message: `local catalog reference is not a file: ${reference}`
+      });
+    }
+  } catch {
+    errors.push({
+      location: relativeToRepo(sourceFile),
+      message: `local catalog reference does not exist: ${reference}`
+    });
+  }
+}
+
+function isPathInside(parent, child) {
+  const relativePath = path.relative(parent, child);
+
+  return relativePath.length === 0
+    || (!relativePath.startsWith("..") && !path.isAbsolute(relativePath));
+}
+
+function relativeToRepo(filePath) {
+  return path.relative(repoRoot, filePath).replaceAll(path.sep, "/");
+}
+
+const isEntrypoint = process.argv[1] !== undefined
+  && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+
+if (isEntrypoint) {
+  try {
+    await runCli(process.argv.slice(2));
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}
+
+async function runCli(argv) {
+  const options = parseCliOptions(argv);
+  const result = await validateCatalog(options);
+  const output = formatValidationResult(result);
+
+  if (result.errors.length === 0) {
+    console.log(output);
+  } else {
+    console.error(output);
+  }
+
+  if (result.errors.length > 0) {
+    process.exitCode = 1;
+  }
+}
+
+function parseCliOptions(argv) {
+  if (argv.length === 0) {
+    return {};
+  }
+
+  if (argv.length === 2 && argv[0] === "--skills-dir") {
+    return {
+      skillsDir: argv[1]
+    };
+  }
+
+  throw new Error("Usage: node tools/validate-catalog.mjs [--skills-dir <path>]");
+}

--- a/tools/validate-catalog.mjs
+++ b/tools/validate-catalog.mjs
@@ -26,6 +26,8 @@ const IGNORED_SKILLS_ENTRIES = new Set([
   ".gitkeep"
 ]);
 
+const CANONICAL_SKILL_ID_PATTERN = /^ai-skills-[a-z0-9]+(?:-[a-z0-9]+)*$/u;
+
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
 export async function validateCatalog(options = {}) {
@@ -95,10 +97,10 @@ async function validateSkillDirectory(skillsDir, skillId, errors) {
   const skillMarkdown = path.join(skillDir, "SKILL.md");
   const skillLocation = path.join("skills", skillId);
 
-  if (!skillId.startsWith("ai-skills-")) {
+  if (!CANONICAL_SKILL_ID_PATTERN.test(skillId)) {
     errors.push({
       location: skillLocation,
-      message: "canonical skill id must start with ai-skills-"
+      message: "canonical skill id must be lowercase kebab-case and start with ai-skills-"
     });
   }
 
@@ -271,10 +273,20 @@ function validateSectionOrder(bodyLines, location, errors) {
 }
 
 async function validateLocalReferences(skillsDir, skillDir, errors) {
-  const markdownFiles = await findMarkdownFiles(skillDir);
+  const markdownFiles = await findMarkdownFiles(skillDir, errors);
 
   for (const markdownFile of markdownFiles) {
-    const markdown = await fs.readFile(markdownFile, "utf8");
+    let markdown;
+
+    try {
+      markdown = await fs.readFile(markdownFile, "utf8");
+    } catch (error) {
+      errors.push({
+        location: relativeToRepo(markdownFile),
+        message: `cannot read markdown file: ${error.message}`
+      });
+      continue;
+    }
 
     for (const reference of findLocalReferences(markdown)) {
       await validateLocalReference(skillsDir, markdownFile, reference, errors);
@@ -282,15 +294,25 @@ async function validateLocalReferences(skillsDir, skillDir, errors) {
   }
 }
 
-async function findMarkdownFiles(directory) {
-  const entries = await fs.readdir(directory, { withFileTypes: true });
+async function findMarkdownFiles(directory, errors) {
+  let entries;
   const files = [];
+
+  try {
+    entries = await fs.readdir(directory, { withFileTypes: true });
+  } catch (error) {
+    errors.push({
+      location: relativeToRepo(directory),
+      message: `cannot read directory: ${error.message}`
+    });
+    return files;
+  }
 
   for (const entry of entries) {
     const entryPath = path.join(directory, entry.name);
 
     if (entry.isDirectory()) {
-      files.push(...await findMarkdownFiles(entryPath));
+      files.push(...await findMarkdownFiles(entryPath, errors));
     } else if (entry.isFile() && entry.name.endsWith(".md")) {
       files.push(entryPath);
     }


### PR DESCRIPTION
Closes #119

## Summary

- Adds a repo-only catalog validator at `tools/validate-catalog.mjs`.
- Validates canonical skill directory names, required `SKILL.md` files, YAML frontmatter, name/description fields, section order, and detectable local catalog references.
- Adds `pnpm validate` and runs validation from `prepack` so package dry-run/publish preparation fails on malformed catalog state.
- Adds tests for a valid catalog, invalid metadata/structure, missing `SKILL.md`, broken local references, and non-zero validator exit behavior.
- Updates CI and README to include internal validation without exposing a public `ai-skills validate` command.

## Validation

- `corepack pnpm validate`
- `corepack pnpm test`
- `corepack pnpm lint:md`
- `corepack pnpm pack:dry-run`
- `git diff --check`
- JS test/tool line-length check

## Notes

- The validator remains internal repo tooling and is not wired into the public `ai-skills` binary.