### PR TITLE
Address #117: implement reset-style install and update CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,17 @@ npm install -g @barney-media/ai-skills
 ai-skills --help
 ```
 
-The `install` and `update` command behavior is defined in `spec.md`. The CLI
-binary is scaffolded in this release-surface migration; the reset-style
-installer implementation follows that permanent contract in later issues.
+The `install` and `update` commands both replace package-owned `ai-skills-*`
+directories in the supported target directories. Non-prefixed user skills are
+preserved.
+
+```bash
+ai-skills install
+ai-skills update --assume-yes
+```
+
+Without `--assume-yes`, the CLI asks for confirmation before deleting and
+replacing package-owned `ai-skills-*` directories.
 
 ## Build
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -154,7 +154,7 @@ function writeReplacementWarning(command: string, targetDirs: string[], io: CliI
   io.stderr.write(
     [
       `Warning: ai-skills ${command} will delete and replace every ${PACKAGE_OWNED_PREFIX}*`,
-      "directory in the supported target directories.",
+      "directory under the supported target directories.",
       "Non-prefixed user skills will be preserved.",
       "",
       "Targets:",
@@ -187,19 +187,37 @@ async function resetInstallCatalog(packageRoot: string, targetDirs: string[]): P
   const skillIds = await listPackagedSkillIds(packagedSkillsDir);
 
   for (const targetDir of targetDirs) {
-    await fs.mkdir(targetDir, { recursive: true });
-    await removePackageOwnedSkills(targetDir);
+    await withTargetContext(targetDir, "create target directory", async () => {
+      await fs.mkdir(targetDir, { recursive: true });
+    });
+    await withTargetContext(targetDir, "remove existing package-owned skills", async () => {
+      await removePackageOwnedSkills(targetDir);
+    });
 
     for (const skillId of skillIds) {
-      await fs.cp(
-        path.join(packagedSkillsDir, skillId),
-        path.join(targetDir, skillId),
-        { recursive: true }
-      );
+      await withTargetContext(targetDir, `copy ${skillId}`, async () => {
+        await fs.cp(
+          path.join(packagedSkillsDir, skillId),
+          path.join(targetDir, skillId),
+          { recursive: true }
+        );
+      });
     }
   }
 
   return skillIds.length;
+}
+
+async function withTargetContext(
+  targetDir: string,
+  operation: string,
+  action: () => Promise<void>
+): Promise<void> {
+  try {
+    await action();
+  } catch (error) {
+    throw new Error(`${operation} failed for ${targetDir}: ${errorMessage(error)}`);
+  }
 }
 
 async function listPackagedSkillIds(packagedSkillsDir: string): Promise<string[]> {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,8 +1,11 @@
 #!/usr/bin/env node
 
 import { createRequire } from "node:module";
-import { resolve } from "node:path";
-import { pathToFileURL } from "node:url";
+import os from "node:os";
+import path, { resolve } from "node:path";
+import { createInterface } from "node:readline/promises";
+import fs from "node:fs/promises";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const requirePackageJson = createRequire(import.meta.url);
 
@@ -20,25 +23,62 @@ export const VERSION = readPackageVersion();
 
 export interface CliIo {
   stderr: NodeJS.WritableStream;
+  stdin?: NodeJS.ReadableStream;
   stdout: NodeJS.WritableStream;
 }
+
+export interface RunOptions {
+  homeDir?: string;
+  packageRoot?: string;
+}
+
+export interface InstallTarget {
+  label: string;
+  relativePath: string[];
+}
+
+export const SUPPORTED_TARGETS: InstallTarget[] = [
+  {
+    label: "Codex",
+    relativePath: [".codex", "skills"]
+  },
+  {
+    label: "Claude Code",
+    relativePath: [".claude", "skills"]
+  },
+  {
+    label: "GitHub Copilot",
+    relativePath: [".copilot", "skills"]
+  }
+];
+
+const PACKAGE_OWNED_PREFIX = "ai-skills-";
+const defaultPackageRoot = resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
 const HELP = `ai-skills ${VERSION}
 
 Usage:
-  ai-skills <command>
+  ai-skills <command> [--assume-yes]
 
 Commands:
-  install    Install the packaged ai-skills catalog (implemented in a later issue)
-  update     Update the packaged ai-skills catalog (implemented in a later issue)
+  install    Replace ai-skills-* in all supported targets with the packaged catalog
+  update     Replace ai-skills-* in all supported targets with the packaged catalog
 
 Options:
-  -h, --help     Show this help message
-  -v, --version  Show the package version
+  --assume-yes  Confirm replacement of all package-owned ai-skills-* directories
+  -h, --help    Show this help message
+  -v, --version Show the package version
+
+Install/update preserve non-prefixed user skills and replace only package-owned
+ai-skills-* directories.
 `;
 
-export function run(argv = process.argv.slice(2), io: CliIo = process): number {
-  const [command] = argv;
+export async function run(
+  argv = process.argv.slice(2),
+  io: CliIo = process,
+  options: RunOptions = {}
+): Promise<number> {
+  const [command, ...args] = argv;
 
   if (command === undefined || command === "-h" || command === "--help") {
     io.stdout.write(HELP);
@@ -51,17 +91,139 @@ export function run(argv = process.argv.slice(2), io: CliIo = process): number {
   }
 
   if (command === "install" || command === "update") {
-    io.stderr.write(`ai-skills ${command} is not implemented in this package scaffold yet.\n`);
-    return 1;
+    return installOrUpdate(command, args, io, options);
   }
 
   io.stderr.write(`Unknown command: ${command}\n\n${HELP}`);
   return 1;
 }
 
+async function installOrUpdate(
+  command: string,
+  args: string[],
+  io: CliIo,
+  options: RunOptions
+): Promise<number> {
+  const assumeYes = args.includes("--assume-yes");
+  const unknownArgs = args.filter((arg) => arg !== "--assume-yes");
+
+  if (unknownArgs.length > 0) {
+    io.stderr.write(`Unknown option for ${command}: ${unknownArgs.join(" ")}\n\n${HELP}`);
+    return 1;
+  }
+
+  const homeDir = options.homeDir ?? os.homedir();
+  const packageRoot = options.packageRoot ?? defaultPackageRoot;
+  const targetDirs = resolveTargetDirs(homeDir);
+
+  writeReplacementWarning(command, targetDirs, io);
+
+  if (!assumeYes && !await confirmReplacement(io)) {
+    io.stderr.write("No changes made.\n");
+    return 1;
+  }
+
+  let installedSkillCount;
+
+  try {
+    installedSkillCount = await resetInstallCatalog(packageRoot, targetDirs);
+  } catch (error) {
+    io.stderr.write(`ai-skills ${command} failed: ${errorMessage(error)}\n`);
+    return 1;
+  }
+
+  io.stdout.write(
+    `ai-skills ${command} complete: installed ${installedSkillCount} skill(s) into `
+      + `${targetDirs.length} target(s).\n`
+  );
+
+  return 0;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error
+    ? error.message
+    : String(error);
+}
+
+function resolveTargetDirs(homeDir: string): string[] {
+  return SUPPORTED_TARGETS.map((target) => path.join(homeDir, ...target.relativePath));
+}
+
+function writeReplacementWarning(command: string, targetDirs: string[], io: CliIo): void {
+  io.stderr.write(
+    [
+      `Warning: ai-skills ${command} will delete and replace every ${PACKAGE_OWNED_PREFIX}*`,
+      "directory in the supported target directories.",
+      "Non-prefixed user skills will be preserved.",
+      "",
+      "Targets:",
+      ...targetDirs.map((targetDir) => `- ${targetDir}`),
+      ""
+    ].join("\n")
+  );
+}
+
+async function confirmReplacement(io: CliIo): Promise<boolean> {
+  if (io.stdin === undefined) {
+    return false;
+  }
+
+  const readline = createInterface({
+    input: io.stdin,
+    output: io.stderr
+  });
+
+  try {
+    const answer = await readline.question("Type \"yes\" to continue: ");
+    return answer.trim().toLowerCase() === "yes";
+  } finally {
+    readline.close();
+  }
+}
+
+async function resetInstallCatalog(packageRoot: string, targetDirs: string[]): Promise<number> {
+  const packagedSkillsDir = path.join(packageRoot, "skills");
+  const skillIds = await listPackagedSkillIds(packagedSkillsDir);
+
+  for (const targetDir of targetDirs) {
+    await fs.mkdir(targetDir, { recursive: true });
+    await removePackageOwnedSkills(targetDir);
+
+    for (const skillId of skillIds) {
+      await fs.cp(
+        path.join(packagedSkillsDir, skillId),
+        path.join(targetDir, skillId),
+        { recursive: true }
+      );
+    }
+  }
+
+  return skillIds.length;
+}
+
+async function listPackagedSkillIds(packagedSkillsDir: string): Promise<string[]> {
+  const entries = await fs.readdir(packagedSkillsDir, { withFileTypes: true });
+
+  return entries
+    .filter((entry) => entry.isDirectory() && entry.name.startsWith(PACKAGE_OWNED_PREFIX))
+    .map((entry) => entry.name)
+    .sort();
+}
+
+async function removePackageOwnedSkills(targetDir: string): Promise<void> {
+  const entries = await fs.readdir(targetDir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (entry.isDirectory() && entry.name.startsWith(PACKAGE_OWNED_PREFIX)) {
+      await fs.rm(path.join(targetDir, entry.name), { force: true, recursive: true });
+    }
+  }
+}
+
 const isEntrypoint = process.argv[1] !== undefined
   && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
 
 if (isEntrypoint) {
-  process.exitCode = run();
+  process.exitCode = await run();
 }

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -1,15 +1,18 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { dirname } from "node:path";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path, { dirname } from "node:path";
+import { Readable } from "node:stream";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
-import { run, VERSION } from "../dist/cli.js";
+import { run, SUPPORTED_TARGETS, VERSION } from "../dist/cli.js";
 
 const testDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = dirname(testDir);
 
-function createIo() {
+function createIo(stdinText) {
   let stderr = "";
   let stdout = "";
 
@@ -24,7 +27,10 @@ function createIo() {
         write(chunk) {
           stdout += String(chunk);
         }
-      }
+      },
+      stdin: stdinText === undefined
+        ? undefined
+        : Readable.from([stdinText])
     },
     output() {
       return { stderr, stdout };
@@ -32,42 +38,108 @@ function createIo() {
   };
 }
 
-test("prints help", () => {
+test("prints help", async () => {
   const harness = createIo();
 
-  const exitCode = run(["--help"], harness.io);
+  const exitCode = await run(["--help"], harness.io);
 
   assert.equal(exitCode, 0);
   assert.match(harness.output().stdout, /Usage:/);
+  assert.match(harness.output().stdout, /ai-skills-\*/);
   assert.equal(harness.output().stderr, "");
 });
 
-test("prints version", () => {
+test("prints version", async () => {
   const harness = createIo();
 
-  const exitCode = run(["--version"], harness.io);
+  const exitCode = await run(["--version"], harness.io);
 
   assert.equal(exitCode, 0);
   assert.equal(harness.output().stdout, `${VERSION}\n`);
   assert.equal(harness.output().stderr, "");
 });
 
-test("keeps install and update reserved for later implementation", () => {
-  for (const command of ["install", "update"]) {
-    const harness = createIo();
+test("installs and updates all targets through the same reset flow", async (t) => {
+  const packageRoot = await createPackageRoot(t, ["ai-skills-one", "ai-skills-two"]);
+  const installHome = await createHomeDir(t);
+  const updateHome = await createHomeDir(t);
 
-    const exitCode = run([command], harness.io);
+  await seedTarget(updateHome, ".codex", [
+    ["ai-skills-stale", "stale"],
+    ["custom-user-skill", "keep"]
+  ]);
 
-    assert.equal(exitCode, 1);
-    assert.match(harness.output().stderr, new RegExp(`${command} is not implemented`));
-    assert.equal(harness.output().stdout, "");
+  const installHarness = createIo();
+  const updateHarness = createIo();
+  const installExit = await run(
+    ["install", "--assume-yes"],
+    installHarness.io,
+    { homeDir: installHome, packageRoot }
+  );
+  const updateExit = await run(
+    ["update", "--assume-yes"],
+    updateHarness.io,
+    { homeDir: updateHome, packageRoot }
+  );
+
+  assert.equal(installExit, 0);
+  assert.equal(updateExit, 0);
+  assert.match(installHarness.output().stderr, /will delete and replace every ai-skills-\*/);
+  assert.match(installHarness.output().stderr, /Non-prefixed user skills will be preserved/);
+  assert.match(installHarness.output().stdout, /installed 2 skill\(s\) into 3 target\(s\)/);
+  assert.match(updateHarness.output().stdout, /installed 2 skill\(s\) into 3 target\(s\)/);
+
+  for (const homeDir of [installHome, updateHome]) {
+    for (const target of SUPPORTED_TARGETS) {
+      const targetDir = path.join(homeDir, ...target.relativePath);
+      const entries = await fs.readdir(targetDir);
+
+      assert.ok(entries.includes("ai-skills-one"));
+      assert.ok(entries.includes("ai-skills-two"));
+      assert.ok(!entries.includes("ai-skills-stale"));
+    }
   }
+
+  const customSkill = path.join(updateHome, ".codex", "skills", "custom-user-skill", "SKILL.md");
+  assert.equal(await fs.readFile(customSkill, "utf8"), "keep");
 });
 
-test("prints help after an unknown command error", () => {
+test("declined confirmation leaves targets unchanged", async (t) => {
+  const packageRoot = await createPackageRoot(t, ["ai-skills-new"]);
+  const homeDir = await createHomeDir(t);
+  const targetDir = await seedTarget(homeDir, ".codex", [
+    ["ai-skills-old", "old"],
+    ["custom-user-skill", "keep"]
+  ]);
+  const harness = createIo("no\n");
+
+  const exitCode = await run(["install"], harness.io, { homeDir, packageRoot });
+
+  assert.equal(exitCode, 1);
+  assert.match(harness.output().stderr, /No changes made/);
+  assert.equal(await fs.readFile(path.join(targetDir, "ai-skills-old", "SKILL.md"), "utf8"), "old");
+  assert.equal(
+    await fs.readFile(path.join(targetDir, "custom-user-skill", "SKILL.md"), "utf8"),
+    "keep"
+  );
+  await assert.rejects(fs.access(path.join(targetDir, "ai-skills-new")));
+});
+
+test("requires confirmation when assume yes is absent", async (t) => {
+  const packageRoot = await createPackageRoot(t, ["ai-skills-new"]);
+  const homeDir = await createHomeDir(t);
   const harness = createIo();
 
-  const exitCode = run(["unknown"], harness.io);
+  const exitCode = await run(["update"], harness.io, { homeDir, packageRoot });
+
+  assert.equal(exitCode, 1);
+  assert.match(harness.output().stderr, /No changes made/);
+});
+
+test("prints help after an unknown command error", async () => {
+  const harness = createIo();
+
+  const exitCode = await run(["unknown"], harness.io);
 
   assert.equal(exitCode, 1);
   assert.match(harness.output().stderr, /Unknown command: unknown/);
@@ -85,3 +157,48 @@ test("runs directly through a relative script path", () => {
   assert.equal(result.stdout, `${VERSION}\n`);
   assert.equal(result.stderr, "");
 });
+
+async function createPackageRoot(t, skillIds) {
+  const packageRoot = await createTempDir(t);
+  const skillsDir = path.join(packageRoot, "skills");
+
+  await fs.mkdir(skillsDir);
+
+  for (const skillId of skillIds) {
+    const skillDir = path.join(skillsDir, skillId);
+
+    await fs.mkdir(skillDir);
+    await fs.writeFile(path.join(skillDir, "SKILL.md"), `---\nname: ${skillId}\n---\n`);
+  }
+
+  return packageRoot;
+}
+
+async function createHomeDir(t) {
+  return createTempDir(t);
+}
+
+async function createTempDir(t) {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "ai-skills-cli-"));
+
+  t.after(async () => {
+    await fs.rm(tempDir, { force: true, recursive: true });
+  });
+
+  return tempDir;
+}
+
+async function seedTarget(homeDir, targetName, skills) {
+  const targetDir = path.join(homeDir, targetName, "skills");
+
+  await fs.mkdir(targetDir, { recursive: true });
+
+  for (const [skillId, content] of skills) {
+    const skillDir = path.join(targetDir, skillId);
+
+    await fs.mkdir(skillDir, { recursive: true });
+    await fs.writeFile(path.join(skillDir, "SKILL.md"), content);
+  }
+
+  return targetDir;
+}


### PR DESCRIPTION
Closes #117

## Summary

- Implements public `ai-skills install` and `ai-skills update` commands.
- Keeps both commands semantically separate while using the same reset/install flow for 0.1.0.
- Resolves supported target directories from the current user home directory, with fake-home injection for tests.
- Prints destructive namespace warnings, preserves non-prefixed skills, and requires confirmation unless `--assume-yes` is passed.
- Removes only direct `ai-skills-*` directories and installs the complete packaged `ai-skills-*` catalog into Codex, Claude Code, and GitHub Copilot target directories.
- Updates README install docs now that the commands are implemented.

## Validation

- `corepack pnpm test`
- `corepack pnpm validate`
- `corepack pnpm lint:md`
- `corepack pnpm pack:dry-run`
- `git diff --check`
- CLI line-length check

## Notes

- This PR implements the shared reset/install behavior required by #117.
- The more robust per-target staging and failure-handling strategy remains scoped to #118.