### PR TITLE
Address #118: implement robust per-target reset behavior

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -221,12 +221,10 @@ async function resetTarget(
     await moveExistingPackageOwnedSkills(targetDir, backupDir, backedUpSkillIds);
     await moveStagedSkills(targetDir, stagingDir, skillIds, installedNewSkillIds);
 
-    await withTargetContext(targetDir, "remove backup directory", async () => {
-      await fs.rm(backupDir!, { force: true, recursive: true });
-    });
-    await withTargetContext(targetDir, "remove staging directory", async () => {
-      await fs.rm(stagingDir!, { force: true, recursive: true });
-    });
+    await bestEffortRemove(backupDir);
+    backupDir = undefined;
+    await bestEffortRemove(stagingDir);
+    stagingDir = undefined;
   } catch (error) {
     await rollbackTargetReset(
       targetDir,
@@ -300,7 +298,7 @@ async function rollbackTargetReset(
     await bestEffortRemove(path.join(targetDir, skillId));
   }
 
-  if (backupDir !== undefined) {
+  if (backupDir !== undefined && await pathExists(backupDir)) {
     for (const skillId of [...backedUpSkillIds].reverse()) {
       await bestEffortRename(path.join(backupDir, skillId), path.join(targetDir, skillId));
     }
@@ -350,6 +348,15 @@ async function bestEffortRename(source: string, destination: string): Promise<vo
     await fs.rename(source, destination);
   } catch {
     // Preserve the original install/update error.
+  }
+}
+
+async function pathExists(entryPath: string): Promise<boolean> {
+  try {
+    await fs.access(entryPath);
+    return true;
+  } catch {
+    return false;
   }
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -53,6 +53,8 @@ export const SUPPORTED_TARGETS: InstallTarget[] = [
 ];
 
 const PACKAGE_OWNED_PREFIX = "ai-skills-";
+const BACKUP_DIR_PREFIX = ".ai-skills-backup-";
+const STAGING_DIR_PREFIX = ".ai-skills-stage-";
 const defaultPackageRoot = resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
 const HELP = `ai-skills ${VERSION}
@@ -187,25 +189,128 @@ async function resetInstallCatalog(packageRoot: string, targetDirs: string[]): P
   const skillIds = await listPackagedSkillIds(packagedSkillsDir);
 
   for (const targetDir of targetDirs) {
-    await withTargetContext(targetDir, "create target directory", async () => {
-      await fs.mkdir(targetDir, { recursive: true });
-    });
-    await withTargetContext(targetDir, "remove existing package-owned skills", async () => {
-      await removePackageOwnedSkills(targetDir);
-    });
-
-    for (const skillId of skillIds) {
-      await withTargetContext(targetDir, `copy ${skillId}`, async () => {
-        await fs.cp(
-          path.join(packagedSkillsDir, skillId),
-          path.join(targetDir, skillId),
-          { recursive: true }
-        );
-      });
-    }
+    await resetTarget(packagedSkillsDir, skillIds, targetDir);
   }
 
   return skillIds.length;
+}
+
+async function resetTarget(
+  packagedSkillsDir: string,
+  skillIds: string[],
+  targetDir: string
+): Promise<void> {
+  let backupDir: string | undefined;
+  let stagingDir: string | undefined;
+  const installedNewSkillIds: string[] = [];
+  const backedUpSkillIds: string[] = [];
+
+  try {
+    await withTargetContext(targetDir, "create target directory", async () => {
+      await fs.mkdir(targetDir, { recursive: true });
+    });
+
+    stagingDir = await withTargetContextResult(targetDir, "create staging directory", async () =>
+      fs.mkdtemp(path.join(targetDir, STAGING_DIR_PREFIX))
+    );
+    await stagePackagedSkills(packagedSkillsDir, skillIds, stagingDir, targetDir);
+
+    backupDir = await withTargetContextResult(targetDir, "create backup directory", async () =>
+      fs.mkdtemp(path.join(targetDir, BACKUP_DIR_PREFIX))
+    );
+    await moveExistingPackageOwnedSkills(targetDir, backupDir, backedUpSkillIds);
+    await moveStagedSkills(targetDir, stagingDir, skillIds, installedNewSkillIds);
+
+    await withTargetContext(targetDir, "remove backup directory", async () => {
+      await fs.rm(backupDir!, { force: true, recursive: true });
+    });
+    await withTargetContext(targetDir, "remove staging directory", async () => {
+      await fs.rm(stagingDir!, { force: true, recursive: true });
+    });
+  } catch (error) {
+    await rollbackTargetReset(
+      targetDir,
+      backupDir,
+      stagingDir,
+      installedNewSkillIds,
+      backedUpSkillIds
+    );
+    throw error;
+  }
+}
+
+async function stagePackagedSkills(
+  packagedSkillsDir: string,
+  skillIds: string[],
+  stagingDir: string,
+  targetDir: string
+): Promise<void> {
+  for (const skillId of skillIds) {
+    await withTargetContext(targetDir, `stage ${skillId}`, async () => {
+      await fs.cp(
+        path.join(packagedSkillsDir, skillId),
+        path.join(stagingDir, skillId),
+        { recursive: true }
+      );
+    });
+  }
+}
+
+async function moveExistingPackageOwnedSkills(
+  targetDir: string,
+  backupDir: string,
+  backedUpSkillIds: string[]
+): Promise<void> {
+  const existingSkillIds = await withTargetContextResult(
+    targetDir,
+    "list existing package-owned skills",
+    async () => listPackageOwnedTargetSkillIds(targetDir)
+  );
+
+  for (const skillId of existingSkillIds) {
+    await withTargetContext(targetDir, `back up ${skillId}`, async () => {
+      await fs.rename(path.join(targetDir, skillId), path.join(backupDir, skillId));
+    });
+    backedUpSkillIds.push(skillId);
+  }
+}
+
+async function moveStagedSkills(
+  targetDir: string,
+  stagingDir: string,
+  skillIds: string[],
+  installedNewSkillIds: string[]
+): Promise<void> {
+  for (const skillId of skillIds) {
+    await withTargetContext(targetDir, `install staged ${skillId}`, async () => {
+      await fs.rename(path.join(stagingDir, skillId), path.join(targetDir, skillId));
+    });
+    installedNewSkillIds.push(skillId);
+  }
+}
+
+async function rollbackTargetReset(
+  targetDir: string,
+  backupDir: string | undefined,
+  stagingDir: string | undefined,
+  installedNewSkillIds: string[],
+  backedUpSkillIds: string[]
+): Promise<void> {
+  for (const skillId of [...installedNewSkillIds].reverse()) {
+    await bestEffortRemove(path.join(targetDir, skillId));
+  }
+
+  if (backupDir !== undefined) {
+    for (const skillId of [...backedUpSkillIds].reverse()) {
+      await bestEffortRename(path.join(backupDir, skillId), path.join(targetDir, skillId));
+    }
+
+    await bestEffortRemove(backupDir);
+  }
+
+  if (stagingDir !== undefined) {
+    await bestEffortRemove(stagingDir);
+  }
 }
 
 async function withTargetContext(
@@ -220,6 +325,34 @@ async function withTargetContext(
   }
 }
 
+async function withTargetContextResult<T>(
+  targetDir: string,
+  operation: string,
+  action: () => Promise<T>
+): Promise<T> {
+  try {
+    return await action();
+  } catch (error) {
+    throw new Error(`${operation} failed for ${targetDir}: ${errorMessage(error)}`);
+  }
+}
+
+async function bestEffortRemove(entryPath: string): Promise<void> {
+  try {
+    await fs.rm(entryPath, { force: true, recursive: true });
+  } catch {
+    // Preserve the original install/update error.
+  }
+}
+
+async function bestEffortRename(source: string, destination: string): Promise<void> {
+  try {
+    await fs.rename(source, destination);
+  } catch {
+    // Preserve the original install/update error.
+  }
+}
+
 async function listPackagedSkillIds(packagedSkillsDir: string): Promise<string[]> {
   const entries = await fs.readdir(packagedSkillsDir, { withFileTypes: true });
 
@@ -229,14 +362,13 @@ async function listPackagedSkillIds(packagedSkillsDir: string): Promise<string[]
     .sort();
 }
 
-async function removePackageOwnedSkills(targetDir: string): Promise<void> {
+async function listPackageOwnedTargetSkillIds(targetDir: string): Promise<string[]> {
   const entries = await fs.readdir(targetDir, { withFileTypes: true });
 
-  for (const entry of entries) {
-    if (entry.isDirectory() && entry.name.startsWith(PACKAGE_OWNED_PREFIX)) {
-      await fs.rm(path.join(targetDir, entry.name), { force: true, recursive: true });
-    }
-  }
+  return entries
+    .filter((entry) => entry.isDirectory() && entry.name.startsWith(PACKAGE_OWNED_PREFIX))
+    .map((entry) => entry.name)
+    .sort();
 }
 
 const isEntrypoint = process.argv[1] !== undefined

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -97,6 +97,7 @@ test("installs and updates all targets through the same reset flow", async (t) =
       assert.ok(entries.includes("ai-skills-one"));
       assert.ok(entries.includes("ai-skills-two"));
       assert.ok(!entries.includes("ai-skills-stale"));
+      assertNoTemporaryResetDirs(entries);
     }
   }
 
@@ -123,6 +124,38 @@ test("declined confirmation leaves targets unchanged", async (t) => {
     "keep"
   );
   await assert.rejects(fs.access(path.join(targetDir, "ai-skills-new")));
+});
+
+test("reports target failure and preserves non-prefixed skills", async (t) => {
+  const packageRoot = await createPackageRoot(t, ["ai-skills-one"]);
+  const homeDir = await createHomeDir(t);
+  const codexTargetDir = await seedTarget(homeDir, ".codex", [
+    ["custom-user-skill", "keep"]
+  ]);
+  const blockingPath = path.join(homeDir, ".claude");
+  const harness = createIo();
+
+  await fs.writeFile(blockingPath, "blocking file");
+
+  const exitCode = await run(
+    ["install", "--assume-yes"],
+    harness.io,
+    { homeDir, packageRoot }
+  );
+  const codexEntries = await fs.readdir(codexTargetDir);
+  const codexSkill = path.join(codexTargetDir, "ai-skills-one", "SKILL.md");
+  const failedTargetDir = path.join(homeDir, ".claude", "skills");
+
+  assert.equal(exitCode, 1);
+  assert.match(harness.output().stderr, /create target directory failed/);
+  assert.ok(harness.output().stderr.includes(failedTargetDir));
+  assert.equal(
+    await fs.readFile(path.join(codexTargetDir, "custom-user-skill", "SKILL.md"), "utf8"),
+    "keep"
+  );
+  assert.equal(await fs.readFile(blockingPath, "utf8"), "blocking file");
+  assert.equal(await fs.readFile(codexSkill, "utf8"), "---\nname: ai-skills-one\n---\n");
+  assertNoTemporaryResetDirs(codexEntries);
 });
 
 test("requires confirmation when assume yes is absent", async (t) => {
@@ -201,4 +234,9 @@ async function seedTarget(homeDir, targetName, skills) {
   }
 
   return targetDir;
+}
+
+function assertNoTemporaryResetDirs(entries) {
+  assert.ok(!entries.some((entry) => entry.startsWith(".ai-skills-stage-")));
+  assert.ok(!entries.some((entry) => entry.startsWith(".ai-skills-backup-")));
 }


### PR DESCRIPTION
Closes #118

## Summary

- Changes each target reset to stage the complete packaged skill set before replacing existing `ai-skills-*` directories.
- Backs up existing package-owned directories, moves staged skills into place, and cleans staging/backup directories on success.
- Adds best-effort rollback cleanup on failure while preserving the original target/operation error.
- Keeps targets independent: a later target can fail after an earlier target succeeds, and the failure output names the target path and operation.
- Extends tests for temp cleanup, target failure reporting, partial target-level success, and non-prefixed skill preservation.

## Validation

- `corepack pnpm test`
- `corepack pnpm validate`
- `corepack pnpm lint:md`
- `corepack pnpm pack:dry-run`
- `git diff --check`
- CLI line-length check

## Notes

- This PR hardens the reset implementation added in #117 without changing the public command contract.