### PR TITLE
Address #120: add cross-platform CI and npm package release checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,8 +10,16 @@ permissions:
 
 jobs:
   package-check:
-    name: Package Check
-    runs-on: ubuntu-latest
+    name: Package Check (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Closes #120

## Summary
- Run the package verification workflow on Ubuntu, macOS, and Windows.
- Keep the existing Corepack/pnpm build, test, validation, and package dry-run gates on every OS.
- Preserve the installer safety coverage already exercised by the test suite, including fake-home install/update behavior.

## Validation
- `corepack pnpm lint:md`
- `git diff --check`
- `corepack pnpm test`
- `corepack pnpm validate`
- `corepack pnpm pack:dry-run`