### PR TITLE
Address #121: publish ai-skills 0.1.0 to npmjs.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+## 0.1.0 - 2026-05-01
+
+Initial public release of `@barney-media/ai-skills`.
+
+### Added
+
+- Published the canonical AI skills catalog as an npm package with the public `ai-skills` CLI.
+- Added global installation through `npm install -g @barney-media/ai-skills`.
+- Added `ai-skills install` and `ai-skills update` commands.
+- Installed the complete packaged skill set into the current user's Codex, Claude Code, and GitHub Copilot skill
+  directories.
+- Added cross-platform package verification for Windows, macOS, and Linux.
+- Added internal catalog validation for build, package, and release verification.
+
+### Install and Update Behavior
+
+- `install` and `update` intentionally use the same reset/install flow in 0.1.0.
+- The `ai-skills-` prefix is reserved for this package in supported target directories.
+- Existing `ai-skills-*` directories are deleted and replaced by the packaged catalog during install or update.
+- Non-prefixed user skills are never modified, moved, or deleted.
+- Interactive confirmation is required unless `--assume-yes` is passed.
+
+### Supported Targets
+
+- Codex: `<home>/.codex/skills`
+- Claude Code: `<home>/.claude/skills`
+- GitHub Copilot: `<home>/.copilot/skills`
+
+The CLI resolves the current user's home directory through the Node.js runtime and does not rely on shell `~`
+expansion.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "files": [
     "dist",
     "skills",
+    "CHANGELOG.md",
     "README.md",
     "spec.md",
     "LICENSE"


### PR DESCRIPTION
Closes #121

## Summary
- Add `CHANGELOG.md` for the initial 0.1.0 release.
- Document user-visible install/update behavior, including the reserved `ai-skills-` namespace and destructive replacement of prefixed skills.
- Include the changelog in the npm package file list.

## Release Readiness
- All other GitHub issues are closed; #121 is the only remaining open issue before this PR.
- `package.json` is already set to `0.1.0`.
- README already documents `npm install -g @barney-media/ai-skills`.

## Validation
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm lint:md`
- `corepack pnpm build`
- `corepack pnpm test`
- `corepack pnpm validate`
- `corepack pnpm pack:dry-run`
- `git diff --check`