### PR TITLE
Rename quality gate checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,8 +48,8 @@ jobs:
       - name: Package dry run
         run: corepack pnpm pack:dry-run
 
-  cognitive-typescript-gate:
-    name: cognitive-java Gate
+  quality-cognitive:
+    name: quality-cognitive
     runs-on: ubuntu-latest
 
     steps:
@@ -70,8 +70,8 @@ jobs:
       - name: Cognitive Complexity Gate
         run: corepack pnpm quality:cognitive
 
-  crap-typescript-gate:
-    name: crap-java Gate
+  quality-crap:
+    name: quality-crap
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary

- rename the required quality gate check names to `quality-cognitive` and `quality-crap`
- keep the TypeScript gate commands and behavior unchanged
- align the workflow naming with the actual language being checked

## Validation

- `corepack pnpm quality:cognitive`
- `corepack pnpm quality:crap`
- `corepack pnpm test`
- `corepack pnpm validate`