### PR TITLE
Update TypeScript tooling dependencies

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -12,8 +12,8 @@ jobs:
   markdownlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - uses: DavidAnson/markdownlint-cli2-action@b4c9feab76d8025d1e83c653fa3990936df0e6c8
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd
         with:
           globs: |
             **/*.md
@@ -23,8 +23,8 @@ jobs:
   linkcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - uses: lycheeverse/lychee-action@7cd0af4c74a61395d455af97419279d86aafaede
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411
         with:
           args: --no-progress --verbose './**/*.md'
           failIfEmpty: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: "24"
 
@@ -54,10 +54,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: "24"
 
@@ -76,10 +76,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: "24"
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "engines": {
     "node": ">=20.11"
   },
-  "packageManager": "pnpm@10.33.2",
+  "packageManager": "pnpm@10.33.4",
   "publishConfig": {
     "access": "public"
   },
@@ -43,10 +43,10 @@
   "devDependencies": {
     "@barney-media/cognitive-typescript-vitest": "^0.1.1",
     "@barney-media/crap-typescript-vitest": "^0.2.3",
-    "@types/node": "^24.10.1",
+    "@types/node": "^24.12.3",
     "@vitest/coverage-v8": "^4.1.5",
     "markdownlint-cli2": "^0.22.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^0.2.3
         version: 0.2.3(vitest@4.1.5)
       '@types/node':
-        specifier: ^24.10.1
-        version: 24.12.2
+        specifier: ^24.12.3
+        version: 24.12.3
       '@vitest/coverage-v8':
         specifier: ^4.1.5
         version: 4.1.5(vitest@4.1.5)
@@ -24,11 +24,11 @@ importers:
         specifier: ^0.22.1
         version: 0.22.1
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@24.12.2))
+        version: 4.1.5(@types/node@24.12.3)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@24.12.3))
 
 packages:
 
@@ -239,8 +239,8 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
-  '@types/node@24.12.2':
-    resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
+  '@types/node@24.12.3':
+    resolution: {integrity: sha512-8oljBDGun9cIsZRJR6fkihn0TSXJI0UDOOhncYaERq6M0JMDoPLxyscwruJcb4GKS6dvK/d8xebYBg27h/duaQ==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -766,11 +766,6 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -897,7 +892,7 @@ snapshots:
   '@barney-media/cognitive-typescript-vitest@0.1.1(vitest@4.1.5)':
     dependencies:
       '@barney-media/cognitive-typescript-core': 0.1.1
-      vitest: 4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@24.12.2))
+      vitest: 4.1.5(@types/node@24.12.3)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@24.12.3))
 
   '@barney-media/crap-typescript-core@0.2.3':
     dependencies:
@@ -906,7 +901,7 @@ snapshots:
   '@barney-media/crap-typescript-vitest@0.2.3(vitest@4.1.5)':
     dependencies:
       '@barney-media/crap-typescript-core': 0.2.3
-      vitest: 4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@24.12.2))
+      vitest: 4.1.5(@types/node@24.12.3)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@24.12.3))
 
   '@bcoe/v8-coverage@1.0.2': {}
 
@@ -1033,7 +1028,7 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
-  '@types/node@24.12.2':
+  '@types/node@24.12.3':
     dependencies:
       undici-types: 7.16.0
 
@@ -1051,7 +1046,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@24.12.2))
+      vitest: 4.1.5(@types/node@24.12.3)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@24.12.3))
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -1062,13 +1057,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@24.12.2))':
+  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@24.12.3))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.10(@types/node@24.12.2)
+      vite: 8.0.10(@types/node@24.12.3)
 
   '@vitest/pretty-format@4.1.5':
     dependencies:
@@ -1635,8 +1630,6 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
-  typescript@5.9.3: {}
-
   typescript@6.0.3: {}
 
   uc.micro@2.1.0: {}
@@ -1645,7 +1638,7 @@ snapshots:
 
   unicorn-magic@0.4.0: {}
 
-  vite@8.0.10(@types/node@24.12.2):
+  vite@8.0.10(@types/node@24.12.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -1653,13 +1646,13 @@ snapshots:
       rolldown: 1.0.0-rc.17
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 24.12.2
+      '@types/node': 24.12.3
       fsevents: 2.3.3
 
-  vitest@4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@24.12.2)):
+  vitest@4.1.5(@types/node@24.12.3)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@24.12.3)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@24.12.2))
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@24.12.3))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -1676,10 +1669,10 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.10(@types/node@24.12.2)
+      vite: 8.0.10(@types/node@24.12.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 24.12.2
+      '@types/node': 24.12.3
       '@vitest/coverage-v8': 4.1.5(vitest@4.1.5)
     transitivePeerDependencies:
       - msw

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -222,20 +222,26 @@ async function resetTarget(
       await fs.mkdir(targetDir, { recursive: true });
     });
 
-    stagingDir = await withTargetContextResult(targetDir, "create staging directory", async () =>
-      fs.mkdtemp(path.join(targetDir, STAGING_DIR_PREFIX))
+    const createdStagingDir = await withTargetContextResult(
+      targetDir,
+      "create staging directory",
+      async () => fs.mkdtemp(path.join(targetDir, STAGING_DIR_PREFIX))
     );
-    await stagePackagedSkills(packagedSkillsDir, skillIds, stagingDir, targetDir);
+    stagingDir = createdStagingDir;
+    await stagePackagedSkills(packagedSkillsDir, skillIds, createdStagingDir, targetDir);
 
-    backupDir = await withTargetContextResult(targetDir, "create backup directory", async () =>
-      fs.mkdtemp(path.join(targetDir, BACKUP_DIR_PREFIX))
+    const createdBackupDir = await withTargetContextResult(
+      targetDir,
+      "create backup directory",
+      async () => fs.mkdtemp(path.join(targetDir, BACKUP_DIR_PREFIX))
     );
-    await moveExistingPackageOwnedSkills(targetDir, backupDir, backedUpSkillIds);
-    await moveStagedSkills(targetDir, stagingDir, skillIds, installedNewSkillIds);
+    backupDir = createdBackupDir;
+    await moveExistingPackageOwnedSkills(targetDir, createdBackupDir, backedUpSkillIds);
+    await moveStagedSkills(targetDir, createdStagingDir, skillIds, installedNewSkillIds);
 
-    await bestEffortRemove(backupDir);
+    await bestEffortRemove(createdBackupDir);
     backupDir = undefined;
-    await bestEffortRemove(stagingDir);
+    await bestEffortRemove(createdStagingDir);
     stagingDir = undefined;
   } catch (error) {
     await rollbackTargetReset(
@@ -396,8 +402,9 @@ async function listPackageOwnedTargetSkillIds(targetDir: string): Promise<string
     .sort();
 }
 
-const isEntrypoint = process.argv[1] !== undefined
-  && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+const entrypointArg = process.argv[1];
+const isEntrypoint = entrypointArg !== undefined
+  && import.meta.url === pathToFileURL(resolve(entrypointArg)).href;
 
 if (isEntrypoint) {
   process.exitCode = await run();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,10 @@
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,
-    "target": "ES2022"
+    "target": "ES2022",
+    "types": [
+      "node"
+    ]
   },
   "include": [
     "src/**/*.ts"


### PR DESCRIPTION
## Summary
- update pnpm within the Node 20-compatible 10.x line instead of pnpm 11, which now requires Node >=22.13
- update TypeScript to 6.0.3 and Node typings to the latest Node 24 LTS-compatible package
- update pinned GitHub Actions SHAs for checkout and setup-node
- add the TypeScript 6 migration adjustments needed for Node ambient types and stricter narrowing

## Validation
- `corepack pnpm build`
- `corepack pnpm test`
- `corepack pnpm validate`
- `corepack pnpm quality:cognitive`
- `corepack pnpm quality:crap`
- `corepack pnpm pack:dry-run`

Closes #175