### PR TITLE
Remove ai-rules references from canonical skills

### DIFF
--- a/skills/ai-skills-conventions-java/references/java-convention-defaults.md
+++ b/skills/ai-skills-conventions-java/references/java-convention-defaults.md
@@ -1,6 +1,7 @@
 # Java Convention Defaults
 
-Distilled from issue `#13` plus the shared Java baseline in `ai-rules`.
+Distilled from issue `#13` plus the shared Java baseline in the governing
+rulesets.
 
 - Default to the focused Java leaf skills first:
   skill `ai-skills-conventions-null`, skill `ai-skills-conventions-lombok`,

--- a/skills/ai-skills-gates-exit/SKILL.md
+++ b/skills/ai-skills-gates-exit/SKILL.md
@@ -30,8 +30,8 @@ and passed.
 # Inputs
 
 - the bounded diff, changed files, and implementation goal
-- confirmation that the complete applicable ai-rules and downstream rulesets
-  have been read before implementation/gate evaluation
+- confirmation that the complete applicable repository rulesets and downstream
+  extensions have been read before implementation/gate evaluation
 - the repository build and test commands or the strongest equivalent CI/local
   evidence
 - the behavior changes in the bounded scope and the tests added or updated for
@@ -68,9 +68,9 @@ when they materially apply to the bounded scope:
 
 ## Gate Evaluation
 
-1. Verify that the complete applicable ai-rules and downstream rulesets were
-   read before implementation and exit-gate evaluation. If not, read them before
-   continuing or mark the gate evaluation blocked.
+1. Verify that the complete applicable repository rulesets and downstream
+   extensions were read before implementation and exit-gate evaluation. If not,
+   read them before continuing or mark the gate evaluation blocked.
 2. Identify the bounded scope and determine which languages, frameworks,
    persistence paths, and quality signals are relevant.
 3. Evaluate the mandatory gates in the order from

--- a/skills/ai-skills-plan/SKILL.md
+++ b/skills/ai-skills-plan/SKILL.md
@@ -34,8 +34,8 @@ implicit.
 
 - the user request and success criteria
 - relevant repository context, constraints, and existing implementation shape
-- applicable repository rulesets, including complete ai-rules and downstream
-  extension entrypoints when present
+- applicable repository rulesets and downstream extension entrypoints when
+  present
 - unresolved product or technical tradeoffs
 - any user answers that materially affect the plan
 - `references/decision-complete-plan.md`,
@@ -48,8 +48,8 @@ implicit.
 # Workflow
 
 1. Read the complete applicable rulesets before any other planning task,
-   including ai-rules and downstream extension rulesets when they govern the
-   target repository.
+   including downstream extension rulesets when they govern the target
+   repository.
 2. Explore the repository, issue history, semantic parent and sibling docs,
    architecture constraints, external dependencies, and blockers before asking
    questions that could be answered by inspection.


### PR DESCRIPTION
## Summary
- remove remaining `ai-rules` wording from canonical skill content
- replace those references with neutral repository-ruleset language
- keep the change bounded to the three canonical files still carrying the legacy term

## Why
The catalog has already moved away from `ai-rules` as an active canonical dependency. These remaining references were stale wording and made the affected skills inconsistent with the current repository model.

## Validation
- `corepack pnpm lint:md`
- `corepack pnpm validate`
- `corepack pnpm test`
- `corepack pnpm quality:cognitive`
- `corepack pnpm quality:crap`
- `corepack pnpm pack:dry-run`

Closes #167