### PR TITLE
Add version support policy skill

### DIFF
--- a/skills/ai-skills-release-github/SKILL.md
+++ b/skills/ai-skills-release-github/SKILL.md
@@ -19,6 +19,8 @@ annotated tags, and GitHub release notes aligned.
   user-visible changes since the latest tag
 - use when changelog content, tags, and GitHub release notes must describe the
   same release
+- use skill `ai-skills-version-support-policy` when the release also changes
+  the officially supported runtime or platform matrix
 - use `references/version-selection.md` for semantic version bump selection
 - use `references/github-release-flow.md` for the tagged-release sequence and
   GitHub-specific checks
@@ -30,6 +32,8 @@ annotated tags, and GitHub release notes aligned.
 - confirmation that no open release-bound PRs remain
 - the latest reachable release tag and the merged changes since that tag
 - any explicit target version provided by the user or repository policy
+- any support-policy changes in the release scope that affect compatibility
+  claims
 - the changelog or strongest release-notes source for the repository
 - GitHub access capable of pushing tags and creating releases
 - `references/version-selection.md`
@@ -39,26 +43,29 @@ annotated tags, and GitHub release notes aligned.
 
 1. Ensure the default branch is current, all release-bound PRs are merged, and
    no open release-bound PRs remain; do not release from a feature branch.
-2. Determine the target version: use an explicit version when provided;
+2. If the release changes officially supported runtimes or platforms and the
+   support policy is not explicit yet, apply skill `ai-skills-version-support-policy`
+   before finalizing compatibility claims.
+3. Determine the target version: use an explicit version when provided;
    otherwise classify the changes since the latest tag and select the smallest
    valid semantic-version bump that fits the strongest user-visible change.
-3. Stop if there are no meaningful release changes instead of creating an empty
+4. Stop if there are no meaningful release changes instead of creating an empty
    tag.
-4. Update the changelog or release-notes source with the selected version, the
+5. Update the changelog or release-notes source with the selected version, the
    release date, and a concise summary of user-visible changes.
-5. Run `git grep -F "<previous-tag>"` before creating the release commit,
+6. Run `git grep -F "<previous-tag>"` before creating the release commit,
    replacing `<previous-tag>` with the actual latest released version tag, for
    example `v1.2.3`. Update every versioned release example or documentation
    reference found so it points at the new tag.
-6. Stage the changelog or release-notes source and all versioned-example
+7. Stage the changelog or release-notes source and all versioned-example
    updates together.
-7. Commit the release-preparation changes on the default branch, create an
+8. Commit the release-preparation changes on the default branch, create an
    annotated tag for the release commit, and push both branch and tag.
-8. Create the GitHub Release from the pushed tag using notes that stay aligned
+9. Create the GitHub Release from the pushed tag using notes that stay aligned
    with the changelog or release-notes source. If both exist, treat the
    changelog as authoritative unless repository policy explicitly says
    otherwise.
-9. Verify that the tag and release page exist and point at the intended commit.
+10. Verify that the tag and release page exist and point at the intended commit.
 
 # Outputs
 

--- a/skills/ai-skills-release/SKILL.md
+++ b/skills/ai-skills-release/SKILL.md
@@ -25,6 +25,8 @@ not as rules to copy into downstream projects.
 - use when artifact publication may target Maven Central, the Gradle Plugin
   Portal, a private artifactory, or another repository-specific release target
 - use when skill `ai-skills-release-github` is necessary but not sufficient on its own
+- use skill `ai-skills-version-support-policy` when the release changes the
+  officially supported runtime or platform policy
 - use skill `ai-skills-release-github` for the full GitHub-release workflow,
   including version selection, docs/changelog alignment, the release-prep
   commit and push, tag creation, and the GitHub Release itself
@@ -40,6 +42,8 @@ not as rules to copy into downstream projects.
 - repository-specific release policy, versioning rules, and publication rules
 - the strongest available final build and test commands or CI evidence
 - the latest release tag and the delta since that release
+- any support-policy changes in the release scope that affect the published
+  artifact or compatibility claims
 - documentation, changelog, and versioned example locations that must be
   updated
 - the artifact publication targets actually used by the repository
@@ -55,19 +59,22 @@ not as rules to copy into downstream projects.
    not continue if the final verification is red or missing.
 3. Apply the repository-specific release policy as an input, without copying
    policy text into downstream projects.
-4. Confirm versioned release examples and documentation references are known so
+4. If support-policy decisions in the release scope are still open, apply
+   skill `ai-skills-version-support-policy` before finalizing the release
+   candidate.
+5. Confirm versioned release examples and documentation references are known so
    the release can update them to the new tag.
-5. Apply skill `ai-skills-release-github` to perform the GitHub-release workflow,
+6. Apply skill `ai-skills-release-github` to perform the GitHub-release workflow,
    including version selection, changelog/docs alignment, release-prep commit,
    versioned-example updates, tag creation, push, and GitHub Release creation.
-6. Publish release artifacts only after tag creation and GitHub Release
+7. Publish release artifacts only after tag creation and GitHub Release
    creation both succeed. Publish to each applicable target registry listed in
    `references/publication-targets.md`, such as Maven Central, the Gradle
    Plugin Portal, or a private artifactory, and record any target that is
    intentionally not applicable.
-7. Verify the published artifacts and release metadata so version numbers,
+8. Verify the published artifacts and release metadata so version numbers,
    tags, changelog entries, and published packages all match.
-8. Use `examples/release-checklist.md` when communicating the completed release
+9. Use `examples/release-checklist.md` when communicating the completed release
    steps or any blocked publication target.
 
 # Outputs

--- a/skills/ai-skills-version-support-policy/SKILL.md
+++ b/skills/ai-skills-version-support-policy/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: ai-skills-version-support-policy
+description: >-
+  Define which runtime, platform, or ecosystem versions a project officially
+  supports, with LTS and EOL status treated as primary decision inputs.
+---
+<!-- markdownlint-disable MD025 -->
+
+# Purpose
+
+Set a clear support policy for runtimes, platforms, or ecosystem versions so
+documentation, CI, and compatibility promises all align.
+
+# When to Use
+
+- use when a project must decide which runtime, platform, or ecosystem versions
+  it officially supports
+- use when CI matrices, README claims, or compatibility guarantees depend on a
+  support statement
+- use when adding or removing supported versions for a library, service, CLI,
+  or application
+- use before dependency-selection work when supported versions constrain which
+  frameworks, tools, or dependencies remain viable
+
+# Inputs
+
+- the runtime, platform, or ecosystem surfaces that need official support
+  claims
+- project-specific compatibility, consumer, or deployment constraints
+- upstream vendor support windows, LTS status, and EOL status
+- current or intended CI coverage and documentation claims
+- any explicit user or maintainer policy about support breadth
+
+# Workflow
+
+1. Identify which runtime, platform, or ecosystem versions need an explicit
+   support statement.
+2. Gather the project constraints, consumer expectations, and upstream support
+   windows that limit viable support choices.
+3. Exclude EOL versions from official support unless an explicit project policy
+   exception exists and the risk is surfaced clearly.
+4. When maintained LTS releases exist, default official support to maintained
+   LTS lines rather than non-LTS lines unless project policy requires broader
+   support.
+5. Distinguish official support, tested compatibility, and unverified versions
+   instead of collapsing them into one claim.
+6. Define the minimum CI and documentation obligations needed to make the
+   support policy credible.
+7. Surface any planned support additions, removals, or deprecations clearly
+   enough for downstream consumers to react.
+
+# Outputs
+
+- an explicit supported-version policy for the scoped runtimes or platforms
+- aligned expectations for CI coverage and documentation claims
+- clear deprecation or exclusion notes when versions are no longer supported
+
+# Guardrails
+
+- do not officially support EOL versions by default
+- do not claim broad compatibility without CI or documented testing support
+- do not conflate best-effort compatibility with official support
+- do not broaden this skill into dependency graph version selection
+
+# Exit Checks
+
+- supported versions are explicit and justified
+- EOL and LTS status were considered explicitly
+- CI and documentation implications of the support policy are clear
+- removed or unsupported versions are called out concretely


### PR DESCRIPTION
## Summary
- add the canonical `ai-skills-version-support-policy` skill bundle
- define LTS and EOL status as first-class inputs to support-policy decisions
- teach the existing release skills to pull in support-policy decisions when compatibility claims change during a release

## Why
The version family needs a distinct leaf skill for support policy so runtime and platform support promises stay separate from dependency-version choice while still driving CI and documentation expectations.

## Validation
- `corepack pnpm lint:md`
- `corepack pnpm validate`
- `corepack pnpm test`
- `corepack pnpm quality:cognitive`
- `corepack pnpm quality:crap`
- `corepack pnpm pack:dry-run`

Closes #180