### PR TITLE
Add version dependency selection skill

### DIFF
--- a/skills/ai-skills-release-github/SKILL.md
+++ b/skills/ai-skills-release-github/SKILL.md
@@ -19,6 +19,9 @@ annotated tags, and GitHub release notes aligned.
   user-visible changes since the latest tag
 - use when changelog content, tags, and GitHub release notes must describe the
   same release
+- use skill `ai-skills-version-dependency-selection` when framework,
+  build-tool, or dependency choices in the release scope still need explicit
+  version selection
 - use skill `ai-skills-version-support-policy` when the release also changes
   the officially supported runtime or platform matrix
 - use `references/version-selection.md` for semantic version bump selection
@@ -32,8 +35,8 @@ annotated tags, and GitHub release notes aligned.
 - confirmation that no open release-bound PRs remain
 - the latest reachable release tag and the merged changes since that tag
 - any explicit target version provided by the user or repository policy
-- any support-policy changes in the release scope that affect compatibility
-  claims
+- any framework, build-tool, dependency, or support-policy changes in the
+  release scope that affect compatibility claims
 - the changelog or strongest release-notes source for the repository
 - GitHub access capable of pushing tags and creating releases
 - `references/version-selection.md`
@@ -43,29 +46,32 @@ annotated tags, and GitHub release notes aligned.
 
 1. Ensure the default branch is current, all release-bound PRs are merged, and
    no open release-bound PRs remain; do not release from a feature branch.
-2. If the release changes officially supported runtimes or platforms and the
+2. If the release scope includes framework, build-tool, or dependency choices
+   that are not fixed yet, apply skill `ai-skills-version-dependency-selection`
+   before finalizing release timing or compatibility notes.
+3. If the release changes officially supported runtimes or platforms and the
    support policy is not explicit yet, apply skill `ai-skills-version-support-policy`
    before finalizing compatibility claims.
-3. Determine the target version: use an explicit version when provided;
+4. Determine the target version: use an explicit version when provided;
    otherwise classify the changes since the latest tag and select the smallest
    valid semantic-version bump that fits the strongest user-visible change.
-4. Stop if there are no meaningful release changes instead of creating an empty
+5. Stop if there are no meaningful release changes instead of creating an empty
    tag.
-5. Update the changelog or release-notes source with the selected version, the
+6. Update the changelog or release-notes source with the selected version, the
    release date, and a concise summary of user-visible changes.
-6. Run `git grep -F "<previous-tag>"` before creating the release commit,
+7. Run `git grep -F "<previous-tag>"` before creating the release commit,
    replacing `<previous-tag>` with the actual latest released version tag, for
    example `v1.2.3`. Update every versioned release example or documentation
    reference found so it points at the new tag.
-7. Stage the changelog or release-notes source and all versioned-example
+8. Stage the changelog or release-notes source and all versioned-example
    updates together.
-8. Commit the release-preparation changes on the default branch, create an
+9. Commit the release-preparation changes on the default branch, create an
    annotated tag for the release commit, and push both branch and tag.
-9. Create the GitHub Release from the pushed tag using notes that stay aligned
+10. Create the GitHub Release from the pushed tag using notes that stay aligned
    with the changelog or release-notes source. If both exist, treat the
    changelog as authoritative unless repository policy explicitly says
    otherwise.
-10. Verify that the tag and release page exist and point at the intended commit.
+11. Verify that the tag and release page exist and point at the intended commit.
 
 # Outputs
 

--- a/skills/ai-skills-release/SKILL.md
+++ b/skills/ai-skills-release/SKILL.md
@@ -25,6 +25,8 @@ not as rules to copy into downstream projects.
 - use when artifact publication may target Maven Central, the Gradle Plugin
   Portal, a private artifactory, or another repository-specific release target
 - use when skill `ai-skills-release-github` is necessary but not sufficient on its own
+- use skill `ai-skills-version-dependency-selection` when dependency,
+  framework, or build-tool choices are still open in the release scope
 - use skill `ai-skills-version-support-policy` when the release changes the
   officially supported runtime or platform policy
 - use skill `ai-skills-release-github` for the full GitHub-release workflow,
@@ -42,8 +44,8 @@ not as rules to copy into downstream projects.
 - repository-specific release policy, versioning rules, and publication rules
 - the strongest available final build and test commands or CI evidence
 - the latest release tag and the delta since that release
-- any support-policy changes in the release scope that affect the published
-  artifact or compatibility claims
+- any dependency, framework, build-tool, or support-policy changes in the
+  release scope that affect the published artifact or support claims
 - documentation, changelog, and versioned example locations that must be
   updated
 - the artifact publication targets actually used by the repository
@@ -59,9 +61,9 @@ not as rules to copy into downstream projects.
    not continue if the final verification is red or missing.
 3. Apply the repository-specific release policy as an input, without copying
    policy text into downstream projects.
-4. If support-policy decisions in the release scope are still open, apply
-   skill `ai-skills-version-support-policy` before finalizing the release
-   candidate.
+4. If dependency, framework, build-tool, or support-policy decisions in the
+   release scope are still open, apply the relevant version-family skills
+   before finalizing the release candidate.
 5. Confirm versioned release examples and documentation references are known so
    the release can update them to the new tag.
 6. Apply skill `ai-skills-release-github` to perform the GitHub-release workflow,

--- a/skills/ai-skills-release/SKILL.md
+++ b/skills/ai-skills-release/SKILL.md
@@ -61,22 +61,25 @@ not as rules to copy into downstream projects.
    not continue if the final verification is red or missing.
 3. Apply the repository-specific release policy as an input, without copying
    policy text into downstream projects.
-4. If dependency, framework, build-tool, or support-policy decisions in the
-   release scope are still open, apply the relevant version-family skills
-   before finalizing the release candidate.
-5. Confirm versioned release examples and documentation references are known so
+4. If dependency, framework, or build-tool choices in the release scope are
+   still open, apply skill `ai-skills-version-dependency-selection` before
+   finalizing the release candidate.
+5. If support-policy decisions in the release scope are still open, apply
+   skill `ai-skills-version-support-policy` before finalizing the release
+   candidate.
+6. Confirm versioned release examples and documentation references are known so
    the release can update them to the new tag.
-6. Apply skill `ai-skills-release-github` to perform the GitHub-release workflow,
+7. Apply skill `ai-skills-release-github` to perform the GitHub-release workflow,
    including version selection, changelog/docs alignment, release-prep commit,
    versioned-example updates, tag creation, push, and GitHub Release creation.
-7. Publish release artifacts only after tag creation and GitHub Release
+8. Publish release artifacts only after tag creation and GitHub Release
    creation both succeed. Publish to each applicable target registry listed in
    `references/publication-targets.md`, such as Maven Central, the Gradle
    Plugin Portal, or a private artifactory, and record any target that is
    intentionally not applicable.
-8. Verify the published artifacts and release metadata so version numbers,
+9. Verify the published artifacts and release metadata so version numbers,
    tags, changelog entries, and published packages all match.
-9. Use `examples/release-checklist.md` when communicating the completed release
+10. Use `examples/release-checklist.md` when communicating the completed release
    steps or any blocked publication target.
 
 # Outputs

--- a/skills/ai-skills-version-dependency-selection/SKILL.md
+++ b/skills/ai-skills-version-dependency-selection/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: ai-skills-version-dependency-selection
+description: >-
+  Choose framework, build-tool, and dependency versions with a
+  compatibility-first strategy that still prefers the newest stable viable
+  option.
+---
+<!-- markdownlint-disable MD025 -->
+
+# Purpose
+
+Select framework, build-tool, and dependency versions in a way that preserves
+compatibility, respects project policy, and still moves the stack as far
+forward as safely possible.
+
+# When to Use
+
+- use when bootstrapping or upgrading a project requires explicit version
+  choices for frameworks, runtimes, build tools, or dependencies
+- use when compatibility constraints, peer dependencies, or runtime support
+  limits make version choice non-trivial
+- use skill `ai-skills-version-support-policy` when the supported runtime or
+  platform matrix is still open and constrains viable versions
+- use skill `ai-skills-compliance-dependency` when dependency governance,
+  license, or stewardship risk materially affects the choice
+
+# Inputs
+
+- the components whose versions must be chosen, added, or upgraded
+- compatibility constraints from runtimes, frameworks, peer dependencies, and
+  repository policy
+- candidate versions, release channels, LTS tracks, and stability information
+- security, compliance, or maintenance constraints that affect selection
+- whether the selection applies to bootstrap, routine maintenance, or a release
+  scope
+
+# Workflow
+
+1. Identify the components whose versions must be selected and the dependency
+   surfaces they constrain.
+2. Gather the hard compatibility constraints from runtimes, frameworks,
+   toolchains, peer dependencies, and repository policy.
+3. If the supported runtime or platform matrix is still undecided, apply skill `ai-skills-version-support-policy`
+   before locking incompatible choices.
+4. Prefer explicit project policy when it already constrains a version.
+5. Otherwise prefer the newest stable compatible version, favoring maintained
+   LTS lines when they materially improve runtime or toolchain stability.
+6. Sequence framework, platform, and build-tool choices before ordinary
+   dependency upgrades because they constrain the rest of the stack.
+7. Apply skill `ai-skills-compliance-dependency` when governance, license, or
+   stewardship risk matters to the decision.
+8. Record the selected versions, rejected candidates, and the concrete reason
+   each rejected candidate did not fit.
+
+# Outputs
+
+- explicit version choices for the scoped frameworks, tools, or dependencies
+- a compatibility rationale for the selected versions
+- surfaced blockers when no acceptable compatible version exists
+
+# Guardrails
+
+- do not choose the latest version when it is incompatible with the actual
+  stack constraints
+- do not skip peer, runtime, framework, or build-tool compatibility checks
+- do not treat prerelease, unstable, or EOL versions as default choices
+- do not broaden this skill into semantic release-version bump selection
+
+# Exit Checks
+
+- every selected version satisfies the known compatibility constraints
+- the newest stable viable option was preferred unless project policy says
+  otherwise
+- framework and build-tool constraints were resolved before ordinary
+  dependency choices
+- compliance or stewardship concerns were surfaced when they mattered

--- a/skills/ai-skills-version-dependency-selection/SKILL.md
+++ b/skills/ai-skills-version-dependency-selection/SKILL.md
@@ -40,8 +40,9 @@ forward as safely possible.
    surfaces they constrain.
 2. Gather the hard compatibility constraints from runtimes, frameworks,
    toolchains, peer dependencies, and repository policy.
-3. If the supported runtime or platform matrix is still undecided, apply skill `ai-skills-version-support-policy`
-   before locking incompatible choices.
+3. If the supported runtime or platform matrix is still undecided, apply
+   skill `ai-skills-version-support-policy` before locking incompatible
+   choices.
 4. Prefer explicit project policy when it already constrains a version.
 5. Otherwise prefer the newest stable compatible version, favoring maintained
    LTS lines when they materially improve runtime or toolchain stability.

--- a/skills/ai-skills-version-dependency-selection/SKILL.md
+++ b/skills/ai-skills-version-dependency-selection/SKILL.md
@@ -16,7 +16,7 @@ forward as safely possible.
 # When to Use
 
 - use when bootstrapping or upgrading a project requires explicit version
-  choices for frameworks, runtimes, build tools, or dependencies
+  choices for frameworks, build tools, or dependencies
 - use when compatibility constraints, peer dependencies, or runtime support
   limits make version choice non-trivial
 - use skill `ai-skills-version-support-policy` when the supported runtime or
@@ -45,8 +45,10 @@ forward as safely possible.
 4. Prefer explicit project policy when it already constrains a version.
 5. Otherwise prefer the newest stable compatible version, favoring maintained
    LTS lines when they materially improve runtime or toolchain stability.
-6. Sequence framework, platform, and build-tool choices before ordinary
-   dependency upgrades because they constrain the rest of the stack.
+6. Sequence framework and build-tool choices before ordinary dependency
+   upgrades because they constrain the rest of the stack; treat runtime or
+   platform versions as input constraints from support policy or repository
+   policy rather than outputs owned by this skill.
 7. Apply skill `ai-skills-compliance-dependency` when governance, license, or
    stewardship risk matters to the decision.
 8. Record the selected versions, rejected candidates, and the concrete reason
@@ -64,7 +66,8 @@ forward as safely possible.
   stack constraints
 - do not skip peer, runtime, framework, or build-tool compatibility checks
 - do not treat prerelease, unstable, or EOL versions as default choices
-- do not broaden this skill into semantic release-version bump selection
+- do not broaden this skill into semantic release-version bump selection or
+  runtime or platform support-policy ownership
 
 # Exit Checks
 
@@ -72,5 +75,6 @@ forward as safely possible.
 - the newest stable viable option was preferred unless project policy says
   otherwise
 - framework and build-tool constraints were resolved before ordinary
-  dependency choices
+  dependency choices, and runtime or platform policy constraints were
+  respected
 - compliance or stewardship concerns were surfaced when they mattered

--- a/skills/ai-skills-version-support-policy/SKILL.md
+++ b/skills/ai-skills-version-support-policy/SKILL.md
@@ -19,8 +19,9 @@ documentation, CI, and compatibility promises all align.
   support statement
 - use when adding or removing supported versions for a library, service, CLI,
   or application
-- use before dependency-selection work when supported versions constrain which
-  frameworks, tools, or dependencies remain viable
+- use skill `ai-skills-version-dependency-selection` after support policy
+  decisions when supported versions constrain which frameworks, tools, or
+  dependencies remain viable
 
 # Inputs
 

--- a/skills/ai-skills-version-support-policy/SKILL.md
+++ b/skills/ai-skills-version-support-policy/SKILL.md
@@ -19,9 +19,8 @@ documentation, CI, and compatibility promises all align.
   support statement
 - use when adding or removing supported versions for a library, service, CLI,
   or application
-- use skill `ai-skills-version-dependency-selection` after support policy
-  decisions when supported versions constrain which frameworks, tools, or
-  dependencies remain viable
+- use before skill `ai-skills-version-dependency-selection` when supported
+  versions constrain which frameworks, tools, or dependencies remain viable
 
 # Inputs
 


### PR DESCRIPTION
## Summary
- add the canonical `ai-skills-version-dependency-selection` skill bundle
- keep dependency, framework, and build-tool version choice separate from release semver bump selection
- complete the release-skill composition and backfill the explicit sibling reference from support policy to dependency selection

## Why
The version family needs a dedicated dependency-selection leaf skill so reusable compatibility-first version choice is separated from both release tagging decisions and support-policy ownership.

## Validation
- `corepack pnpm lint:md`
- `corepack pnpm validate`
- `corepack pnpm test`
- `corepack pnpm quality:cognitive`
- `corepack pnpm quality:crap`
- `corepack pnpm pack:dry-run`

Closes #179