### PR TITLE
Add bootstrap ci pipeline skill

### DIFF
--- a/skills/ai-skills-bootstrap-ci-pipeline/SKILL.md
+++ b/skills/ai-skills-bootstrap-ci-pipeline/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: ai-skills-bootstrap-ci-pipeline
+description: >-
+  Establish the initial CI pipeline for a project so build, lint, test, and
+  policy checks run consistently from the start.
+---
+<!-- markdownlint-disable MD025 -->
+
+# Purpose
+
+Create a safe initial CI baseline that executes the project's real quality
+checks with an explicit stage-family layout, without tying the workflow to one
+vendor, framework, or deployment path.
+
+# When to Use
+
+- use when a new project needs its first shared build, lint, test, or policy
+  automation
+- use when a repository exists but CI triggers, jobs, or status checks are not
+  established yet
+- use when the support matrix or default branch must be reflected in CI
+- use when GitLab stage ordering or the GitHub Actions analogue should follow a
+  consistent bootstrap layout
+- use skill `ai-skills-version-support-policy` when the official runtime or
+  platform matrix is still undecided and CI coverage depends on it
+- use `references/ci-layout-conventions.md` for the required GitLab stage order
+  and the GitHub Actions naming and grouping analogue
+
+# Inputs
+
+- the repository location and default-branch workflow
+- the language, framework, package-manager, and build-tool commands the
+  project actually uses
+- the required baseline checks such as build, lint, test, package, or
+  validation
+- branch, PR, and merge-gate expectations for CI execution
+- the target CI surface and any organization policy that constrains it
+- secret, token, cache, or artifact needs for the CI environment
+- `references/ci-layout-conventions.md`
+
+# Workflow
+
+1. Identify the minimum required automated checks for a healthy project
+   baseline.
+2. Confirm which runtime or platform versions CI must cover; if the support
+   matrix is still open, apply skill `ai-skills-version-support-policy` before
+   freezing the CI matrix.
+3. Choose the CI execution surface that fits the repository and organization
+   policy without assuming a specific vendor.
+4. Map the required checks into the shared stage-family layout from
+   `references/ci-layout-conventions.md`.
+5. If the target platform is GitLab CI, encode the pipeline stages in this
+   order: `build`, `test`, `package`, `verify`, `publish`, `tools`.
+6. In GitLab CI, use the stage families with these meanings:
+   `build` for compile, assemble, dependency installation, or generated
+   sources; `test` for unit tests; `package` for artifact creation; `verify`
+   for integration tests, security or quality gates, and reports; `publish`
+   for registry or artifact publication; `tools` for manual helper jobs.
+7. If the target platform is GitHub Actions, group jobs under one workflow
+   category such as `CI`, `Release`, or `Nightly`, use job `needs` for
+   ordering, and encode the stage family in job names such as `build`,
+   `test / unit`, `package`, `verify / integration`, `verify / owasp`,
+   `publish`, or `tools / ...`.
+8. When GitHub required checks depend on job names, keep those job names unique
+   across workflows so branch protection stays unambiguous.
+9. Define the initial triggers, jobs, and status expectations around the real
+   project commands rather than placeholder commands.
+10. Configure secrets, caches, and artifacts conservatively so CI can run
+   safely without overscoping credentials.
+11. Record how CI status feeds later bootstrap, merge, or release workflows.
+
+# Outputs
+
+- an explicit CI baseline covering the project's required checks
+- a stage-family layout that fits the chosen CI platform
+- a defined trigger and status model for branch and PR workflows
+- a conservative secret and artifact-handling approach for CI
+
+# Guardrails
+
+- do not assume GitHub Actions, GitLab CI, Jenkins, or any single CI product
+- do not add deployment or release automation unless the request includes it
+- do not rely on placeholder commands that the repository cannot actually run
+- do not collapse the pipeline into unnamed generic jobs when stage-family
+  intent should stay explicit
+- do not require broad or long-lived secrets when safer alternatives exist
+
+# Exit Checks
+
+- the CI baseline maps to real build, lint, test, package, or validation
+  commands
+- the stage-family layout is explicit for the chosen CI platform
+- GitLab pipelines use the required stage order, or GitHub Actions workflows
+  encode the required analogue with `needs` and unique job names
+- the supported runtime or platform matrix is explicit or an upstream blocker
+  is surfaced
+- trigger behavior and merge-status expectations are explicit
+- secret and artifact handling are narrow enough for initial project setup

--- a/skills/ai-skills-bootstrap-ci-pipeline/references/ci-layout-conventions.md
+++ b/skills/ai-skills-bootstrap-ci-pipeline/references/ci-layout-conventions.md
@@ -1,0 +1,40 @@
+# CI Layout Conventions
+
+Use these conventions when the project wants a portable CI bootstrap layout
+that can be expressed in both GitLab CI and GitHub Actions.
+
+## GitLab Stage Order
+
+Use this stage order:
+
+1. `build`
+2. `test`
+3. `package`
+4. `verify`
+5. `publish`
+6. `tools`
+
+Stage meanings:
+
+- `build`: compile, assemble, dependency installation, generated sources
+- `test`: unit tests
+- `package`: artifact creation
+- `verify`: integration tests, security or quality gates, reports
+- `publish`: registry or artifact publication
+- `tools`: manual helper jobs
+
+## GitHub Actions Analogue
+
+GitHub Actions has no native stage list, so express the same layout with these
+rules:
+
+- use one workflow-level category name such as `CI`, `Release`, or `Nightly`
+- order jobs with `needs`
+- encode the stage family in job names such as `build`, `test / unit`,
+  `package`, `verify / integration`, `verify / owasp`, `publish`, or
+  `tools / ...`
+- keep job names unique across workflows when required checks are used so
+  branch-protection rules stay stable
+
+Apply the layout to the repository's real commands rather than placeholder
+commands.


### PR DESCRIPTION
## Summary
- add the canonical `ai-skills-bootstrap-ci-pipeline` leaf skill bundle
- encode the required GitLab stage order and stage meanings explicitly
- capture the GitHub Actions analogue for workflow grouping, `needs` ordering, and stable job naming

## Why
Bootstrap needs a portable CI setup skill that stays vendor-agnostic while still preserving the concrete layout conventions recovered in issue `#170`.

## Validation
- `corepack pnpm lint:md`
- `corepack pnpm validate`
- `corepack pnpm test`
- `corepack pnpm quality:cognitive`
- `corepack pnpm quality:crap`
- `corepack pnpm pack:dry-run`

Closes #170