### PR TITLE
Align framework setup exit checks with deferred defaults

### DIFF
--- a/skills/ai-skills-bootstrap-framework-setup/SKILL.md
+++ b/skills/ai-skills-bootstrap-framework-setup/SKILL.md
@@ -70,5 +70,5 @@ repository can build, test, and evolve on an explicit stack.
 - the framework, runtime, and toolchain choices are explicit
 - unresolved version-selection questions are settled or surfaced clearly
 - the baseline includes real development, build, and test entrypoints
-- accepted and overridden scaffold defaults are documented clearly enough for
-  follow-up work
+- accepted, overridden, and deferred scaffold defaults are documented clearly
+  enough for follow-up work


### PR DESCRIPTION
## Summary
- update `ai-skills-bootstrap-framework-setup` exit checks to require deferred scaffold defaults to be documented
- align the exit contract with the skill workflow that already records accepted, overridden, and intentionally deferred defaults

## Why
A late review on the merged framework-setup PR identified that the skill could exit successfully without documenting deferred scaffold defaults even though the workflow explicitly records them.

## Validation
- `corepack pnpm lint:md`
- `corepack pnpm validate`
- `corepack pnpm test`
- `corepack pnpm quality:cognitive`
- `corepack pnpm quality:crap`
- `corepack pnpm pack:dry-run`

Closes #172