### PR TITLE
Add prompt-caching conventions skill

### DIFF
--- a/skills/ai-skills-conventions-prompt-caching/SKILL.md
+++ b/skills/ai-skills-conventions-prompt-caching/SKILL.md
@@ -18,8 +18,8 @@ on repeated invocations.
 # When to Use
 
 - use when authoring or revising a skill bundle whose `SKILL.md` and any
-  references, examples, or templates files are intended to be reused
-  across many invocations
+  reference, example, or template files are intended to be reused across
+  many invocations
 - use when structuring a prompt that will be replayed with only minor
   per-request variations (different user input, different target file,
   different chosen example)
@@ -41,9 +41,10 @@ on repeated invocations.
 - the cache-hit and cache-creation token counts from recent runs when
   available, used to detect the antipattern of a breakpoint on changing
   content
-- the target Claude model and its minimum cacheable-prefix size
-  (Opus and Haiku require 4,096 tokens; Sonnet and older Opus require
-  1,024 tokens)
+- the target Claude model and its minimum cacheable-prefix size, as
+  published in Anthropic's current prompt-caching documentation; the
+  cache will not be used when the prefix is below the published
+  threshold even with a correct breakpoint
 - `references/cache-breakpoint-placement.md`
 - `references/skill-structure-for-caching.md`
 
@@ -74,9 +75,10 @@ on repeated invocations.
    `cache_read_input_tokens` should grow as cached prefixes are reused;
    persistently high `cache_creation_input_tokens` on every call means a
    breakpoint sits on changing content and must be moved earlier.
-8. Confirm the cacheable prefix meets the model's minimum size before
-   relying on caching. Below the threshold the cache will not be used
-   even with a correct breakpoint.
+8. Confirm the cacheable prefix meets the target model's minimum size as
+   published in the current Anthropic prompt-caching documentation
+   before relying on caching. Below the published threshold the cache
+   will not be used even with a correct breakpoint.
 9. For skill bundles, keep the SKILL.md section order from the catalog
    spec (Purpose → When to Use → Inputs → Workflow → Outputs →
    Guardrails → Exit Checks) and treat the bundle reference files as
@@ -104,7 +106,8 @@ on repeated invocations.
   references; keep variable content trailing
 - do not exceed four cache breakpoints in a single prompt
 - do not assume caching is active when the cacheable prefix is below the
-  model's minimum size threshold; verify by reading the usage block
+  target model's published minimum size threshold; verify by reading the
+  response usage block
 - do not edit reference, example, or template files inside a skill bundle
   as part of normal per-request work; treat them as immutable between
   releases so the cached prefix stays valid
@@ -118,7 +121,8 @@ on repeated invocations.
 - the last `cache_control` breakpoint sits on a byte-stable block, not on
   changing content
 - the total number of breakpoints is at most four
-- the cacheable prefix meets the target model's minimum token threshold
+- the cacheable prefix meets the target model's published minimum token
+  threshold
 - a representative invocation shows `cache_read_input_tokens` growing on
   reuse and `cache_creation_input_tokens` falling toward zero after the
   first warm-up call

--- a/skills/ai-skills-conventions-prompt-caching/SKILL.md
+++ b/skills/ai-skills-conventions-prompt-caching/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: ai-skills-conventions-prompt-caching
+description: >-
+  Structure prompts and skill bundles so the static prefix stays stable across
+  invocations and Anthropic prompt-prefix caching can hit instead of rebuild.
+---
+<!-- markdownlint-disable MD025 -->
+
+# Purpose
+
+Apply the default prompt-prefix-caching conventions so that the static
+portion of a prompt or skill bundle stays byte-identical across invocations,
+the cache breakpoint is placed on the last stable block, and per-request
+variable content is appended last. The goal is to keep
+`cache_read_input_tokens` high and `cache_creation_input_tokens` near zero
+on repeated invocations.
+
+# When to Use
+
+- use when authoring or revising a skill bundle whose `SKILL.md` and any
+  references, examples, or templates files are intended to be reused
+  across many invocations
+- use when structuring a prompt that will be replayed with only minor
+  per-request variations (different user input, different target file,
+  different chosen example)
+- use when reviewing an existing skill or prompt that exhibits low cache
+  hit rates or high per-request token cost
+- use `references/cache-breakpoint-placement.md` for the decision framework
+  on where the last cache breakpoint belongs
+- use `references/skill-structure-for-caching.md` for how the canonical
+  SKILL.md section order keeps a long stable prefix
+- use `examples/cache-control-correct.md` when communicating the expected
+  correct-vs-incorrect breakpoint placement
+
+# Inputs
+
+- the prompt or skill bundle whose prefix stability is in scope
+- the set of blocks the model will see in order: tools, system, references,
+  prior turns, and the current variable input
+- which blocks change per invocation versus which stay byte-identical
+- the cache-hit and cache-creation token counts from recent runs when
+  available, used to detect the antipattern of a breakpoint on changing
+  content
+- the target Claude model and its minimum cacheable-prefix size
+  (Opus and Haiku require 4,096 tokens; Sonnet and older Opus require
+  1,024 tokens)
+- `references/cache-breakpoint-placement.md`
+- `references/skill-structure-for-caching.md`
+
+# Workflow
+
+1. Order content static-first: tools, then system, then long-lived
+   references and examples, then prior turns, then the current variable
+   input last. Variable content at the front breaks the prefix for every
+   invocation.
+2. Identify the last byte-stable block in the ordered sequence. That is
+   the block whose content is identical across the next batch of expected
+   invocations.
+3. Place a single `cache_control` breakpoint on that last stable block.
+   Never place a breakpoint on a block whose content changes per request
+   (timestamps, user input, chosen target file), because that forces a
+   cache rewrite every call.
+4. Keep the static prefix above any breakpoint within the 20-block
+   lookback window the cache uses; if a new long-lived block has to be
+   added past the breakpoint, move the breakpoint forward rather than
+   appending past it.
+5. For multi-turn conversations, rely on the automatic breakpoint that
+   advances per request rather than hand-placing breakpoints on each
+   turn.
+6. When tools, system, long-lived references, and messages change at
+   different cadences, use up to four explicit breakpoints — one at the
+   trailing edge of each cadence band — but do not exceed four.
+7. After a representative run, inspect the response usage:
+   `cache_read_input_tokens` should grow as cached prefixes are reused;
+   persistently high `cache_creation_input_tokens` on every call means a
+   breakpoint sits on changing content and must be moved earlier.
+8. Confirm the cacheable prefix meets the model's minimum size before
+   relying on caching. Below the threshold the cache will not be used
+   even with a correct breakpoint.
+9. For skill bundles, keep the SKILL.md section order from the catalog
+   spec (Purpose → When to Use → Inputs → Workflow → Outputs →
+   Guardrails → Exit Checks) and treat the bundle reference files as
+   immutable between releases so they stay in the cached prefix across
+   invocations.
+
+# Outputs
+
+- a prompt or skill bundle whose static blocks come first and whose
+  variable per-request content comes last
+- a single trailing `cache_control` breakpoint on the last byte-stable
+  block, or up to four breakpoints aligned to the cadence bands
+- a measurement note for any non-obvious decision, citing the
+  `cache_read_input_tokens` and `cache_creation_input_tokens` values that
+  justified the breakpoint placement
+- a review finding when a prompt or skill places variable content ahead
+  of static content or puts a breakpoint on changing content
+
+# Guardrails
+
+- do not place `cache_control` on a block that changes per request, even
+  when it appears late in the prompt; the breakpoint must sit on a block
+  whose bytes are stable across the next batch of invocations
+- do not interleave per-request variable content with long-lived
+  references; keep variable content trailing
+- do not exceed four cache breakpoints in a single prompt
+- do not assume caching is active when the cacheable prefix is below the
+  model's minimum size threshold; verify by reading the usage block
+- do not edit reference, example, or template files inside a skill bundle
+  as part of normal per-request work; treat them as immutable between
+  releases so the cached prefix stays valid
+- do not silently move a breakpoint forward without confirming the
+  previous prefix was no longer being reused
+
+# Exit Checks
+
+- the static prefix (tools, system, long-lived references, examples)
+  precedes any per-request variable content
+- the last `cache_control` breakpoint sits on a byte-stable block, not on
+  changing content
+- the total number of breakpoints is at most four
+- the cacheable prefix meets the target model's minimum token threshold
+- a representative invocation shows `cache_read_input_tokens` growing on
+  reuse and `cache_creation_input_tokens` falling toward zero after the
+  first warm-up call
+- bundle reference and example files used inside the cached prefix are
+  treated as immutable between releases

--- a/skills/ai-skills-conventions-prompt-caching/examples/cache-control-correct.md
+++ b/skills/ai-skills-conventions-prompt-caching/examples/cache-control-correct.md
@@ -1,0 +1,38 @@
+# Example Cache Control Placement
+
+```text
+# Don't — breakpoint on changing content
+tools           (stable)
+system          (stable)
+references      (stable)
+user input      (changes per request)   <- cache_control HERE
+```
+
+The breakpoint sits on the per-request user input, so every call writes a
+new cache entry and reads nothing. `cache_creation_input_tokens` stays
+high on every call; `cache_read_input_tokens` stays near zero.
+
+```text
+# Do — breakpoint on the last stable block
+tools           (stable)
+system          (stable)
+references      (stable)                <- cache_control HERE
+user input      (changes per request)
+```
+
+The breakpoint sits on the trailing stable references block. The static
+prefix is reused on every call. After the first warm-up call,
+`cache_read_input_tokens` grows and `cache_creation_input_tokens` falls
+toward zero.
+
+```text
+# Do — up to four breakpoints when cadence bands differ
+tools           (changes rarely)        <- cache_control 1
+system          (changes per release)   <- cache_control 2
+long-lived refs (changes per release)   <- cache_control 3
+prior turns     (changes per session)   <- cache_control 4
+current input   (changes per request)
+```
+
+One breakpoint per cadence band, never on the trailing per-request block.
+Never use more than four breakpoints in a single prompt.

--- a/skills/ai-skills-conventions-prompt-caching/references/cache-breakpoint-placement.md
+++ b/skills/ai-skills-conventions-prompt-caching/references/cache-breakpoint-placement.md
@@ -21,9 +21,10 @@ authoring.
 - For multi-turn conversations the automatic breakpoint advances per
   request; do not hand-place additional breakpoints per turn unless a
   cadence band needs its own breakpoint.
-- Confirm the cacheable prefix meets the model minimum: Claude Opus and
-  Haiku require 4,096 tokens, Sonnet and older Opus require 1,024 tokens.
-  Below the threshold the cache will not be used even with a correct
+- Confirm the cacheable prefix meets the target model's published
+  minimum cacheable-prefix size. Anthropic's current prompt-caching
+  documentation is the source of truth for per-model thresholds; below
+  the published threshold the cache will not be used even with a correct
   breakpoint.
 - Use the response `usage` block to verify placement:
   `cache_read_input_tokens` should grow as cached prefixes are reused;

--- a/skills/ai-skills-conventions-prompt-caching/references/cache-breakpoint-placement.md
+++ b/skills/ai-skills-conventions-prompt-caching/references/cache-breakpoint-placement.md
@@ -1,0 +1,31 @@
+# Cache Breakpoint Placement
+
+Distilled from Anthropic prompt-caching guidance, adapted to skill-bundle
+authoring.
+
+- Identify the last block in the ordered prompt sequence (tools → system →
+  long-lived references → prior turns → current variable input) whose bytes
+  are identical across the next batch of expected invocations.
+- Place a single `cache_control` breakpoint on that block, not on any
+  earlier block, so the cache spans the full stable prefix.
+- Never place a breakpoint on a block whose content changes per request:
+  per-task user input, current file path, timestamp, or any rendered
+  per-invocation context. A breakpoint on changing content forces a cache
+  rewrite on every call.
+- Respect the 20-block lookback window: when a new long-lived block has to
+  be added past the existing breakpoint, move the breakpoint forward
+  rather than appending past it and relying on lookback.
+- When tools, system, long-lived references, and messages change at
+  different cadences, use up to four breakpoints — one at the trailing
+  edge of each cadence band. Do not exceed four.
+- For multi-turn conversations the automatic breakpoint advances per
+  request; do not hand-place additional breakpoints per turn unless a
+  cadence band needs its own breakpoint.
+- Confirm the cacheable prefix meets the model minimum: Claude Opus and
+  Haiku require 4,096 tokens, Sonnet and older Opus require 1,024 tokens.
+  Below the threshold the cache will not be used even with a correct
+  breakpoint.
+- Use the response `usage` block to verify placement:
+  `cache_read_input_tokens` should grow as cached prefixes are reused;
+  persistently high `cache_creation_input_tokens` means the breakpoint sits
+  on changing content and must be moved earlier.

--- a/skills/ai-skills-conventions-prompt-caching/references/skill-structure-for-caching.md
+++ b/skills/ai-skills-conventions-prompt-caching/references/skill-structure-for-caching.md
@@ -1,0 +1,30 @@
+# Skill Structure For Caching
+
+Distilled from the canonical `SKILL.md` contract in `spec.md`, viewed
+through the lens of prompt-prefix caching.
+
+- The canonical SKILL.md section order — Purpose, When to Use, Inputs,
+  Workflow, Outputs, Guardrails, Exit Checks — already produces a long
+  stable prefix; preserve that order so the cached prefix stays valid
+  across invocations.
+- Treat files under the reference, example, and template directories as
+  immutable between releases. They are part of the cached prefix when
+  loaded; per-request edits invalidate the cache for every consumer of
+  the skill.
+- Per-task variable content (the user request, the current diff, the
+  target file path) must arrive in the prompt after the bundle's static
+  blocks, never woven into the reference or example files.
+- Render skill inputs as appended user-message content rather than as
+  patched references; the reference text stays byte-stable and the input
+  stays trailing.
+- When a skill needs alternative behavior for a target platform, put the
+  variation in the per-target notes file instead of editing the shared
+  bundle; the shared bundle remains byte-stable across targets and stays
+  cacheable.
+- For composite skills, prefer referencing child skills by their canonical
+  skill id form rather than inlining their text; the inlined text would
+  duplicate bytes across many bundles and fragment the cache.
+- When a SKILL.md section unavoidably needs per-release evolution, edit
+  in a single release-prep commit rather than ad-hoc edits across
+  unrelated work, so the cached prefix flips once per release rather than
+  drifting continuously.

--- a/skills/ai-skills-skill-improve/SKILL.md
+++ b/skills/ai-skills-skill-improve/SKILL.md
@@ -33,6 +33,9 @@ during unrelated daily work.
   `examples/local-skill-improvement-entry.md` when a concrete rendered example
   helps
 - use skill `ai-skills-skill-template` to normalize the canonical field set before rendering
+- use skill `ai-skills-conventions-prompt-caching` when the proposed improvement
+  changes bundle structure, section ordering, or reference content in ways that
+  affect prompt-prefix cache hits
 - use skill `ai-skills-formatting-github-comment` when the GitHub issue body still needs final
   Markdown normalization
 

--- a/skills/ai-skills-skill-new/SKILL.md
+++ b/skills/ai-skills-skill-new/SKILL.md
@@ -30,6 +30,9 @@ important context.
 - use `targets/github-issue.md` and `targets/local-backlog-entry.md` when a
   concrete rendered target artifact helps
 - use skill `ai-skills-skill-template` to normalize the canonical field set before rendering
+- use skill `ai-skills-conventions-prompt-caching` when the new skill is meant
+  to be reused across many invocations and the bundle should be authored for
+  prompt-prefix cache hits
 - use skill `ai-skills-formatting-github-comment` when the GitHub issue body still needs final
   Markdown normalization
 

--- a/skills/ai-skills-skill-template/SKILL.md
+++ b/skills/ai-skills-skill-template/SKILL.md
@@ -26,6 +26,9 @@ Markdown records.
 - use `examples/new-skill-example.md`, `examples/improve-skill-example.md`, and
   `examples/new-skill.md` as examples of the canonical field set and its
   rendered output
+- use skill `ai-skills-conventions-prompt-caching` when the captured backlog
+  entry will lead to an implementation whose bundle is expected to be reused
+  across many invocations and the cached prefix matters
 
 # Inputs
 


### PR DESCRIPTION
## Summary

- New `ai-skills-conventions-prompt-caching` leaf skill capturing Anthropic prompt-prefix-caching principles: order content static-first, place `cache_control` on the last byte-stable block (never on changing content), respect the 20-block lookback window, use at most four breakpoints across cadence bands, and verify with `cache_read_input_tokens` vs `cache_creation_input_tokens`.
- Two references (`cache-breakpoint-placement.md`, `skill-structure-for-caching.md`) and one example (`cache-control-correct.md`) under the new skill.
- Cross-linked from the three authoring/capture skills (`ai-skills-skill-improve`, `ai-skills-skill-new`, `ai-skills-skill-template`) via a single When-to-Use line each.

Closes #193.

## Test plan

- [x] `corepack pnpm validate` — catalog validation passes (45 skills).
- [x] `corepack pnpm lint:md` — 167 files, 0 errors.
- [x] `corepack pnpm test` — 2 test files / 16 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)