### PR TITLE
Add tag-triggered npm release workflow (first publish)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,14 @@ jobs:
       - name: Build
         run: corepack pnpm build
 
-      - name: Test and quality gates
+      - name: Tests
         run: corepack pnpm test
+
+      - name: Cognitive complexity gate
+        run: corepack pnpm quality:cognitive
+
+      - name: CRAP gate
+        run: corepack pnpm quality:crap
 
       - name: Validate catalog
         run: corepack pnpm validate
@@ -49,7 +55,20 @@ jobs:
       - name: Package dry run
         run: corepack pnpm pack:dry-run
 
+      - name: Check if version is already published
+        id: published
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          if npm view "@barney-media/ai-skills@${version}" version >/dev/null 2>&1; then
+            echo "already_published=true" >> "${GITHUB_OUTPUT}"
+            echo "Version ${version} is already on npm; skipping publish."
+          else
+            echo "already_published=false" >> "${GITHUB_OUTPUT}"
+          fi
+
       - name: Publish to npm
+        if: steps.published.outputs.already_published == 'false'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    name: Publish Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: corepack pnpm install --frozen-lockfile
+
+      - name: Verify release version
+        run: node ./scripts/verify-release-version.mjs "${GITHUB_REF_NAME}"
+
+      - name: Render release notes
+        run: node ./scripts/render-release-notes.mjs "${GITHUB_REF_NAME}" > release-notes.md
+
+      - name: Build
+        run: corepack pnpm build
+
+      - name: Test and quality gates
+        run: corepack pnpm test
+
+      - name: Validate catalog
+        run: corepack pnpm validate
+
+      - name: Package dry run
+        run: corepack pnpm pack:dry-run
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public
+
+      - name: Create or update GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            gh release edit "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --notes-file release-notes.md
+          else
+            gh release create "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --notes-file release-notes.md
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.1.0 - 2026-05-01
+## 0.1.0 - 2026-05-19
 
 Initial public release of `@barney-media/ai-skills`.
 
@@ -13,6 +13,8 @@ Initial public release of `@barney-media/ai-skills`.
   directories.
 - Added cross-platform package verification for Windows, macOS, and Linux.
 - Added internal catalog validation for build, package, and release verification.
+- Added the `ai-skills-conventions-prompt-caching` skill capturing Anthropic prompt-prefix caching conventions for
+  authoring stable, cacheable skill bundles.
 
 ### Install and Update Behavior
 

--- a/scripts/render-release-notes.mjs
+++ b/scripts/render-release-notes.mjs
@@ -1,0 +1,36 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+const tagRef = process.env.GITHUB_REF_NAME ?? process.argv[2];
+if (!tagRef) {
+  throw new Error("A tag name is required.");
+}
+
+const expectedVersion = tagRef.startsWith("v") ? tagRef.slice(1) : tagRef;
+const changelog = await readFile(path.resolve("CHANGELOG.md"), "utf8");
+const lines = changelog.replace(/\r\n/g, "\n").split("\n");
+
+const headerPattern = new RegExp(
+  `^##\\s+\\[?${expectedVersion.replace(/\./g, "\\.")}\\]?(?:\\s|$)`
+);
+const startIndex = lines.findIndex((line) => headerPattern.test(line));
+
+if (startIndex === -1) {
+  throw new Error(`CHANGELOG.md does not contain a section for ${expectedVersion}.`);
+}
+
+const sectionLines = [];
+for (let index = startIndex + 1; index < lines.length; index += 1) {
+  const line = lines[index];
+  if (/^##\s/.test(line)) {
+    break;
+  }
+  sectionLines.push(line);
+}
+
+const releaseNotes = sectionLines.join("\n").trim();
+if (!releaseNotes) {
+  throw new Error(`CHANGELOG.md section ${expectedVersion} is empty.`);
+}
+
+process.stdout.write(`${releaseNotes}\n`);

--- a/scripts/verify-release-version.mjs
+++ b/scripts/verify-release-version.mjs
@@ -1,0 +1,16 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+const tagRef = process.env.GITHUB_REF_NAME ?? process.argv[2];
+if (!tagRef) {
+  throw new Error("A tag name is required.");
+}
+
+const expectedVersion = tagRef.startsWith("v") ? tagRef.slice(1) : tagRef;
+const raw = await readFile(path.resolve("package.json"), "utf8");
+const parsed = JSON.parse(raw);
+if (parsed.version !== expectedVersion) {
+  throw new Error(
+    `package.json has version ${parsed.version}, expected ${expectedVersion}`
+  );
+}


### PR DESCRIPTION
## Summary

- New `.github/workflows/release.yml` — tag-triggered (`push: tags: v*`) single publish job mirroring [`fabian-barney/cognitive-typescript`](https://github.com/fabian-barney/cognitive-typescript/blob/main/.github/workflows/release.yml). For this **first** release it authenticates via `NODE_AUTH_TOKEN` sourced from the `NPM_TOKEN` repo secret; a follow-up will switch to OIDC trusted publishing once the package exists on npm.
- New `scripts/verify-release-version.mjs` — fails the workflow if the pushed tag does not match `package.json` version.
- New `scripts/render-release-notes.mjs` — extracts the `CHANGELOG.md` section for the tag's version to use as the GitHub Release body. Tolerates both `## 0.1.0 - DATE` and `## [0.1.0] - DATE` header forms.
- `CHANGELOG.md` — set the 0.1.0 release date to the actual publish date (`2026-05-19`); added a bullet for the new `ai-skills-conventions-prompt-caching` skill that merged in #194.

After merge, tagging `v0.1.0` will fire the workflow and produce the first published artifact on npm.

Closes #121.

## Test plan

- [x] `node ./scripts/verify-release-version.mjs v0.1.0` exits clean against the current `package.json`.
- [x] `node ./scripts/render-release-notes.mjs v0.1.0` prints the expected 0.1.0 changelog section.
- [x] `corepack pnpm validate` — 45 skills.
- [x] `corepack pnpm lint:md` — 0 errors.
- [x] `corepack pnpm pack:dry-run` — 169 files, 99.8 kB, includes the new prompt-caching skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)