### PR TITLE
Switch release workflow to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   publish:
@@ -69,8 +70,6 @@ jobs:
 
       - name: Publish to npm
         if: steps.published.outputs.already_published == 'false'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access public
 
       - name: Create or update GitHub release


### PR DESCRIPTION
## Summary

- `permissions: id-token: write` added so the runner can mint the OIDC token npm uses to authenticate trusted publishing.
- `env: NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` removed from the publish step — the npm CLI picks up the OIDC token automatically once a trusted publisher matches the workflow.
- Everything else (precheck, GitHub Release creation, tests + cognitive + CRAP gates) stays as-is.

User has already configured the trusted publisher on npm: `@barney-media/ai-skills` → GitHub Actions publisher targeting `fabian-barney/ai-skills` workflow `release.yml`.

After the next tag publishes successfully via OIDC, the leftover `NPM_TOKEN` repo secret and matching npm Automation token can be revoked (as noted in #196 acceptance criteria).

Closes #196.

## Test plan

- [x] Diff is the minimal two-line change (one added permission, one removed env block).
- [ ] Next legitimate release tag (e.g. `v0.1.1`) publishes via OIDC with no `NPM_TOKEN` env in the workflow.
- [ ] `NPM_TOKEN` repo secret + matching npm Automation token revoked after the verifying release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)