### PR TITLE
chore: drop Node 20 support (EOL)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "prepack": "node tools/validate-catalog.mjs && tsc -p tsconfig.json"
   },
   "engines": {
-    "node": ">=20.11"
+    "node": ">=22.12.0"
   },
   "packageManager": "pnpm@11.1.2",
   "publishConfig": {


### PR DESCRIPTION
## Summary

Node.js 20 reached end-of-life on **2026-04-30**. The previous `engines` constraint of `>=20.11` admitted Node 20 explicitly as the floor.

- `engines`: `>=20.11` → `>=22.12.0`

CI already runs Node 24 only — no workflow changes needed. `pnpm-lock.yaml` does not encode the consumer's root engines field, so no lockfile regeneration is required.

## Test plan

- [ ] CI passes
- [ ] `corepack pnpm install --frozen-lockfile` succeeds locally on Node 22.12.0 or newer

🤖 Generated with [Claude Code](https://claude.com/claude-code)