### PR TITLE
Make GH Copilot review trigger explicit in review loop

### DIFF
--- a/skills/ai-skills-pr-review-loop/SKILL.md
+++ b/skills/ai-skills-pr-review-loop/SKILL.md
@@ -71,8 +71,9 @@ after the latest push has been reviewed.
 6. If the latest push does not yet have a submitted automated review, request
    one through the platform API or configured review mechanism, then move on to
    the next item without blocking. For strict GitHub Copilot review loops,
-   first capture the PR node id with `gh pr view --json id --jq .id`, then call
-   `gh api graphql` using the `requestReviewsByLogin` mutation for
+   first capture the PR node id with
+   `gh pr view <PR_NUMBER> --json id --jq .id`, then call `gh api graphql`
+   using the `requestReviewsByLogin` mutation for
    `copilot-pull-request-reviewer`, and treat
    `references/copilot-review-trigger.md` as the copy-safe source for the exact
    mutation and verification steps.

--- a/skills/ai-skills-pr-review-loop/SKILL.md
+++ b/skills/ai-skills-pr-review-loop/SKILL.md
@@ -72,7 +72,7 @@ after the latest push has been reviewed.
    one through the platform API or configured review mechanism, then move on to
    the next item without blocking. For strict GitHub Copilot review loops,
    first capture the PR node id with `gh pr view --json id --jq .id`, then call
-   `gh api graphql` with `requestReviewsByLogin` for
+   `gh api graphql` using the `requestReviewsByLogin` mutation for
    `copilot-pull-request-reviewer`, and treat
    `references/copilot-review-trigger.md` as the copy-safe source for the exact
    mutation and verification steps.

--- a/skills/ai-skills-pr-review-loop/SKILL.md
+++ b/skills/ai-skills-pr-review-loop/SKILL.md
@@ -41,8 +41,9 @@ after the latest push has been reviewed.
   checks for each PR
 - repository preferences about whether clean PRs should be merged
 - access to the PR platform APIs needed to request or inspect automated review
-- for strict GitHub Copilot review loops, access to `gh pr view --json id`
-  and `gh api graphql` for the approved review-request flow
+- for strict GitHub Copilot review loops, access to
+  `gh pr view <PR_NUMBER> --json id --jq .id` and `gh api graphql` for the
+  approved review-request flow
 - the main linked issue for each PR and whether the PR body contains an
   issue-closing link
 - the intended bounded scope for each PR, used to detect unrelated bundled

--- a/skills/ai-skills-pr-review-loop/SKILL.md
+++ b/skills/ai-skills-pr-review-loop/SKILL.md
@@ -121,9 +121,9 @@ after the latest push has been reviewed.
   remain unresolved
 - do not trigger automated review through ad-hoc PR comments when the platform
   provides a proper API or workflow trigger
-- do not replace the approved `gh pr view` plus `gh api graphql
-  requestReviewsByLogin` flow with a weaker GitHub comment convention when
-  strict GitHub Copilot review is required
+- do not replace the approved `gh pr view` plus
+  `gh api graphql requestReviewsByLogin` flow with a weaker GitHub comment
+  convention when strict GitHub Copilot review is required
 - do not mention `@copilot` in PR comments
 - do not delete review comments to make threads disappear; resolve handled
   threads and preserve the history

--- a/skills/ai-skills-pr-review-loop/SKILL.md
+++ b/skills/ai-skills-pr-review-loop/SKILL.md
@@ -122,8 +122,9 @@ after the latest push has been reviewed.
 - do not trigger automated review through ad-hoc PR comments when the platform
   provides a proper API or workflow trigger
 - do not replace the approved `gh pr view` plus
-  `gh api graphql requestReviewsByLogin` flow with a weaker GitHub comment
-  convention when strict GitHub Copilot review is required
+  `gh api graphql` flow using the `requestReviewsByLogin` mutation with a
+  weaker GitHub comment convention when strict GitHub Copilot review is
+  required
 - do not mention `@copilot` in PR comments
 - do not delete review comments to make threads disappear; resolve handled
   threads and preserve the history

--- a/skills/ai-skills-pr-review-loop/SKILL.md
+++ b/skills/ai-skills-pr-review-loop/SKILL.md
@@ -41,6 +41,8 @@ after the latest push has been reviewed.
   checks for each PR
 - repository preferences about whether clean PRs should be merged
 - access to the PR platform APIs needed to request or inspect automated review
+- for strict GitHub Copilot review loops, access to `gh pr view --json id`
+  and `gh api graphql` for the approved review-request flow
 - the main linked issue for each PR and whether the PR body contains an
   issue-closing link
 - the intended bounded scope for each PR, used to detect unrelated bundled
@@ -68,8 +70,12 @@ after the latest push has been reviewed.
    threads, and determine whether a post-push automated review already exists.
 6. If the latest push does not yet have a submitted automated review, request
    one through the platform API or configured review mechanism, then move on to
-   the next item without blocking. For strict GitHub Copilot review loops, use
-   `references/copilot-review-trigger.md`.
+   the next item without blocking. For strict GitHub Copilot review loops,
+   first capture the PR node id with `gh pr view --json id --jq .id`, then call
+   `gh api graphql` with `requestReviewsByLogin` for
+   `copilot-pull-request-reviewer`, and treat
+   `references/copilot-review-trigger.md` as the copy-safe source for the exact
+   mutation and verification steps.
 7. If checks are still running or a review is still in progress for the latest
    push, keep the PR active and continue with the next item.
 8. When the latest push has completed review results, apply
@@ -78,7 +84,9 @@ after the latest push has been reviewed.
    threads that were actually handled.
 9. If fixes were pushed, restart the same post-push review cycle for that PR
    instead of treating earlier review results as sufficient, and explicitly
-   re-trigger automated review for the new head commit.
+   re-trigger automated review for the new head commit. For strict GitHub
+   Copilot review loops, repeat the same approved `gh` CLI / GraphQL flow
+   instead of using PR comments or `@copilot` mentions.
 10. If no fixes were needed, verify the PR remains focused on the linked issue
    and the PR body contains the issue-closing link, then evaluate the
    review-readiness gate from `references/review-loop-state.md`.
@@ -93,6 +101,8 @@ after the latest push has been reviewed.
 
 - a per-PR status showing review state, remaining blockers, and merge
   readiness
+- explicit note when strict GitHub Copilot review was requested through the
+  approved `gh` / GraphQL flow for the latest head commit
 - captured session preferences or explicit note that the loop was skipped
 - handled review threads with explicit valid, invalid, or unresolved treatment
 - issue-link and focused-scope status for each PR
@@ -111,6 +121,9 @@ after the latest push has been reviewed.
   remain unresolved
 - do not trigger automated review through ad-hoc PR comments when the platform
   provides a proper API or workflow trigger
+- do not replace the approved `gh pr view` plus `gh api graphql
+  requestReviewsByLogin` flow with a weaker GitHub comment convention when
+  strict GitHub Copilot review is required
 - do not mention `@copilot` in PR comments
 - do not delete review comments to make threads disappear; resolve handled
   threads and preserve the history
@@ -124,6 +137,9 @@ after the latest push has been reviewed.
   user prompt
 - no PR is marked merge-ready without a completed post-push review for its
   latest head commit
+- when strict GitHub Copilot review is required, the latest head commit review
+  came from the approved `gh` / GraphQL trigger flow or already-existing fresh
+  platform review state
 - each merge-ready PR is focused on its linked issue and has an issue-closing
   link in the PR body
 - remaining blockers are concrete, not generic

--- a/skills/ai-skills-pr-review-loop/examples/review-loop-status.md
+++ b/skills/ai-skills-pr-review-loop/examples/review-loop-status.md
@@ -3,6 +3,7 @@
 - `#71` skill `ai-skills-compliance-dependency`: checks green, issue link present, focused scope,
   no valid findings, no open review threads, waiting only for merge execution
 - `#72` skill `ai-skills-performance-db`: one valid finding fixed and pushed, post-push review
-  requested, checks still running
-- `#73` skill `ai-skills-release-github`: no review submitted yet for the latest push, automated
-  review requested, loop moved on to the next item
+  requested through the approved `gh` / GraphQL flow, checks still running
+- `#73` skill `ai-skills-release-github`: no review submitted yet for the latest push, PR node id
+  captured with `gh pr view --json id`, Copilot review requested through
+  `requestReviewsByLogin`, loop moved on to the next item

--- a/skills/ai-skills-pr-review-loop/examples/review-loop-status.md
+++ b/skills/ai-skills-pr-review-loop/examples/review-loop-status.md
@@ -5,6 +5,6 @@
 - `#72` skill `ai-skills-performance-db`: one valid finding fixed and pushed, post-push review
   requested through the approved `gh` / GraphQL flow, checks still running
 - `#73` skill `ai-skills-release-github`: no review submitted yet for the latest push, PR node id
-  captured with `gh pr view <PR_NUMBER> --json id --jq .id`, Copilot review requested via
+  captured with `gh pr view 73 --json id --jq .id`, Copilot review requested via
   `gh api graphql` using the `requestReviewsByLogin` mutation, loop moved on to
   the next item

--- a/skills/ai-skills-pr-review-loop/examples/review-loop-status.md
+++ b/skills/ai-skills-pr-review-loop/examples/review-loop-status.md
@@ -5,6 +5,6 @@
 - `#72` skill `ai-skills-performance-db`: one valid finding fixed and pushed, post-push review
   requested through the approved `gh` / GraphQL flow, checks still running
 - `#73` skill `ai-skills-release-github`: no review submitted yet for the latest push, PR node id
-  captured with `gh pr view --json id`, Copilot review requested via
+  captured with `gh pr view <PR_NUMBER> --json id --jq .id`, Copilot review requested via
   `gh api graphql` using the `requestReviewsByLogin` mutation, loop moved on to
   the next item

--- a/skills/ai-skills-pr-review-loop/examples/review-loop-status.md
+++ b/skills/ai-skills-pr-review-loop/examples/review-loop-status.md
@@ -5,5 +5,6 @@
 - `#72` skill `ai-skills-performance-db`: one valid finding fixed and pushed, post-push review
   requested through the approved `gh` / GraphQL flow, checks still running
 - `#73` skill `ai-skills-release-github`: no review submitted yet for the latest push, PR node id
-  captured with `gh pr view --json id`, Copilot review requested through
-  `requestReviewsByLogin`, loop moved on to the next item
+  captured with `gh pr view --json id`, Copilot review requested via
+  `gh api graphql` using the `requestReviewsByLogin` mutation, loop moved on to
+  the next item

--- a/skills/ai-skills-pr-review-loop/references/copilot-review-trigger.md
+++ b/skills/ai-skills-pr-review-loop/references/copilot-review-trigger.md
@@ -4,7 +4,8 @@ Use this reference when strict GitHub Copilot review is the configured
 automated review mechanism.
 
 After every fix push, explicitly request a fresh Copilot review for the PR head
-commit through the GitHub API. Do not use PR comments or `@copilot` mentions.
+commit through the approved `gh` CLI / GitHub GraphQL flow. Do not use PR
+comments or `@copilot` mentions.
 
 1. Capture the raw pull request node id:
 
@@ -29,3 +30,6 @@ commit through the GitHub API. Do not use PR comments or `@copilot` mentions.
 
 3. Verify a new review request or submitted review appears for the latest head
    commit before treating the PR as reviewed.
+
+Treat this flow as the authoritative trigger procedure whenever the main skill
+requires strict GitHub Copilot review re-triggering.

--- a/skills/ai-skills-pr-review-loop/references/review-loop-queue.md
+++ b/skills/ai-skills-pr-review-loop/references/review-loop-queue.md
@@ -18,6 +18,7 @@ review/check/thread state.
 For strict GitHub Copilot review loops, re-trigger review through the approved
 `gh pr view <PR_NUMBER> --json id --jq .id` plus `gh api graphql` flow using the
 `requestReviewsByLogin` mutation described in `copilot-review-trigger.md`
+under this skill's `references` directory
 after every fix push. Do not use PR comments or `@copilot` mentions as the
 trigger.
 

--- a/skills/ai-skills-pr-review-loop/references/review-loop-queue.md
+++ b/skills/ai-skills-pr-review-loop/references/review-loop-queue.md
@@ -15,9 +15,10 @@ Treat review generation latency as operational state, not a fixed timer. Do
 not merge because an arbitrary wait elapsed; merge only from explicit
 review/check/thread state.
 
-For strict GitHub Copilot review loops, re-trigger review through the platform
-API described in `copilot-review-trigger.md` after every fix push. Do not use
-PR comments or `@copilot` mentions as the trigger.
+For strict GitHub Copilot review loops, re-trigger review through the approved
+`gh pr view --json id` plus `gh api graphql requestReviewsByLogin` flow
+described in `copilot-review-trigger.md` after every fix push. Do not use PR
+comments or `@copilot` mentions as the trigger.
 
 If a PR cannot proceed because of missing permissions, missing branch updates,
 or missing review infrastructure, keep it in the queue with an explicit blocker

--- a/skills/ai-skills-pr-review-loop/references/review-loop-queue.md
+++ b/skills/ai-skills-pr-review-loop/references/review-loop-queue.md
@@ -15,12 +15,11 @@ Treat review generation latency as operational state, not a fixed timer. Do
 not merge because an arbitrary wait elapsed; merge only from explicit
 review/check/thread state.
 
-For strict GitHub Copilot review loops, re-trigger review through the approved
-`gh pr view <PR_NUMBER> --json id --jq .id` plus `gh api graphql` flow using the
-`requestReviewsByLogin` mutation described in `copilot-review-trigger.md`
-under this skill's `references` directory
-after every fix push. Do not use PR comments or `@copilot` mentions as the
-trigger.
+For strict GitHub Copilot review loops, after every fix push re-trigger review
+through the approved `gh pr view <PR_NUMBER> --json id --jq .id` plus
+`gh api graphql` flow using the `requestReviewsByLogin` mutation described in
+`copilot-review-trigger.md` under this skill's `references` directory. Do not
+use PR comments or `@copilot` mentions as the trigger.
 
 If a PR cannot proceed because of missing permissions, missing branch updates,
 or missing review infrastructure, keep it in the queue with an explicit blocker

--- a/skills/ai-skills-pr-review-loop/references/review-loop-queue.md
+++ b/skills/ai-skills-pr-review-loop/references/review-loop-queue.md
@@ -16,9 +16,10 @@ not merge because an arbitrary wait elapsed; merge only from explicit
 review/check/thread state.
 
 For strict GitHub Copilot review loops, re-trigger review through the approved
-`gh pr view --json id` plus `gh api graphql requestReviewsByLogin` flow
-described in `copilot-review-trigger.md` after every fix push. Do not use PR
-comments or `@copilot` mentions as the trigger.
+`gh pr view --json id` plus `gh api graphql` flow using the
+`requestReviewsByLogin` mutation described in `copilot-review-trigger.md`
+after every fix push. Do not use PR comments or `@copilot` mentions as the
+trigger.
 
 If a PR cannot proceed because of missing permissions, missing branch updates,
 or missing review infrastructure, keep it in the queue with an explicit blocker

--- a/skills/ai-skills-pr-review-loop/references/review-loop-queue.md
+++ b/skills/ai-skills-pr-review-loop/references/review-loop-queue.md
@@ -16,7 +16,7 @@ not merge because an arbitrary wait elapsed; merge only from explicit
 review/check/thread state.
 
 For strict GitHub Copilot review loops, re-trigger review through the approved
-`gh pr view --json id` plus `gh api graphql` flow using the
+`gh pr view <PR_NUMBER> --json id --jq .id` plus `gh api graphql` flow using the
 `requestReviewsByLogin` mutation described in `copilot-review-trigger.md`
 after every fix push. Do not use PR comments or `@copilot` mentions as the
 trigger.


### PR DESCRIPTION
Closes #200

## Implementation Summary
- Scope: strengthen the `ai-skills-pr-review-loop` bundle so strict GitHub Copilot review retriggering uses the approved `gh` CLI / GraphQL flow throughout the main workflow surface.
- Key changes: promote `gh pr view --json id` plus `gh api graphql requestReviewsByLogin` into the main skill workflow, tighten the queue/reference language against comment-based triggers, and update the status example to show the approved flow explicitly.
- Non-goals: merge-gate policy changes, planning-skill guardrails, or broader PR review family changes.

## Review Focus
- Generated/copied files and standard imports that can be skimmed: none.
- Non-obvious code paths and rationale: the skill now states the positive trigger path in `SKILL.md` while keeping `references/copilot-review-trigger.md` as the exact copy-safe mutation source.

## Validation
- Tests executed: `corepack pnpm install --frozen-lockfile`; `corepack pnpm lint:md`; `corepack pnpm validate`; `corepack pnpm test`; `corepack pnpm quality:cognitive`; `corepack pnpm quality:crap`; `corepack pnpm pack:dry-run`.
- Manual checks: reviewed the bounded diff to confirm all wording stays inside the `ai-skills-pr-review-loop` bundle.
- Residual risks: low; the change is documentation-only, but downstream planners still need separate guardrails in `ai-skills-plan`.