### PR TITLE
Tighten merge gates for post-push review discipline

### DIFF
--- a/skills/ai-skills-pr-merge/SKILL.md
+++ b/skills/ai-skills-pr-merge/SKILL.md
@@ -18,6 +18,8 @@ merge authority is explicit.
 - use when deciding whether a PR is merge-ready
 - use when executing a merge in a GitHub-based review workflow
 - use as the merge child skill under skill `ai-skills-pr-review`
+- use skill `ai-skills-pr-review-loop` when strict post-push automated-review
+  trigger discipline must be verified before merge
 - use `references/merge-gate.md` for the hard gate checklist
 - use `references/post-push-review.md` for the requirement that review must
   exist after the latest push
@@ -28,6 +30,9 @@ merge authority is explicit.
 
 - the current PR head commit and latest push timestamp
 - the latest review submission state after that push
+- when strict post-push automated review is required, evidence that the latest
+  head review came from the approved platform or API trigger flow rather than
+  ad-hoc PR comments
 - unresolved review threads or conversations
 - required status checks for the current head commit
 - repository merge permissions and policies
@@ -54,13 +59,18 @@ merge authority is explicit.
    `Closes #<id>`.
 6. Verify that a completed review exists after the latest push, not only before
    it.
-7. Verify that all required checks are green for the current head commit.
-8. Verify that no required review conversations remain unresolved.
-9. Verify that the merge method respects repository policy and never requires a
+7. If the repository requires strict post-push automated review discipline,
+   reject PR comments, `@copilot` mentions, or similar ad-hoc trigger evidence
+   as merge-readiness proof. Require evidence from skill `ai-skills-pr-review-loop`
+   or equivalent platform state showing that the latest head review came from
+   the approved trigger flow.
+8. Verify that all required checks are green for the current head commit.
+9. Verify that no required review conversations remain unresolved.
+10. Verify that the merge method respects repository policy and never requires a
    force, admin-bypass, or skipped required gate.
-10. Merge only when every gate in `references/merge-gate.md` is satisfied in the
+11. Merge only when every gate in `references/merge-gate.md` is satisfied in the
    same evaluation round.
-11. Use `examples/merge-decision.md` when a concrete decision summary helps.
+12. Use `examples/merge-decision.md` when a concrete decision summary helps.
 
 # Outputs
 
@@ -72,6 +82,9 @@ merge authority is explicit.
 # Guardrails
 
 - do not merge without a review pass after the latest push
+- do not treat PR comments, `@copilot` mentions, or other ad-hoc trigger
+  artifacts as sufficient merge evidence when the repository expects a proper
+  automated review trigger flow
 - do not merge without explicit user merge instruction
 - do not merge a PR you created or substantially authored unless the user gives
   the specific merge instruction and explicitly confirms repository owner
@@ -89,6 +102,9 @@ merge authority is explicit.
   confirmation
 - the PR body links the main issue
 - the latest push is covered by a completed review pass
+- when strict post-push automated review discipline is required, the latest
+  head review evidence comes from the approved trigger flow rather than a PR
+  comment convention
 - required checks are green on the current head
 - review threads are resolved according to repository policy
 - the merge decision is explicit and auditable

--- a/skills/ai-skills-pr-merge/SKILL.md
+++ b/skills/ai-skills-pr-merge/SKILL.md
@@ -18,7 +18,7 @@ merge authority is explicit.
 - use when deciding whether a PR is merge-ready
 - use when executing a merge in a GitHub-based review workflow
 - use as the merge child skill under skill `ai-skills-pr-review`
-- use skill `ai-skills-pr-review-loop` when strict post-push automated-review
+- use skill `ai-skills-pr-review-loop` when strict post-push automated review
   trigger discipline must be verified before merge
 - use `references/merge-gate.md` for the hard gate checklist
 - use `references/post-push-review.md` for the requirement that review must

--- a/skills/ai-skills-pr-merge/SKILL.md
+++ b/skills/ai-skills-pr-merge/SKILL.md
@@ -61,9 +61,9 @@ merge authority is explicit.
    it.
 7. If the repository requires strict post-push automated review discipline,
    reject PR comments, `@copilot` mentions, or similar ad-hoc trigger evidence
-   as merge-readiness proof. Require evidence from skill `ai-skills-pr-review-loop`
-   or equivalent platform state showing that the latest head review came from
-   the approved trigger flow.
+   as merge-readiness proof. Require platform or API evidence showing that the
+   latest head review came from the approved trigger flow, using skill `ai-skills-pr-review-loop`
+   only as the verification procedure when needed.
 8. Verify that all required checks are green for the current head commit.
 9. Verify that no required review conversations remain unresolved.
 10. Verify that the merge method respects repository policy and never requires a

--- a/skills/ai-skills-pr-merge/examples/merge-decision.md
+++ b/skills/ai-skills-pr-merge/examples/merge-decision.md
@@ -4,7 +4,7 @@ Merge-ready:
 
 - latest push has a completed review pass
 - strict post-push automated review evidence came from the approved platform or
-  API trigger flow, not PR comments
+  API trigger flow, not PR comments or `@copilot` mentions
 - all required checks are green
 - no review threads remain unresolved
 - protected-branch discipline is satisfied by a feature branch and PR

--- a/skills/ai-skills-pr-merge/examples/merge-decision.md
+++ b/skills/ai-skills-pr-merge/examples/merge-decision.md
@@ -3,6 +3,8 @@
 Merge-ready:
 
 - latest push has a completed review pass
+- strict post-push automated review evidence came from the approved platform or
+  API trigger flow, not PR comments
 - all required checks are green
 - no review threads remain unresolved
 - protected-branch discipline is satisfied by a feature branch and PR

--- a/skills/ai-skills-pr-merge/references/merge-gate.md
+++ b/skills/ai-skills-pr-merge/references/merge-gate.md
@@ -3,6 +3,9 @@
 Treat the PR as merge-ready only when all of the following are true:
 
 - a completed review exists after the latest push
+- when strict post-push automated review discipline is required, the latest
+  head review came from the approved platform or API trigger flow rather than
+  PR comments or `@copilot` mentions
 - no required review threads or conversations remain unresolved
 - all required checks are green on the current head commit
 - protected-branch discipline is satisfied by a feature branch and PR

--- a/skills/ai-skills-pr-merge/references/post-push-review.md
+++ b/skills/ai-skills-pr-merge/references/post-push-review.md
@@ -7,5 +7,8 @@ After each push:
 - wait for the new review pass to complete
 - treat a review still in progress as a blocked merge state
 - verify that the latest review covers the current head commit
+- when strict GitHub Copilot or similar automated review discipline is
+  required, verify the latest head review came from the approved platform or
+  API trigger flow rather than PR comments or `@copilot` mentions
 
 Passing CI alone is never enough to merge.


### PR DESCRIPTION
Closes #201

## Implementation Summary
- Scope: harden the `ai-skills-pr-merge` bundle so merge readiness rejects ad-hoc comment triggers when the repository expects strict post-push automated review discipline.
- Key changes: add an explicit dependency on skill `ai-skills-pr-review-loop` for strict trigger-discipline verification, require approved latest-head review evidence in the workflow and exit checks, and update the merge gate/reference/example text to reject PR comments or `@copilot` mentions as merge proof.
- Non-goals: review-loop trigger mechanics themselves, planning guardrails, or issue-link policy changes.

## Review Focus
- Generated/copied files and standard imports that can be skimmed: none.
- Non-obvious code paths and rationale: the merge skill stays merge-focused while delegating strict trigger-flow verification back to skill `ai-skills-pr-review-loop` instead of trying to reimplement the full review loop.

## Validation
- Tests executed: `corepack pnpm install --frozen-lockfile`; `corepack pnpm lint:md`; `corepack pnpm validate`; `corepack pnpm test`; `corepack pnpm quality:cognitive`; `corepack pnpm quality:crap`; `corepack pnpm pack:dry-run`.
- Manual checks: reviewed the bounded diff to confirm all wording stays inside the `ai-skills-pr-merge` bundle.
- Residual risks: low; the change is documentation-only, but downstream workflows still need to supply the repository-specific notion of when strict automated review discipline is required.