### PR TITLE
Add planning guardrails for PR review loops

### DIFF
--- a/skills/ai-skills-plan/SKILL.md
+++ b/skills/ai-skills-plan/SKILL.md
@@ -21,6 +21,8 @@ implicit.
   implementation path
 - use when repository or downstream rulesets must be read before implementation
   planning can be trusted
+- use skill `ai-skills-pr-review-loop` before finalizing any plan that includes
+  post-push review, review retriggering, or merge-loop work
 - use `references/decision-complete-plan.md` to make sure the plan is
   decision-complete
 - use `references/decision-complete-planning.md` for planning behavior and
@@ -57,20 +59,23 @@ implicit.
    important assumptions.
 4. Ask only the questions that materially change the plan or lock important
    tradeoffs.
-5. Produce a decision-complete plan covering approach, dependencies, edge
+5. If the plan includes post-push review, review retriggering, or merge-loop
+   work, consult skill `ai-skills-pr-review-loop` before finalizing the plan
+   and prohibit comment-based review triggers such as `@copilot review`.
+6. Produce a decision-complete plan covering approach, dependencies, edge
    cases, verification, and acceptance signals.
-6. If a user answer has significant impact on the plan, present the altered
+7. If a user answer has significant impact on the plan, present the altered
    plan before starting implementation instead of switching directly into
    coding.
-7. Use `references/decision-complete-plan.md` to confirm scope, decisions, and
+8. Use `references/decision-complete-plan.md` to confirm scope, decisions, and
    verification are explicit.
-8. Use `references/decision-complete-planning.md` and
+9. Use `references/decision-complete-planning.md` and
    `references/workflow-order.md` to refine planning behavior and sequencing.
-9. Use `examples/implementation-plan.md` when a concrete output shape or
+10. Use `examples/implementation-plan.md` when a concrete output shape or
    verification section is helpful.
-10. Re-read the complete applicable rulesets at the end and verify the plan
+11. Re-read the complete applicable rulesets at the end and verify the plan
     still conforms; if not, update the plan before presenting it as complete.
-11. Apply any target-specific note such as `targets/codex.md` only after the
+12. Apply any target-specific note such as `targets/codex.md` only after the
    canonical plan is stable.
 
 # Outputs
@@ -92,6 +97,8 @@ implicit.
   confirming conformance
 - do not ask questions that can be resolved by repository exploration
 - do not leave critical behavior, interfaces, or test strategy implicit
+- do not propose PR comments, `@copilot review`, or similar comment-based
+  review triggers in a plan; defer to skill `ai-skills-pr-review-loop`
 - do not treat a materially changed plan as unchanged after new answers arrive
 
 # Exit Checks
@@ -103,5 +110,7 @@ implicit.
   conformance
 - important assumptions are explicit
 - verification steps and acceptance signals are concrete
+- any plan with review-loop or merge-loop work consulted skill `ai-skills-pr-review-loop`
+  and avoided comment-based review triggers
 - any answer that materially changed the approach is reflected in the latest
   plan

--- a/skills/ai-skills-plan/examples/implementation-plan.md
+++ b/skills/ai-skills-plan/examples/implementation-plan.md
@@ -12,6 +12,9 @@
 - create `SKILL.md` with required frontmatter and sections
 - add a small reference note and one example file
 - update only files required for the issue
+- if the workflow later includes post-push PR review or merge-loop work,
+  consult skill `ai-skills-pr-review-loop` and use the approved review trigger
+  flow instead of PR comments such as `@copilot review`
 - final task re-reads the applicable rulesets and verifies conformance
 
 ## Test Plan

--- a/skills/ai-skills-plan/references/decision-complete-plan.md
+++ b/skills/ai-skills-plan/references/decision-complete-plan.md
@@ -10,9 +10,15 @@ A strong implementation plan should make these elements explicit:
 - external dependencies, blockers, and dependency-first ordering
 - important risks, edge cases, and mitigations
 - verification steps and acceptance criteria
+- required skill handoffs for specialized workflows such as post-push PR review
+  loops or merge-loop handling
 
 Repository exploration comes before clarification questions when the answer can
 be discovered locally.
 
 When governing rulesets exist, the plan must start with a complete-ruleset read
 task and end with a complete-ruleset conformance re-read.
+
+If the plan includes post-push review, review retriggering, or merge-loop work,
+it must consult skill `ai-skills-pr-review-loop` and must not propose PR
+comments such as `@copilot review` as the trigger mechanism.

--- a/skills/ai-skills-plan/references/decision-complete-planning.md
+++ b/skills/ai-skills-plan/references/decision-complete-planning.md
@@ -9,6 +9,10 @@ Distilled from the project's planning guidance.
 - Keep the plan dependency-aware and implementation-ready.
 - Make assumptions explicit instead of letting them hide in execution.
 - Define verification before implementation starts.
+- When planning post-push PR review, review retriggering, or merge-loop work,
+  consult skill `ai-skills-pr-review-loop` before finalizing the plan.
+- Do not encode PR comments, `@copilot review`, or similar ad-hoc comment
+  triggers in a plan; name the approved workflow or defer to skill `ai-skills-pr-review-loop`.
 - If new information changes the plan materially, refresh the plan first.
 - End by re-reading governing rulesets and correcting any plan
   non-conformance before presenting the plan as complete.

--- a/skills/ai-skills-plan/references/workflow-order.md
+++ b/skills/ai-skills-plan/references/workflow-order.md
@@ -4,6 +4,8 @@ Implementation work should follow a stable execution order:
 
 - read complete governing rulesets before any other planning task
 - plan first with dependency and blocker research
+- consult skill `ai-skills-pr-review-loop` before finalizing any plan that
+  includes post-push review, review retriggering, or merge-loop work
 - create a dedicated issue branch
 - implement the bounded change
 - open a PR or MR
@@ -14,3 +16,7 @@ Implementation work should follow a stable execution order:
 
 This keeps the scope aligned to one concern and prevents implementation from
 starting without an actionable plan.
+
+Plans that include PR review-loop work should name the approved review trigger
+workflow or defer to skill `ai-skills-pr-review-loop`; they should not propose
+PR comments such as `@copilot review`.


### PR DESCRIPTION
Closes #199

## Implementation Summary
- require planning-stage consultation of skill `ai-skills-pr-review-loop` for post-push review, retrigger, and merge-loop plans
- forbid plan outputs that propose comment-based review triggers such as `@copilot review`
- update the canonical plan references and example plan shape to carry the same guardrail

## Review Focus
- wording and placement of the new planning-stage guardrails
- whether the cross-skill handoff to `ai-skills-pr-review-loop` is clear enough without over-specifying the trigger details here

## Validation
- `corepack pnpm lint:md`
- `corepack pnpm validate`
- `corepack pnpm test`
- `corepack pnpm quality:cognitive`
- `corepack pnpm quality:crap`
- `corepack pnpm pack:dry-run`
