### PR TITLE
Allow isolated branch GitHub releases

### DIFF
--- a/skills/ai-skills-release-github/SKILL.md
+++ b/skills/ai-skills-release-github/SKILL.md
@@ -57,8 +57,9 @@ annotated tags, and GitHub release notes aligned.
    released tag so unrelated unreleased default-branch work is excluded.
 2. Ensure the chosen release source is current for its intended scope, all
    release-bound PRs for that scope are merged or intentionally recreated on
-   the isolated branch, and no open release-bound PRs remain; do not release
-   from a feature branch.
+   the isolated branch, and no open release-bound PRs remain for the chosen
+   release source and intended release scope; do not release from a feature
+   branch.
 3. If the release scope includes framework, build-tool, or dependency choices
    that are not fixed yet, apply skill `ai-skills-version-dependency-selection`
    before finalizing release timing or compatibility notes.

--- a/skills/ai-skills-release-github/SKILL.md
+++ b/skills/ai-skills-release-github/SKILL.md
@@ -39,7 +39,7 @@ annotated tags, and GitHub release notes aligned.
   tag when skill `ai-skills-release` explicitly requires that narrower source
   as an input to this skill
 - confirmation that no open release-bound PRs remain
-- the latest reachable release tag and the merged changes since that tag
+- the latest released tag and the merged changes since that tag
 - any explicit target version provided by the user or repository policy
 - any framework, build-tool, dependency, or support-policy changes in the
   release scope that affect compatibility claims
@@ -129,6 +129,6 @@ annotated tags, and GitHub release notes aligned.
 - all changelog/release-notes and versioned-example updates were staged in the
   release-preparation commit before tagging
 - the release was created from the intended default-branch commit or justified
-  isolated release-branch commit
+  isolated release branch commit
 - unrelated unreleased work was excluded from the chosen release source
 - the published result is specific enough for downstream consumers to use

--- a/skills/ai-skills-release-github/SKILL.md
+++ b/skills/ai-skills-release-github/SKILL.md
@@ -121,7 +121,7 @@ annotated tags, and GitHub release notes aligned.
 - the target version is explicit and justified
 - the chosen release source is explicit and justified, and isolated release
   branch use is backed by an explicit skill `ai-skills-release` requirement
-- the default branch or isolated release source includes all release-bound work
+- the default branch or isolated release branch includes all release-bound work
   for the intended scope and no open release-bound PRs remain
 - changelog or release notes, tag, and GitHub Release all reference the same
   release

--- a/skills/ai-skills-release-github/SKILL.md
+++ b/skills/ai-skills-release-github/SKILL.md
@@ -15,6 +15,9 @@ annotated tags, and GitHub release notes aligned.
 # When to Use
 
 - use when a repository needs a new GitHub release from its default branch
+- use when the parent release workflow intentionally requires an isolated
+  release branch created from the latest released tag so unrelated unreleased
+  default-branch work stays out of the release
 - use when a version must be chosen explicitly or inferred from merged
   user-visible changes since the latest tag
 - use when changelog content, tags, and GitHub release notes must describe the
@@ -31,7 +34,9 @@ annotated tags, and GitHub release notes aligned.
 
 # Inputs
 
-- the repository default branch with all release-bound changes already merged
+- the repository default branch with all release-bound changes already merged,
+  or an intentionally isolated release branch created from the latest released
+  tag when the parent release workflow explicitly requires that narrower source
 - confirmation that no open release-bound PRs remain
 - the latest reachable release tag and the merged changes since that tag
 - any explicit target version provided by the user or repository policy
@@ -44,38 +49,50 @@ annotated tags, and GitHub release notes aligned.
 
 # Workflow
 
-1. Ensure the default branch is current, all release-bound PRs are merged, and
-   no open release-bound PRs remain; do not release from a feature branch.
-2. If the release scope includes framework, build-tool, or dependency choices
+1. Treat the default branch as the normal release source. Only use an isolated
+   release branch when the parent release workflow explicitly requires it;
+   create that branch from the latest released tag so unrelated unreleased
+   default-branch work is excluded.
+2. Ensure the chosen release source is current for its intended scope, all
+   release-bound PRs for that scope are merged or intentionally recreated on
+   the isolated branch, and no open release-bound PRs remain; do not release
+   from a feature branch.
+3. If the release scope includes framework, build-tool, or dependency choices
    that are not fixed yet, apply skill `ai-skills-version-dependency-selection`
    before finalizing release timing or compatibility notes.
-3. If the release changes officially supported runtimes or platforms and the
+4. If the release changes officially supported runtimes or platforms and the
    support policy is not explicit yet, apply skill `ai-skills-version-support-policy`
    before finalizing compatibility claims.
-4. Determine the target version: use an explicit version when provided;
+5. Determine the target version: use an explicit version when provided;
    otherwise classify the changes since the latest tag and select the smallest
    valid semantic-version bump that fits the strongest user-visible change.
-5. Stop if there are no meaningful release changes instead of creating an empty
+6. Stop if there are no meaningful release changes instead of creating an empty
    tag.
-6. Update the changelog or release-notes source with the selected version, the
+7. Verify the chosen release source contains only the intended scoped release
+   change set. Stop until the source is narrowed if unrelated unreleased work
+   would be included.
+8. Update the changelog or release-notes source with the selected version, the
    release date, and a concise summary of user-visible changes.
-7. Run `git grep -F "<previous-tag>"` before creating the release commit,
+9. Run `git grep -F "<previous-tag>"` before creating the release commit,
    replacing `<previous-tag>` with the actual latest released version tag, for
    example `v1.2.3`. Update every versioned release example or documentation
    reference found so it points at the new tag.
-8. Stage the changelog or release-notes source and all versioned-example
+10. Stage the changelog or release-notes source and all versioned-example
    updates together.
-9. Commit the release-preparation changes on the default branch, create an
-   annotated tag for the release commit, and push both branch and tag.
-10. Create the GitHub Release from the pushed tag using notes that stay aligned
+11. Commit the release-preparation changes on the chosen release source,
+   create an annotated tag for the release commit, and push both branch and
+   tag.
+12. Create the GitHub Release from the pushed tag using notes that stay aligned
    with the changelog or release-notes source. If both exist, treat the
    changelog as authoritative unless repository policy explicitly says
    otherwise.
-11. Verify that the tag and release page exist and point at the intended commit.
+13. Verify that the tag and release page exist and point at the intended commit.
 
 # Outputs
 
 - the selected release version and release commit
+- the release source used, including whether it was the default branch or an
+  intentionally isolated branch from the latest released tag
 - aligned changelog or release notes for that version
 - a pushed annotated tag and a published GitHub Release
 - a concise release summary or release URL for follow-up communication
@@ -83,9 +100,13 @@ annotated tags, and GitHub release notes aligned.
 # Guardrails
 
 - do not release from a feature branch or dirty branch state
+- do not use an isolated release branch unless the parent release workflow
+  explicitly requires it
 - do not release while open release-bound PRs remain
 - do not guess a version bump without checking the merged change set
 - do not create a release when there are no meaningful release changes
+- do not include unrelated unreleased default-branch work in the chosen release
+  source
 - do not skip the previous-tag `git grep` scan before the release-preparation
   commit
 - do not let GitHub release notes drift from the authoritative changelog or
@@ -94,8 +115,10 @@ annotated tags, and GitHub release notes aligned.
 # Exit Checks
 
 - the target version is explicit and justified
-- the default branch includes all release-bound PRs and no open release-bound
-  PRs remain
+- the chosen release source is explicit and justified, and isolated-branch use
+  is backed by a parent release workflow requirement
+- the default branch or isolated release source includes all release-bound work
+  for the intended scope and no open release-bound PRs remain
 - changelog or release notes, tag, and GitHub Release all reference the same
   release
 - `git grep -F "<previous-tag>"` was run with the actual latest released tag and
@@ -103,5 +126,7 @@ annotated tags, and GitHub release notes aligned.
   explicitly ruled out
 - all changelog/release-notes and versioned-example updates were staged in the
   release-preparation commit before tagging
-- the release was created from the intended default-branch commit
+- the release was created from the intended default-branch commit or justified
+  isolated release-branch commit
+- unrelated unreleased work was excluded from the chosen release source
 - the published result is specific enough for downstream consumers to use

--- a/skills/ai-skills-release-github/SKILL.md
+++ b/skills/ai-skills-release-github/SKILL.md
@@ -15,7 +15,7 @@ annotated tags, and GitHub release notes aligned.
 # When to Use
 
 - use when a repository needs a new GitHub release from its default branch
-- use when the parent release workflow intentionally requires an isolated
+- use when skill `ai-skills-release` intentionally requires an isolated
   release branch created from the latest released tag so unrelated unreleased
   default-branch work stays out of the release
 - use when a version must be chosen explicitly or inferred from merged
@@ -36,7 +36,8 @@ annotated tags, and GitHub release notes aligned.
 
 - the repository default branch with all release-bound changes already merged,
   or an intentionally isolated release branch created from the latest released
-  tag when the parent release workflow explicitly requires that narrower source
+  tag when skill `ai-skills-release` explicitly requires that narrower source
+  as an input to this skill
 - confirmation that no open release-bound PRs remain
 - the latest reachable release tag and the merged changes since that tag
 - any explicit target version provided by the user or repository policy
@@ -50,9 +51,9 @@ annotated tags, and GitHub release notes aligned.
 # Workflow
 
 1. Treat the default branch as the normal release source. Only use an isolated
-   release branch when the parent release workflow explicitly requires it;
-   create that branch from the latest released tag so unrelated unreleased
-   default-branch work is excluded.
+   release branch when skill `ai-skills-release` explicitly requires it and
+   passes that requirement into this skill; create that branch from the latest
+   released tag so unrelated unreleased default-branch work is excluded.
 2. Ensure the chosen release source is current for its intended scope, all
    release-bound PRs for that scope are merged or intentionally recreated on
    the isolated branch, and no open release-bound PRs remain; do not release
@@ -101,7 +102,7 @@ annotated tags, and GitHub release notes aligned.
 # Guardrails
 
 - do not release from a feature branch or dirty branch state
-- do not use an isolated release branch unless the parent release workflow
+- do not use an isolated release branch unless skill `ai-skills-release`
   explicitly requires it
 - do not release while open release-bound PRs remain
 - do not guess a version bump without checking the merged change set
@@ -117,7 +118,7 @@ annotated tags, and GitHub release notes aligned.
 
 - the target version is explicit and justified
 - the chosen release source is explicit and justified, and isolated-branch use
-  is backed by a parent release workflow requirement
+  is backed by an explicit skill `ai-skills-release` requirement
 - the default branch or isolated release source includes all release-bound work
   for the intended scope and no open release-bound PRs remain
 - changelog or release notes, tag, and GitHub Release all reference the same

--- a/skills/ai-skills-release-github/SKILL.md
+++ b/skills/ai-skills-release-github/SKILL.md
@@ -19,7 +19,7 @@ annotated tags, and GitHub release notes aligned.
   release branch created from the latest released tag so unrelated unreleased
   default-branch work stays out of the release
 - use when a version must be chosen explicitly or inferred from merged
-  user-visible changes since the latest tag
+  user-visible changes since the latest released tag
 - use when changelog content, tags, and GitHub release notes must describe the
   same release
 - use skill `ai-skills-version-dependency-selection` when framework,
@@ -65,8 +65,9 @@ annotated tags, and GitHub release notes aligned.
    support policy is not explicit yet, apply skill `ai-skills-version-support-policy`
    before finalizing compatibility claims.
 5. Determine the target version: use an explicit version when provided;
-   otherwise classify the changes since the latest tag and select the smallest
-   valid semantic-version bump that fits the strongest user-visible change.
+   otherwise classify the changes since the latest released tag and select the
+   smallest valid semantic-version bump that fits the strongest user-visible
+   change.
 6. Stop if there are no meaningful release changes instead of creating an empty
    tag.
 7. Verify the chosen release source contains only the intended scoped release

--- a/skills/ai-skills-release-github/SKILL.md
+++ b/skills/ai-skills-release-github/SKILL.md
@@ -38,7 +38,8 @@ annotated tags, and GitHub release notes aligned.
   or an intentionally isolated release branch created from the latest released
   tag when skill `ai-skills-release` explicitly requires that narrower source
   as an input to this skill
-- confirmation that no open release-bound PRs remain
+- confirmation that no open release-bound PRs remain for the chosen release
+  source and intended release scope
 - the latest released tag and the merged changes since that tag
 - any explicit target version provided by the user or repository policy
 - any framework, build-tool, dependency, or support-policy changes in the
@@ -95,7 +96,7 @@ annotated tags, and GitHub release notes aligned.
 
 - the selected release version and release commit
 - the release source used, including whether it was the default branch or an
-  intentionally isolated branch from the latest released tag
+  intentionally isolated release branch from the latest released tag
 - aligned changelog or release notes for that version
 - a pushed annotated tag and a published GitHub Release
 - a concise release summary or release URL for follow-up communication

--- a/skills/ai-skills-release-github/SKILL.md
+++ b/skills/ai-skills-release-github/SKILL.md
@@ -118,8 +118,8 @@ annotated tags, and GitHub release notes aligned.
 # Exit Checks
 
 - the target version is explicit and justified
-- the chosen release source is explicit and justified, and isolated-branch use
-  is backed by an explicit skill `ai-skills-release` requirement
+- the chosen release source is explicit and justified, and isolated release
+  branch use is backed by an explicit skill `ai-skills-release` requirement
 - the default branch or isolated release source includes all release-bound work
   for the intended scope and no open release-bound PRs remain
 - changelog or release notes, tag, and GitHub Release all reference the same

--- a/skills/ai-skills-release-github/SKILL.md
+++ b/skills/ai-skills-release-github/SKILL.md
@@ -106,7 +106,8 @@ annotated tags, and GitHub release notes aligned.
 - do not release from a feature branch or dirty branch state
 - do not use an isolated release branch unless skill `ai-skills-release`
   explicitly requires it
-- do not release while open release-bound PRs remain
+- do not release while open release-bound PRs remain for the chosen release
+  source and intended release scope
 - do not guess a version bump without checking the merged change set
 - do not create a release when there are no meaningful release changes
 - do not include unrelated unreleased default-branch work in the chosen release

--- a/skills/ai-skills-release-github/SKILL.md
+++ b/skills/ai-skills-release-github/SKILL.md
@@ -69,8 +69,9 @@ annotated tags, and GitHub release notes aligned.
 6. Stop if there are no meaningful release changes instead of creating an empty
    tag.
 7. Verify the chosen release source contains only the intended scoped release
-   change set. Stop until the source is narrowed if unrelated unreleased work
-   would be included.
+   change set by inspecting the commits or file diff from the latest released
+   tag to that source. Stop until the source is narrowed if unrelated
+   unreleased work would be included.
 8. Update the changelog or release-notes source with the selected version, the
    release date, and a concise summary of user-visible changes.
 9. Run `git grep -F "<previous-tag>"` before creating the release commit,

--- a/skills/ai-skills-release-github/references/github-release-flow.md
+++ b/skills/ai-skills-release-github/references/github-release-flow.md
@@ -15,7 +15,9 @@ Preferred sequence:
    scoped release change
 3. verify the chosen release source is current for its intended scope and no
    release-bound PRs remain open for that scope
-4. stop if unrelated unreleased default-branch work would be included
+4. inspect the commits or file diff from the latest released tag to the chosen
+   release source and stop if unrelated unreleased default-branch work would be
+   included
 5. update release-notes source
 6. run `git grep -F "<previous-tag>"`, replacing `<previous-tag>` with the
    actual latest released tag, for example `v1.2.3`

--- a/skills/ai-skills-release-github/references/github-release-flow.md
+++ b/skills/ai-skills-release-github/references/github-release-flow.md
@@ -10,7 +10,7 @@ Keep these release artifacts aligned:
 Preferred sequence:
 
 1. treat the default branch as the normal release source
-2. if skill `ai-skills-release` explicitly passes an isolated release-branch
+2. if skill `ai-skills-release` explicitly passes an isolated release branch
    requirement into this flow, create that branch from the latest released tag
    and keep it limited to the scoped release change
 3. verify the chosen release source is current for its intended scope and no

--- a/skills/ai-skills-release-github/references/github-release-flow.md
+++ b/skills/ai-skills-release-github/references/github-release-flow.md
@@ -9,17 +9,23 @@ Keep these release artifacts aligned:
 
 Preferred sequence:
 
-1. verify the default branch is current and no release-bound PRs remain open
-2. update release-notes source
-3. run `git grep -F "<previous-tag>"`, replacing `<previous-tag>` with the
+1. treat the default branch as the normal release source
+2. if the parent release workflow explicitly requires an isolated release
+   branch, create it from the latest released tag and keep it limited to the
+   scoped release change
+3. verify the chosen release source is current for its intended scope and no
+   release-bound PRs remain open for that scope
+4. stop if unrelated unreleased default-branch work would be included
+5. update release-notes source
+6. run `git grep -F "<previous-tag>"`, replacing `<previous-tag>` with the
    actual latest released tag, for example `v1.2.3`
-4. update every relevant versioned example or documentation reference to the new
+7. update every relevant versioned example or documentation reference to the new
    tag
-5. commit the release-preparation change
-6. create the annotated tag on that commit
-7. push branch and tag
-8. create the GitHub Release from the pushed tag
-9. verify the tag and release page point at the same commit
+8. commit the release-preparation change on the chosen release source
+9. create the annotated tag on that commit
+10. push branch and tag
+11. create the GitHub Release from the pushed tag
+12. verify the tag and release page point at the same commit
 
 When repository policy defines a release-note heading or formatting template,
 honor that policy rather than inventing a new layout during release.
@@ -27,3 +33,8 @@ honor that policy rather than inventing a new layout during release.
 If a repository has both a changelog and a separate release-notes source, decide
 which source is authoritative before creating the GitHub Release and keep the
 other one aligned or explicitly out of scope.
+
+An isolated release branch is an exception path for intentionally scoped
+releases. It is not a substitute for a dirty or lagging default branch and
+should only be used when the parent release workflow requires a release that
+excludes unrelated unreleased work.

--- a/skills/ai-skills-release-github/references/github-release-flow.md
+++ b/skills/ai-skills-release-github/references/github-release-flow.md
@@ -10,9 +10,9 @@ Keep these release artifacts aligned:
 Preferred sequence:
 
 1. treat the default branch as the normal release source
-2. if the parent release workflow explicitly requires an isolated release
-   branch, create it from the latest released tag and keep it limited to the
-   scoped release change
+2. if skill `ai-skills-release` explicitly passes an isolated release-branch
+   requirement into this flow, create that branch from the latest released tag
+   and keep it limited to the scoped release change
 3. verify the chosen release source is current for its intended scope and no
    release-bound PRs remain open for that scope
 4. inspect the commits or file diff from the latest released tag to the chosen
@@ -38,5 +38,5 @@ other one aligned or explicitly out of scope.
 
 An isolated release branch is an exception path for intentionally scoped
 releases. It is not a substitute for a dirty or lagging default branch and
-should only be used when the parent release workflow requires a release that
-excludes unrelated unreleased work.
+should only be used when skill `ai-skills-release` passes an explicit isolated
+source requirement into this flow so unrelated unreleased work stays out.

--- a/skills/ai-skills-release-github/references/version-selection.md
+++ b/skills/ai-skills-release-github/references/version-selection.md
@@ -4,7 +4,7 @@ Select the target version in this order:
 
 1. use the explicit version if the user or repository policy already provides
    one
-2. otherwise inspect the changes since the latest reachable tag
+2. otherwise inspect the changes since the latest released tag
 
 Choose the semantic-version bump by strongest change type:
 


### PR DESCRIPTION
Closes #203

## Implementation Summary
- keep default-branch releases as the normal GitHub release path
- allow an intentionally isolated release branch from the latest released tag only when the parent release workflow explicitly requires it
- require verification that the chosen release source excludes unrelated unreleased work before tagging and publishing

## Review Focus
- whether the isolated-branch exception stays narrow enough
- whether the release-source checks and exit criteria are clear for downstream release workflows

## Validation
- `corepack pnpm lint:md`
- `corepack pnpm validate`
- `corepack pnpm test`
- `corepack pnpm quality:cognitive`
- `corepack pnpm quality:crap`
- `corepack pnpm pack:dry-run`
