### PR TITLE
Add isolated public release guidance

### DIFF
--- a/skills/ai-skills-release/SKILL.md
+++ b/skills/ai-skills-release/SKILL.md
@@ -81,8 +81,9 @@ not as rules to copy into downstream projects.
    path in `references/isolated-public-release.md` and create the release
    source from the latest released tag.
 7. On the isolated-release path, recreate or cherry-pick only the scoped
-   release change onto the isolated branch and stop until unrelated unreleased
-   work is excluded.
+   release change onto the isolated branch; stop if unrelated unreleased work
+   is still present and do not proceed until the isolated branch contains only
+   the scoped release change.
 8. Confirm versioned release examples and documentation references are known so
    the release can update them to the new tag.
 9. Apply skill `ai-skills-release-github` to perform the GitHub-release workflow,

--- a/skills/ai-skills-release/SKILL.md
+++ b/skills/ai-skills-release/SKILL.md
@@ -24,6 +24,9 @@ not as rules to copy into downstream projects.
 - use when a repository needs its full release process executed end to end
 - use when artifact publication may target Maven Central, the Gradle Plugin
   Portal, a private artifactory, or another repository-specific release target
+- use when a public release must ship a narrowly scoped dependency,
+  framework, or build-tool change without also shipping unrelated unreleased
+  default-branch work
 - use when skill `ai-skills-release-github` is necessary but not sufficient on its own
 - use skill `ai-skills-version-dependency-selection` when dependency,
   framework, or build-tool choices are still open in the release scope
@@ -34,6 +37,8 @@ not as rules to copy into downstream projects.
   commit and push, tag creation, and the GitHub Release itself
 - use `references/release-preconditions.md` for the final verification and
   release input requirements
+- use `references/isolated-public-release.md` when public publication may need
+  an intentionally isolated release branch from the latest released tag
 - use `references/publication-targets.md` for target-registry decisions and
   skip rules
 - use `examples/release-checklist.md` when reporting the full release run
@@ -41,6 +46,8 @@ not as rules to copy into downstream projects.
 # Inputs
 
 - the repository default branch with release-bound changes already merged
+- the latest released tag and the exact scoped release change when a public
+  release may need isolation from unrelated unreleased work
 - repository-specific release policy, versioning rules, and publication rules
 - the strongest available final build and test commands or CI evidence
 - the latest release tag and the delta since that release
@@ -51,6 +58,7 @@ not as rules to copy into downstream projects.
 - the artifact publication targets actually used by the repository
 - skill `ai-skills-release-github`
 - `references/release-preconditions.md`
+- `references/isolated-public-release.md`
 - `references/publication-targets.md`
 
 # Workflow
@@ -67,24 +75,40 @@ not as rules to copy into downstream projects.
 5. If support-policy decisions in the release scope are still open, apply
    skill `ai-skills-version-support-policy` before finalizing the release
    candidate.
-6. Confirm versioned release examples and documentation references are known so
+6. Detect the applicable publication targets from
+   `references/publication-targets.md`. If a public registry release would ship
+   unrelated unreleased default-branch work, switch to the isolated-release
+   path in `references/isolated-public-release.md` and create the release
+   source from the latest released tag.
+7. On the isolated-release path, recreate or cherry-pick only the scoped
+   release change onto the isolated branch and stop until unrelated unreleased
+   work is excluded.
+8. Confirm versioned release examples and documentation references are known so
    the release can update them to the new tag.
-7. Apply skill `ai-skills-release-github` to perform the GitHub-release workflow,
+9. Apply skill `ai-skills-release-github` to perform the GitHub-release workflow,
    including version selection, changelog/docs alignment, release-prep commit,
-   versioned-example updates, tag creation, push, and GitHub Release creation.
-8. Publish release artifacts only after tag creation and GitHub Release
+   versioned-example updates, tag creation, push, and GitHub Release creation,
+   using the default branch by default or the isolated release branch when the
+   isolated path was required.
+10. Publish release artifacts only after tag creation and GitHub Release
    creation both succeed. Publish to each applicable target registry listed in
    `references/publication-targets.md`, such as Maven Central, the Gradle
    Plugin Portal, or a private artifactory, and record any target that is
    intentionally not applicable.
-9. Verify the published artifacts and release metadata so version numbers,
-   tags, changelog entries, and published packages all match.
-10. Use `examples/release-checklist.md` when communicating the completed release
+11. Verify the published artifacts and release metadata so version numbers,
+   tags, changelog entries, and published packages all match. Record the
+   released version, tag, chosen release source, and each target result.
+12. If an isolated release branch was used, merge back the same scoped release
+   change cleanly to the default branch or confirm the default branch already
+   contains an equivalent change set.
+13. Use `examples/release-checklist.md` when communicating the completed release
    steps or any blocked publication target.
 
 # Outputs
 
 - a selected release version and final release checklist
+- the chosen release source and, when applicable, isolated-branch merge-back
+  status
 - aligned documentation, changelog, GitHub release, and publication artifacts
 - explicit publication status for each relevant release target
 - a concise release summary with follow-up blockers when publication was only
@@ -95,11 +119,18 @@ not as rules to copy into downstream projects.
 - do not skip the final build or test verification before release
 - do not copy repository-specific release rules into downstream projects; use
   local release policy as input
+- do not release unrelated unreleased default-branch work to a public registry
+- do not create an isolated public-release branch from the default-branch tip;
+  create it from the latest released tag
 - do not skip versioned release example and documentation-reference updates
+- do not recreate or cherry-pick more than the scoped release change onto an
+  isolated release branch
 - do not publish artifacts whose version, changelog, or tag is out of sync
 - do not publish registry artifacts before the tag and GitHub Release exist
 - do not assume every repository publishes to Maven Central, the Gradle Plugin
   Portal, and private artifactory; treat each target as conditional
+- do not declare an isolated public release complete until the same scoped
+  change is merged back cleanly or confirmed equivalent on the default branch
 - do not declare the release complete while a required publication target is
   failed or unverified
 
@@ -107,12 +138,20 @@ not as rules to copy into downstream projects.
 
 - final build and test evidence are green and explicit
 - the selected version matches the documented delta from the previous release
+- the chosen release source is explicit, and any isolated public-release path
+  started from the latest released tag
 - skill `ai-skills-release-github` was applied for the GitHub release portion
+- any isolated public-release branch contains only the scoped release change
+  before tagging and publication
 - versioned examples and documentation references were updated to the new tag or
   explicitly ruled out
 - tag creation completed before GitHub Release creation, and GitHub Release
   creation completed before artifact publication
 - each repository-relevant publication target is either published successfully
   or explicitly marked not applicable
+- the final release report names the released version, tag, chosen release
+  source, and each target outcome
+- any isolated public release was merged back cleanly or confirmed equivalent on
+  the default branch
 - the final release report is concrete enough for downstream consumers and
   maintainers

--- a/skills/ai-skills-release/SKILL.md
+++ b/skills/ai-skills-release/SKILL.md
@@ -45,12 +45,12 @@ not as rules to copy into downstream projects.
 
 # Inputs
 
-- the repository default branch with release-bound changes already merged
-- the latest released tag and the exact scoped release change when a public
+- the repository default branch with release-bound changes already merged, the
+  latest released tag, and the exact scoped release change when a public
   release may need isolation from unrelated unreleased work
 - repository-specific release policy, versioning rules, and publication rules
 - the strongest available final build and test commands or CI evidence
-- the latest release tag and the delta since that release
+- the delta since the latest release
 - any dependency, framework, build-tool, or support-policy changes in the
   release scope that affect the published artifact or support claims
 - documentation, changelog, and versioned example locations that must be

--- a/skills/ai-skills-release/examples/release-checklist.md
+++ b/skills/ai-skills-release/examples/release-checklist.md
@@ -5,6 +5,7 @@
 - delta to previous release: reviewed
 - semantic version: `1.8.0`
 - release tag: `v1.8.0`
+- release source: isolated branch from `v1.7.3`
 - docs/examples updated: yes
 - changelog updated: yes
 - GitHub release: published
@@ -12,6 +13,7 @@
 - Maven Central: published
 - Gradle Plugin Portal: not applicable
 - private artifactory: published
+- merge-back to default branch: completed cleanly
 
 Overall result: release completed successfully for all repository-relevant
 targets.

--- a/skills/ai-skills-release/references/isolated-public-release.md
+++ b/skills/ai-skills-release/references/isolated-public-release.md
@@ -1,0 +1,22 @@
+# Isolated Public Release
+
+Use this path only when a repository-relevant public publication target would
+otherwise ship unrelated unreleased default-branch work.
+
+Sequence:
+
+1. identify the exact scoped release change that must ship now
+2. start the isolated release branch from the latest released tag, not from the
+   current default-branch tip
+3. recreate or cherry-pick only the scoped release change onto that branch
+4. stop if unrelated unreleased work is still present
+5. run the normal release workflow on the isolated branch, including skill `ai-skills-release-github`
+6. publish only to the repository-relevant targets
+7. verify the released version, tag, release notes, and target artifacts all
+   match
+8. merge back the same scoped release change cleanly to the default branch or
+   confirm the default branch already contains an equivalent change set
+
+This path is primarily for intentionally scoped public releases such as a
+dependency-bump publication. It is not a substitute for skipping validation or
+for releasing from an arbitrary branch.

--- a/skills/ai-skills-release/references/publication-targets.md
+++ b/skills/ai-skills-release/references/publication-targets.md
@@ -9,9 +9,11 @@ Evaluate publication targets explicitly:
 For each target:
 
 1. determine whether the repository actually publishes there
-2. publish only after the tag exists and the GitHub Release was created
-3. verify the published artifact version and availability
-4. record `not applicable` when the repository does not use that target
+2. determine whether the target is public enough that unrelated unreleased
+   default-branch work must be excluded before publication
+3. publish only after the tag exists and the GitHub Release was created
+4. verify the published artifact version and availability
+5. record `not applicable` when the repository does not use that target
 
 Do not treat optional targets as mandatory, but do not silently skip required
 targets either.

--- a/skills/ai-skills-release/references/publication-targets.md
+++ b/skills/ai-skills-release/references/publication-targets.md
@@ -10,7 +10,11 @@ For each target:
 
 1. determine whether the repository actually publishes there
 2. determine whether the target is public enough that unrelated unreleased
-   default-branch work must be excluded before publication
+   default-branch work must be excluded before publication; treat a target as
+   public enough when publishing would immediately expose artifacts to the
+   general public, such as Maven Central or the Gradle Plugin Portal, and do
+   not treat private or access-controlled registries as public enough unless
+   repository policy says they should follow the same isolation rule
 3. publish only after the tag exists and the GitHub Release was created
 4. verify the published artifact version and availability
 5. record `not applicable` when the repository does not use that target

--- a/skills/ai-skills-release/references/release-preconditions.md
+++ b/skills/ai-skills-release/references/release-preconditions.md
@@ -8,6 +8,10 @@ Before running the release:
 - final build is green
 - final test run is green
 - latest release tag and delta are known
+- any public-registry release target that would ship unrelated unreleased
+  default-branch work is identified before source-branch selection
+- the exact scoped release change is identified when an isolated public release
+  may be required
 - changelog, versioned documentation, and versioned example locations are
   identified
 


### PR DESCRIPTION
Closes #202

## Implementation Summary
- detect when a repository-relevant public release target would ship unrelated unreleased default-branch work
- add an isolated public-release path that starts from the latest released tag and carries only the scoped release change
- require release reporting to include release source, target outcomes, and clean merge-back status for isolated releases

## Review Focus
- whether the isolated public-release trigger is scoped tightly enough to public publication targets
- whether the merge-back and target-reporting requirements are clear without duplicating repository-specific policy

## Validation
- `corepack pnpm lint:md`
- `corepack pnpm validate`
- `corepack pnpm test`
- `corepack pnpm quality:cognitive`
- `corepack pnpm quality:crap`
- `corepack pnpm pack:dry-run`
