### PR TITLE
Add concrete CI bootstrap examples

### DIFF
--- a/skills/ai-skills-bootstrap-ci-pipeline/SKILL.md
+++ b/skills/ai-skills-bootstrap-ci-pipeline/SKILL.md
@@ -64,12 +64,14 @@ vendor, framework, or deployment path.
    for registry or artifact publication; `tools` for manual helper jobs.
 7. If the target platform is GitHub Actions, group jobs under one workflow
    category such as `CI`, `Release`, or `Nightly`, use job `needs` for
-   ordering, and encode the stage family in job names such as `build`,
-   `test / unit`, `package`, `verify / integration`, `verify / owasp`,
-   `publish`, or `tools / ...`.
+   ordering, keep YAML job IDs valid and simple such as `test-unit` or
+   `verify-owasp`, and encode the stage family in job display names such as
+   `build`, `test / unit`, `package`, `verify / integration`,
+   `verify / owasp`, `publish`, or `tools / ...`.
 8. When GitHub required checks depend on Actions jobs, keep the combined check
    context, usually `<workflow name> / <job name>`, unique and stable so branch
-   protection stays unambiguous over time.
+   protection stays unambiguous over time. Treat `<job name>` as the job
+   display name from `jobs.<id>.name`, or the job ID when `name` is omitted.
 9. Prefer a stable required-check contract from the start, for example
    `CI / build`, `CI / test / unit`, `CI / package`, and
    `CI / verify / policy`, instead of renaming workflows or jobs casually after
@@ -105,7 +107,8 @@ vendor, framework, or deployment path.
   commands
 - the stage-family layout is explicit for the chosen CI platform
 - GitLab pipelines use the required stage order, or GitHub Actions workflows
-  encode the required analogue with `needs` and unique job names
+  encode the required analogue with `needs`, valid job IDs, and unique job
+  display names
 - required-check contexts are stable enough for branch protection or the
   blocker is surfaced explicitly
 - the supported runtime or platform matrix is explicit or an upstream blocker

--- a/skills/ai-skills-bootstrap-ci-pipeline/SKILL.md
+++ b/skills/ai-skills-bootstrap-ci-pipeline/SKILL.md
@@ -25,6 +25,8 @@ vendor, framework, or deployment path.
   platform matrix is still undecided and CI coverage depends on it
 - use `references/ci-layout-conventions.md` for the required GitLab stage order
   and the GitHub Actions naming and grouping analogue
+- use `examples/github-actions-bootstrap-ci.md` or
+  `examples/gitlab-bootstrap-ci.md` when a concrete starter skeleton helps
 
 # Inputs
 
@@ -35,8 +37,12 @@ vendor, framework, or deployment path.
   validation
 - branch, PR, and merge-gate expectations for CI execution
 - the target CI surface and any organization policy that constrains it
+- any branch-protection or required-check names that must stay stable
 - secret, token, cache, or artifact needs for the CI environment
 - `references/ci-layout-conventions.md`
+- `examples/github-actions-bootstrap-ci.md` or
+  `examples/gitlab-bootstrap-ci.md` when the output should include a concrete
+  starter layout
 
 # Workflow
 
@@ -62,12 +68,19 @@ vendor, framework, or deployment path.
    `test / unit`, `package`, `verify / integration`, `verify / owasp`,
    `publish`, or `tools / ...`.
 8. When GitHub required checks depend on job names, keep those job names unique
-   across workflows so branch protection stays unambiguous.
-9. Define the initial triggers, jobs, and status expectations around the real
+   across workflows so branch protection stays unambiguous and stable over
+   time.
+9. Prefer a stable required-check contract from the start, for example
+   `build`, `test / unit`, `package`, and `verify / policy`, instead of
+   renaming jobs casually after branch protection is enabled.
+10. Use `examples/github-actions-bootstrap-ci.md` or
+    `examples/gitlab-bootstrap-ci.md` when a concrete starter skeleton makes
+    the bootstrap output easier to apply.
+11. Define the initial triggers, jobs, and status expectations around the real
    project commands rather than placeholder commands.
-10. Configure secrets, caches, and artifacts conservatively so CI can run
+12. Configure secrets, caches, and artifacts conservatively so CI can run
    safely without overscoping credentials.
-11. Record how CI status feeds later bootstrap, merge, or release workflows.
+13. Record how CI status feeds later bootstrap, merge, or release workflows.
 
 # Outputs
 
@@ -92,6 +105,8 @@ vendor, framework, or deployment path.
 - the stage-family layout is explicit for the chosen CI platform
 - GitLab pipelines use the required stage order, or GitHub Actions workflows
   encode the required analogue with `needs` and unique job names
+- required-check names are stable enough for branch protection or the blocker
+  is surfaced explicitly
 - the supported runtime or platform matrix is explicit or an upstream blocker
   is surfaced
 - trigger behavior and merge-status expectations are explicit

--- a/skills/ai-skills-bootstrap-ci-pipeline/SKILL.md
+++ b/skills/ai-skills-bootstrap-ci-pipeline/SKILL.md
@@ -37,7 +37,7 @@ vendor, framework, or deployment path.
   validation
 - branch, PR, and merge-gate expectations for CI execution
 - the target CI surface and any organization policy that constrains it
-- any branch-protection or required-check names that must stay stable
+- any branch-protection or required-check contexts that must stay stable
 - secret, token, cache, or artifact needs for the CI environment
 - `references/ci-layout-conventions.md`
 - `examples/github-actions-bootstrap-ci.md` or
@@ -67,12 +67,13 @@ vendor, framework, or deployment path.
    ordering, and encode the stage family in job names such as `build`,
    `test / unit`, `package`, `verify / integration`, `verify / owasp`,
    `publish`, or `tools / ...`.
-8. When GitHub required checks depend on job names, keep those job names unique
-   across workflows so branch protection stays unambiguous and stable over
-   time.
+8. When GitHub required checks depend on Actions jobs, keep the combined check
+   context, usually `<workflow name> / <job name>`, unique and stable so branch
+   protection stays unambiguous over time.
 9. Prefer a stable required-check contract from the start, for example
-   `build`, `test / unit`, `package`, and `verify / policy`, instead of
-   renaming jobs casually after branch protection is enabled.
+   `CI / build`, `CI / test / unit`, `CI / package`, and
+   `CI / verify / policy`, instead of renaming workflows or jobs casually after
+   branch protection is enabled.
 10. Use `examples/github-actions-bootstrap-ci.md` or
     `examples/gitlab-bootstrap-ci.md` when a concrete starter skeleton makes
     the bootstrap output easier to apply.
@@ -105,8 +106,8 @@ vendor, framework, or deployment path.
 - the stage-family layout is explicit for the chosen CI platform
 - GitLab pipelines use the required stage order, or GitHub Actions workflows
   encode the required analogue with `needs` and unique job names
-- required-check names are stable enough for branch protection or the blocker
-  is surfaced explicitly
+- required-check contexts are stable enough for branch protection or the
+  blocker is surfaced explicitly
 - the supported runtime or platform matrix is explicit or an upstream blocker
   is surfaced
 - trigger behavior and merge-status expectations are explicit

--- a/skills/ai-skills-bootstrap-ci-pipeline/examples/github-actions-bootstrap-ci.md
+++ b/skills/ai-skills-bootstrap-ci-pipeline/examples/github-actions-bootstrap-ci.md
@@ -3,6 +3,8 @@
 Use one stable workflow category such as `CI` and keep the first required-check
 set small and durable.
 
+Replace each `REPLACE_WITH_REAL_*_COMMAND` token before running the example.
+
 ```yaml
 name: CI
 
@@ -18,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: <real build or install command>
+      - run: REPLACE_WITH_REAL_BUILD_OR_INSTALL_COMMAND
 
   test-unit:
     name: test / unit
@@ -27,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: <real unit-test command>
+      - run: REPLACE_WITH_REAL_UNIT_TEST_COMMAND
 
   package:
     name: package
@@ -36,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: <real package command>
+      - run: REPLACE_WITH_REAL_PACKAGE_COMMAND
 
   verify-policy:
     name: verify / policy
@@ -45,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: <real quality, security, or policy command>
+      - run: REPLACE_WITH_REAL_VERIFY_POLICY_COMMAND
 ```
 
 Treat `CI / build`, `CI / test / unit`, `CI / package`, and

--- a/skills/ai-skills-bootstrap-ci-pipeline/examples/github-actions-bootstrap-ci.md
+++ b/skills/ai-skills-bootstrap-ci-pipeline/examples/github-actions-bootstrap-ci.md
@@ -10,7 +10,7 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - <default-branch>
 
 jobs:
   build:

--- a/skills/ai-skills-bootstrap-ci-pipeline/examples/github-actions-bootstrap-ci.md
+++ b/skills/ai-skills-bootstrap-ci-pipeline/examples/github-actions-bootstrap-ci.md
@@ -48,6 +48,7 @@ jobs:
       - run: <real quality, security, or policy command>
 ```
 
-Treat `build`, `test / unit`, `package`, and `verify / policy` as candidate
-required-check names. Add more jobs later by staying inside the same stage
-families instead of renaming these baseline checks.
+Treat `CI / build`, `CI / test / unit`, `CI / package`, and
+`CI / verify / policy` as candidate required-check contexts. Add more jobs
+later by staying inside the same stage families instead of renaming the
+baseline workflow or job names.

--- a/skills/ai-skills-bootstrap-ci-pipeline/examples/github-actions-bootstrap-ci.md
+++ b/skills/ai-skills-bootstrap-ci-pipeline/examples/github-actions-bootstrap-ci.md
@@ -1,0 +1,53 @@
+# Example GitHub Actions Bootstrap CI
+
+Use one stable workflow category such as `CI` and keep the first required-check
+set small and durable.
+
+```yaml
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: <real build or install command>
+
+  test-unit:
+    name: test / unit
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: <real unit-test command>
+
+  package:
+    name: package
+    needs:
+      - test-unit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: <real package command>
+
+  verify-policy:
+    name: verify / policy
+    needs:
+      - package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: <real quality, security, or policy command>
+```
+
+Treat `build`, `test / unit`, `package`, and `verify / policy` as candidate
+required-check names. Add more jobs later by staying inside the same stage
+families instead of renaming these baseline checks.

--- a/skills/ai-skills-bootstrap-ci-pipeline/examples/github-actions-bootstrap-ci.md
+++ b/skills/ai-skills-bootstrap-ci-pipeline/examples/github-actions-bootstrap-ci.md
@@ -3,7 +3,8 @@
 Use one stable workflow category such as `CI` and keep the first required-check
 set small and durable.
 
-Replace each `REPLACE_WITH_REAL_*_COMMAND` token before running the example.
+Replace each `REPLACE_WITH_REAL_*_COMMAND` token and the
+`<default-branch>` placeholder before running the example.
 
 ```yaml
 name: CI

--- a/skills/ai-skills-bootstrap-ci-pipeline/examples/gitlab-bootstrap-ci.md
+++ b/skills/ai-skills-bootstrap-ci-pipeline/examples/gitlab-bootstrap-ci.md
@@ -1,7 +1,9 @@
 # Example GitLab Bootstrap CI
 
 Use the required stage order even when the first bootstrap pipeline only uses a
-subset of the stages.
+subset of the jobs across those stage families.
+
+Replace each `REPLACE_WITH_REAL_*_COMMAND` token before running the example.
 
 ```yaml
 stages:
@@ -15,28 +17,28 @@ stages:
 build:
   stage: build
   script:
-    - <real build or install command>
+    - REPLACE_WITH_REAL_BUILD_OR_INSTALL_COMMAND
 
 test:unit:
   stage: test
   script:
-    - <real unit-test command>
+    - REPLACE_WITH_REAL_UNIT_TEST_COMMAND
 
 package:
   stage: package
   script:
-    - <real package command>
+    - REPLACE_WITH_REAL_PACKAGE_COMMAND
 
 verify:policy:
   stage: verify
   script:
-    - <real quality, security, or policy command>
+    - REPLACE_WITH_REAL_VERIFY_POLICY_COMMAND
 
 tools:debug:
   stage: tools
   when: manual
   script:
-    - <optional helper command>
+    - REPLACE_WITH_REAL_OPTIONAL_HELPER_COMMAND
 ```
 
 Keep manual helper jobs in `tools` and add later jobs by extending the existing

--- a/skills/ai-skills-bootstrap-ci-pipeline/examples/gitlab-bootstrap-ci.md
+++ b/skills/ai-skills-bootstrap-ci-pipeline/examples/gitlab-bootstrap-ci.md
@@ -1,0 +1,43 @@
+# Example GitLab Bootstrap CI
+
+Use the required stage order even when the first bootstrap pipeline only uses a
+subset of the stages.
+
+```yaml
+stages:
+  - build
+  - test
+  - package
+  - verify
+  - publish
+  - tools
+
+build:
+  stage: build
+  script:
+    - <real build or install command>
+
+test:unit:
+  stage: test
+  script:
+    - <real unit-test command>
+
+package:
+  stage: package
+  script:
+    - <real package command>
+
+verify:policy:
+  stage: verify
+  script:
+    - <real quality, security, or policy command>
+
+tools:debug:
+  stage: tools
+  when: manual
+  script:
+    - <optional helper command>
+```
+
+Keep manual helper jobs in `tools` and add later jobs by extending the existing
+stage families instead of inventing a second stage order.

--- a/skills/ai-skills-bootstrap-ci-pipeline/references/ci-layout-conventions.md
+++ b/skills/ai-skills-bootstrap-ci-pipeline/references/ci-layout-conventions.md
@@ -30,9 +30,11 @@ rules:
 
 - use one workflow-level category name such as `CI`, `Release`, or `Nightly`
 - order jobs with `needs`
-- encode the stage family in job names such as `build`, `test / unit`,
-  `package`, `verify / integration`, `verify / owasp`, `publish`, or
-  `tools / ...`
+- use valid YAML job IDs such as `build`, `test-unit`, `verify-integration`,
+  or `verify-owasp`
+- encode the stage family in job display names such as `build`,
+  `test / unit`, `package`, `verify / integration`, `verify / owasp`,
+  `publish`, or `tools / ...`
 - keep the combined required-check context, usually `<workflow name> / <job name>`,
   unique and stable when branch protection depends on it
 - pick the required-check contexts early and keep them stable once branch
@@ -45,9 +47,9 @@ Concrete bootstrap layouts should keep the stage-family intent obvious even
 before the repository adds every optional job.
 
 - GitHub Actions starter skeleton: one workflow category such as `CI`, job
-  names like `build`, `test / unit`, `package`, and `verify / policy`, check
-  contexts such as `CI / build`, and `needs` edges that reflect the
-  stage-family order
+  IDs like `test-unit`, job display names like `build`, `test / unit`,
+  `package`, and `verify / policy`, check contexts such as `CI / build`, and
+  `needs` edges that reflect the stage-family order
 - GitLab starter skeleton: explicit `stages:` in the required order, at least
   one job per used stage family, and manual-only helper jobs in `tools`
 - required-check contexts should map to the smallest stable review gate set the

--- a/skills/ai-skills-bootstrap-ci-pipeline/references/ci-layout-conventions.md
+++ b/skills/ai-skills-bootstrap-ci-pipeline/references/ci-layout-conventions.md
@@ -33,8 +33,8 @@ rules:
 - encode the stage family in job names such as `build`, `test / unit`,
   `package`, `verify / integration`, `verify / owasp`, `publish`, or
   `tools / ...`
-- keep the combined required-check context, usually `<workflow name> / <job
-  name>`, unique and stable when branch protection depends on it
+- keep the combined required-check context, usually `<workflow name> / <job name>`,
+  unique and stable when branch protection depends on it
 - pick the required-check contexts early and keep them stable once branch
   protection depends on them; avoid casual renames such as changing
   `CI / verify / policy` to `CI / checks`

--- a/skills/ai-skills-bootstrap-ci-pipeline/references/ci-layout-conventions.md
+++ b/skills/ai-skills-bootstrap-ci-pipeline/references/ci-layout-conventions.md
@@ -35,6 +35,24 @@ rules:
   `tools / ...`
 - keep job names unique across workflows when required checks are used so
   branch-protection rules stay stable
+- pick the required-check names early and keep them stable once branch
+  protection depends on them; avoid casual renames such as changing
+  `verify / policy` to `checks`
+
+## Starter Skeleton Expectations
+
+Concrete bootstrap layouts should keep the stage-family intent obvious even
+before the repository adds every optional job.
+
+- GitHub Actions starter skeleton: one workflow category such as `CI`, job
+  names like `build`, `test / unit`, `package`, and `verify / policy`, and
+  `needs` edges that reflect the stage-family order
+- GitLab starter skeleton: explicit `stages:` in the required order, at least
+  one job per used stage family, and manual-only helper jobs in `tools`
+- required-check names should map to the smallest stable review gate set the
+  repository actually wants to protect
+- expand from the starter skeleton by adding more jobs inside the same stage
+  families rather than renaming the existing baseline jobs
 
 Apply the layout to the repository's real commands rather than placeholder
 commands.

--- a/skills/ai-skills-bootstrap-ci-pipeline/references/ci-layout-conventions.md
+++ b/skills/ai-skills-bootstrap-ci-pipeline/references/ci-layout-conventions.md
@@ -33,11 +33,11 @@ rules:
 - encode the stage family in job names such as `build`, `test / unit`,
   `package`, `verify / integration`, `verify / owasp`, `publish`, or
   `tools / ...`
-- keep job names unique across workflows when required checks are used so
-  branch-protection rules stay stable
-- pick the required-check names early and keep them stable once branch
+- keep the combined required-check context, usually `<workflow name> / <job
+  name>`, unique and stable when branch protection depends on it
+- pick the required-check contexts early and keep them stable once branch
   protection depends on them; avoid casual renames such as changing
-  `verify / policy` to `checks`
+  `CI / verify / policy` to `CI / checks`
 
 ## Starter Skeleton Expectations
 
@@ -45,11 +45,12 @@ Concrete bootstrap layouts should keep the stage-family intent obvious even
 before the repository adds every optional job.
 
 - GitHub Actions starter skeleton: one workflow category such as `CI`, job
-  names like `build`, `test / unit`, `package`, and `verify / policy`, and
-  `needs` edges that reflect the stage-family order
+  names like `build`, `test / unit`, `package`, and `verify / policy`, check
+  contexts such as `CI / build`, and `needs` edges that reflect the
+  stage-family order
 - GitLab starter skeleton: explicit `stages:` in the required order, at least
   one job per used stage family, and manual-only helper jobs in `tools`
-- required-check names should map to the smallest stable review gate set the
+- required-check contexts should map to the smallest stable review gate set the
   repository actually wants to protect
 - expand from the starter skeleton by adding more jobs inside the same stage
   families rather than renaming the existing baseline jobs


### PR DESCRIPTION
Closes #205

## Implementation Summary
- add concrete GitHub Actions and GitLab bootstrap CI starter skeletons under the skill examples
- expand the CI layout reference with stable required-check naming guidance and starter-skeleton expectations
- update the main skill to require an explicit required-check contract when branch protection depends on CI names

## Review Focus
- whether the starter skeletons are concrete enough without overfitting to one stack
- whether the required-check naming guidance is strong enough for branch-protection setup

## Validation
- `corepack pnpm lint:md`
- `corepack pnpm validate`
- `corepack pnpm test`
- `corepack pnpm quality:cognitive`
- `corepack pnpm quality:crap`
- `corepack pnpm pack:dry-run`
