### PR TITLE
Add bootstrap surface status contract

### DIFF
--- a/skills/ai-skills-bootstrap-project/SKILL.md
+++ b/skills/ai-skills-bootstrap-project/SKILL.md
@@ -57,30 +57,37 @@ This is a composite skill. It orchestrates these children in dependency order:
    must be `skipped` with an explicit reason. Then track final child results
    using only `completed`, `blocked`, `skipped`, or `out-of-scope` according
    to `references/bootstrap-surface-status.md`.
-3. Apply skill `ai-skills-bootstrap-repository` to establish the hosted
-   project home and repository-level policy decisions.
+3. If `repository` is in scope, apply skill `ai-skills-bootstrap-repository`
+   to establish the hosted project home and repository-level policy decisions.
+   Otherwise, do not run the child and record the surface as `out-of-scope`.
 4. Record the repository child result using the required per-surface fields
    from `references/bootstrap-surface-status.md`, including the final status,
    the child skill used, the handoff output or explicit `none`, and any
    blocker, skip reason, or named gap when the status is not `completed`.
-5. Apply skill `ai-skills-bootstrap-ai-instructions` so the downstream
-   instruction layer is wired before project-specific implementation patterns
-   spread.
+5. If `ai-instructions` is in scope, apply skill `ai-skills-bootstrap-ai-instructions`
+   so the downstream instruction layer is
+   wired before project-specific implementation patterns spread. Otherwise, do
+   not run the child and record the surface as `out-of-scope`.
 6. Record the ai-instructions child result using the same required
    per-surface fields, including the handoff output or explicit `none`, plus
    any blocker, skip reason, or named gap when applicable.
-7. Apply skill `ai-skills-bootstrap-framework-setup` to establish the working
-   framework, runtime, and toolchain baseline.
+7. If `framework` is in scope, apply skill `ai-skills-bootstrap-framework-setup`
+   to establish the working framework,
+   runtime, and toolchain baseline. Otherwise, do not run the child and record
+   the surface as `out-of-scope`.
 8. Record the framework child result using the same required per-surface
    fields, including the handoff output or explicit `none`, plus any blocker,
    skip reason, or named gap when applicable.
-9. Apply skill `ai-skills-bootstrap-ci-pipeline` so the project baseline is
-   checked continuously.
+9. If `ci` is in scope, apply skill `ai-skills-bootstrap-ci-pipeline` so the
+   project baseline is checked continuously. Otherwise, do not run the child
+   and record the surface as `out-of-scope`.
 10. Record the CI child result using the same required per-surface fields,
     including the handoff output or explicit `none`, plus any blocker, skip
     reason, or named gap when applicable.
-11. Apply skill `ai-skills-bootstrap-documentation` last so the initial docs
-   reflect the actual repository, framework, and CI decisions already made.
+11. If `documentation` is in scope, apply skill `ai-skills-bootstrap-documentation`
+   last so the initial docs reflect the
+   actual repository, framework, and CI decisions already made. Otherwise, do
+   not run the child and record the surface as `out-of-scope`.
 12. Record the documentation child result using the same required
     per-surface fields, including the handoff output or explicit `none`, plus
     any blocker, skip reason, or named gap when applicable.

--- a/skills/ai-skills-bootstrap-project/SKILL.md
+++ b/skills/ai-skills-bootstrap-project/SKILL.md
@@ -59,38 +59,46 @@ This is a composite skill. It orchestrates these children in dependency order:
    to `references/bootstrap-surface-status.md`.
 3. If `repository` is in scope, apply skill `ai-skills-bootstrap-repository`
    to establish the hosted project home and repository-level policy decisions.
-   Otherwise, do not run the child and record the surface as `out-of-scope`.
+   Otherwise, do not run the child and record the surface in the next step
+   with status `out-of-scope`.
 4. Record the repository child result using the required per-surface fields
    from `references/bootstrap-surface-status.md`, including the final status,
-   the child skill used, the handoff output or explicit `none`, and any
-   blocker, skip reason, or named gap when the status is not `completed`.
+   the child skill used, the handoff output or explicit `none`, and the
+   blocker, skip reason, out-of-scope rationale, or named gap when the status
+   is not `completed`.
 5. If `ai-instructions` is in scope, apply skill `ai-skills-bootstrap-ai-instructions`
    so the downstream instruction layer is
    wired before project-specific implementation patterns spread. Otherwise, do
-   not run the child and record the surface as `out-of-scope`.
+   not run the child and record the surface in the next step with status
+   `out-of-scope`.
 6. Record the ai-instructions child result using the same required
    per-surface fields, including the handoff output or explicit `none`, plus
-   any blocker, skip reason, or named gap when applicable.
+   the blocker, skip reason, out-of-scope rationale, or named gap when the
+   status is not `completed`.
 7. If `framework` is in scope, apply skill `ai-skills-bootstrap-framework-setup`
    to establish the working framework,
    runtime, and toolchain baseline. Otherwise, do not run the child and record
-   the surface as `out-of-scope`.
+   the surface in the next step with status `out-of-scope`.
 8. Record the framework child result using the same required per-surface
-   fields, including the handoff output or explicit `none`, plus any blocker,
-   skip reason, or named gap when applicable.
+   fields, including the handoff output or explicit `none`, plus the blocker,
+   skip reason, out-of-scope rationale, or named gap when the status is not
+   `completed`.
 9. If `ci` is in scope, apply skill `ai-skills-bootstrap-ci-pipeline` so the
    project baseline is checked continuously. Otherwise, do not run the child
-   and record the surface as `out-of-scope`.
+   and record the surface in the next step with status `out-of-scope`.
 10. Record the CI child result using the same required per-surface fields,
-    including the handoff output or explicit `none`, plus any blocker, skip
-    reason, or named gap when applicable.
+    including the handoff output or explicit `none`, plus the blocker, skip
+    reason, out-of-scope rationale, or named gap when the status is not
+    `completed`.
 11. If `documentation` is in scope, apply skill `ai-skills-bootstrap-documentation`
    last so the initial docs reflect the
    actual repository, framework, and CI decisions already made. Otherwise, do
-   not run the child and record the surface as `out-of-scope`.
+   not run the child and record the surface in the next step with status
+   `out-of-scope`.
 12. Record the documentation child result using the same required
     per-surface fields, including the handoff output or explicit `none`, plus
-    any blocker, skip reason, or named gap when applicable.
+    the blocker, skip reason, out-of-scope rationale, or named gap when the
+    status is not `completed`.
 13. Distinguish a full bootstrap from a partial bootstrap. Full bootstrap
     means every in-scope child finished as `completed` and every excluded
     surface is explicitly `out-of-scope`; partial bootstrap means one or more

--- a/skills/ai-skills-bootstrap-project/SKILL.md
+++ b/skills/ai-skills-bootstrap-project/SKILL.md
@@ -52,30 +52,38 @@ This is a composite skill. It orchestrates these children in dependency order:
 1. Confirm the project really needs a multi-surface bootstrap rather than a
    single leaf setup task.
 2. Before running child skills, classify each bootstrap surface as in scope or
-   `out-of-scope`, then track final child results using only `completed`,
-   `blocked`, `skipped`, or `out-of-scope` according to
-   `references/bootstrap-surface-status.md`.
+   `out-of-scope`. Use `out-of-scope` only for intentionally excluded
+   surfaces. If an in-scope surface is intentionally not run, its final status
+   must be `skipped` with an explicit reason. Then track final child results
+   using only `completed`, `blocked`, `skipped`, or `out-of-scope` according
+   to `references/bootstrap-surface-status.md`.
 3. Apply skill `ai-skills-bootstrap-repository` to establish the hosted
    project home and repository-level policy decisions.
-4. Record the repository child result with its final status, the child skill
-   used, and the handoff output that later bootstrap surfaces rely on.
+4. Record the repository child result using the required per-surface fields
+   from `references/bootstrap-surface-status.md`, including the final status,
+   the child skill used, the handoff output or explicit `none`, and any
+   blocker, skip reason, or named gap when the status is not `completed`.
 5. Apply skill `ai-skills-bootstrap-ai-instructions` so the downstream
    instruction layer is wired before project-specific implementation patterns
    spread.
-6. Record the ai-instructions child result with its final status, the child
-   skill used, and the handoff output for downstream work.
+6. Record the ai-instructions child result using the same required
+   per-surface fields, including the handoff output or explicit `none`, plus
+   any blocker, skip reason, or named gap when applicable.
 7. Apply skill `ai-skills-bootstrap-framework-setup` to establish the working
    framework, runtime, and toolchain baseline.
-8. Record the framework child result with its final status, the child skill
-   used, and the handoff output for CI and documentation.
+8. Record the framework child result using the same required per-surface
+   fields, including the handoff output or explicit `none`, plus any blocker,
+   skip reason, or named gap when applicable.
 9. Apply skill `ai-skills-bootstrap-ci-pipeline` so the project baseline is
    checked continuously.
-10. Record the CI child result with its final status, the child skill used,
-    and the handoff output for later merge or release workflows.
+10. Record the CI child result using the same required per-surface fields,
+    including the handoff output or explicit `none`, plus any blocker, skip
+    reason, or named gap when applicable.
 11. Apply skill `ai-skills-bootstrap-documentation` last so the initial docs
    reflect the actual repository, framework, and CI decisions already made.
-12. Record the documentation child result with its final status, the child
-    skill used, and the handoff output for contributors.
+12. Record the documentation child result using the same required
+    per-surface fields, including the handoff output or explicit `none`, plus
+    any blocker, skip reason, or named gap when applicable.
 13. Distinguish a full bootstrap from a partial bootstrap. Full bootstrap
     means every in-scope child finished as `completed` and every excluded
     surface is explicitly `out-of-scope`; partial bootstrap means one or more

--- a/skills/ai-skills-bootstrap-project/SKILL.md
+++ b/skills/ai-skills-bootstrap-project/SKILL.md
@@ -57,44 +57,51 @@ This is a composite skill. It orchestrates these children in dependency order:
    must be `skipped` with an explicit reason. Then track final child results
    using only `completed`, `blocked`, `skipped`, or `out-of-scope` according
    to `references/bootstrap-surface-status.md`.
-3. If `repository` is in scope, apply skill `ai-skills-bootstrap-repository`
+3. If `repository` is in scope and should run, apply skill `ai-skills-bootstrap-repository`
    to establish the hosted project home and repository-level policy decisions.
-   Otherwise, do not run the child and record the surface in the next step
-   with status `out-of-scope`.
+   If it is in scope but intentionally not run, do not run the child and
+   record the surface in the next step with status `skipped`. Otherwise, do
+   not run the child and record the surface in the next step with status
+   `out-of-scope`.
 4. Record the repository child result using the required per-surface fields
    from `references/bootstrap-surface-status.md`, including the final status,
    the child skill used, the handoff output or explicit `none`, and the
    blocker, skip reason, out-of-scope rationale, or named gap when the status
    is not `completed`.
-5. If `ai-instructions` is in scope, apply skill `ai-skills-bootstrap-ai-instructions`
-   so the downstream instruction layer is
-   wired before project-specific implementation patterns spread. Otherwise, do
-   not run the child and record the surface in the next step with status
-   `out-of-scope`.
+5. If `ai-instructions` is in scope and should run, apply skill `ai-skills-bootstrap-ai-instructions`
+   so the downstream instruction layer is wired before project-specific
+   implementation patterns spread. If it is in scope but intentionally not
+   run, do not run the child and record the surface in the next step with
+   status `skipped`. Otherwise, do not run the child and record the surface in
+   the next step with status `out-of-scope`.
 6. Record the ai-instructions child result using the same required
    per-surface fields, including the handoff output or explicit `none`, plus
    the blocker, skip reason, out-of-scope rationale, or named gap when the
    status is not `completed`.
-7. If `framework` is in scope, apply skill `ai-skills-bootstrap-framework-setup`
-   to establish the working framework,
-   runtime, and toolchain baseline. Otherwise, do not run the child and record
-   the surface in the next step with status `out-of-scope`.
+7. If `framework` is in scope and should run, apply skill `ai-skills-bootstrap-framework-setup`
+   to establish the working framework, runtime, and toolchain baseline. If it
+   is in scope but intentionally not run, do not run the child and record the
+   surface in the next step with status `skipped`. Otherwise, do not run the
+   child and record the surface in the next step with status `out-of-scope`.
 8. Record the framework child result using the same required per-surface
    fields, including the handoff output or explicit `none`, plus the blocker,
    skip reason, out-of-scope rationale, or named gap when the status is not
    `completed`.
-9. If `ci` is in scope, apply skill `ai-skills-bootstrap-ci-pipeline` so the
-   project baseline is checked continuously. Otherwise, do not run the child
-   and record the surface in the next step with status `out-of-scope`.
+9. If `ci` is in scope and should run, apply skill `ai-skills-bootstrap-ci-pipeline`
+   so the project baseline is checked continuously. If it is in scope but
+   intentionally not run, do not run the child and record the surface in the
+   next step with status `skipped`. Otherwise, do not run the child and record
+   the surface in the next step with status `out-of-scope`.
 10. Record the CI child result using the same required per-surface fields,
     including the handoff output or explicit `none`, plus the blocker, skip
     reason, out-of-scope rationale, or named gap when the status is not
     `completed`.
-11. If `documentation` is in scope, apply skill `ai-skills-bootstrap-documentation`
-   last so the initial docs reflect the
-   actual repository, framework, and CI decisions already made. Otherwise, do
-   not run the child and record the surface in the next step with status
-   `out-of-scope`.
+11. If `documentation` is in scope and should run, apply skill `ai-skills-bootstrap-documentation`
+    last so the initial docs reflect the actual repository, framework, and CI
+    decisions already made. If it is in scope but intentionally not run, do
+    not run the child and record the surface in the next step with status
+    `skipped`. Otherwise, do not run the child and record the surface in the
+    next step with status `out-of-scope`.
 12. Record the documentation child result using the same required
     per-surface fields, including the handoff output or explicit `none`, plus
     the blocker, skip reason, out-of-scope rationale, or named gap when the

--- a/skills/ai-skills-bootstrap-project/SKILL.md
+++ b/skills/ai-skills-bootstrap-project/SKILL.md
@@ -116,8 +116,9 @@ This is a composite skill. It orchestrates these children in dependency order:
 - each in-scope bootstrap surface was handled by the correct child skill
 - the execution order preserved repository before framework and CI before final
   documentation
-- every child surface has one explicit status from `completed`, `blocked`,
-  `skipped`, or `out-of-scope`
+- every expected child surface (`repository`, `ai-instructions`,
+  `framework`, `ci`, `documentation`) has exactly one record with one
+  explicit status from `completed`, `blocked`, `skipped`, or `out-of-scope`
 - child handoff outputs and remaining blockers or gaps are explicit
 - skipped, blocked, or out-of-scope child surfaces are explicit
 - the result is labeled full or partial bootstrap correctly

--- a/skills/ai-skills-bootstrap-project/SKILL.md
+++ b/skills/ai-skills-bootstrap-project/SKILL.md
@@ -51,8 +51,9 @@ This is a composite skill. It orchestrates these children in dependency order:
 
 1. Confirm the project really needs a multi-surface bootstrap rather than a
    single leaf setup task.
-2. Before running child skills, classify each bootstrap surface as intended
-   `completed`, `blocked`, `skipped`, or `out-of-scope` according to
+2. Before running child skills, classify each bootstrap surface as in scope or
+   `out-of-scope`, then track final child results using only `completed`,
+   `blocked`, `skipped`, or `out-of-scope` according to
    `references/bootstrap-surface-status.md`.
 3. Apply skill `ai-skills-bootstrap-repository` to establish the hosted
    project home and repository-level policy decisions.
@@ -76,9 +77,10 @@ This is a composite skill. It orchestrates these children in dependency order:
 12. Record the documentation child result with its final status, the child
     skill used, and the handoff output for contributors.
 13. Distinguish a full bootstrap from a partial bootstrap. Full bootstrap
-    means every in-scope child finished as `completed`; partial bootstrap means
-    one or more children are `blocked`, `skipped`, or `out-of-scope`, and each
-    gap must be named explicitly.
+    means every in-scope child finished as `completed` and every excluded
+    surface is explicitly `out-of-scope`; partial bootstrap means one or more
+    in-scope children are `blocked` or `skipped`, and each gap must be named
+    explicitly.
 
 # Outputs
 

--- a/skills/ai-skills-bootstrap-project/SKILL.md
+++ b/skills/ai-skills-bootstrap-project/SKILL.md
@@ -20,6 +20,9 @@ documentation that fit together.
 - use when repository, ai-instructions, framework, CI, and documentation work
   must be sequenced safely
 - use when later setup choices depend on earlier bootstrap outputs
+- use `references/bootstrap-surface-status.md` when the composed bootstrap
+  result must distinguish full completion from partial completion with named
+  gaps
 
 # Inputs
 
@@ -29,6 +32,8 @@ documentation that fit together.
 - whether version-selection decisions for dependencies or support policy are
   already explicit
 - which bootstrap surfaces are in or out of scope for the current project
+- known blockers or partial-delivery expectations for any bootstrap surface
+- `references/bootstrap-surface-status.md`
 
 # Workflow
 
@@ -46,24 +51,43 @@ This is a composite skill. It orchestrates these children in dependency order:
 
 1. Confirm the project really needs a multi-surface bootstrap rather than a
    single leaf setup task.
-2. Apply skill `ai-skills-bootstrap-repository` to establish the hosted
+2. Before running child skills, classify each bootstrap surface as intended
+   `completed`, `blocked`, `skipped`, or `out-of-scope` according to
+   `references/bootstrap-surface-status.md`.
+3. Apply skill `ai-skills-bootstrap-repository` to establish the hosted
    project home and repository-level policy decisions.
-3. Apply skill `ai-skills-bootstrap-ai-instructions` so the downstream
+4. Record the repository child result with its final status, the child skill
+   used, and the handoff output that later bootstrap surfaces rely on.
+5. Apply skill `ai-skills-bootstrap-ai-instructions` so the downstream
    instruction layer is wired before project-specific implementation patterns
    spread.
-4. Apply skill `ai-skills-bootstrap-framework-setup` to establish the working
+6. Record the ai-instructions child result with its final status, the child
+   skill used, and the handoff output for downstream work.
+7. Apply skill `ai-skills-bootstrap-framework-setup` to establish the working
    framework, runtime, and toolchain baseline.
-5. Apply skill `ai-skills-bootstrap-ci-pipeline` so the project baseline is
+8. Record the framework child result with its final status, the child skill
+   used, and the handoff output for CI and documentation.
+9. Apply skill `ai-skills-bootstrap-ci-pipeline` so the project baseline is
    checked continuously.
-6. Apply skill `ai-skills-bootstrap-documentation` last so the initial docs
+10. Record the CI child result with its final status, the child skill used,
+    and the handoff output for later merge or release workflows.
+11. Apply skill `ai-skills-bootstrap-documentation` last so the initial docs
    reflect the actual repository, framework, and CI decisions already made.
-7. Surface any skipped child as intentionally out of scope rather than quietly
-   omitting it.
+12. Record the documentation child result with its final status, the child
+    skill used, and the handoff output for contributors.
+13. Distinguish a full bootstrap from a partial bootstrap. Full bootstrap
+    means every in-scope child finished as `completed`; partial bootstrap means
+    one or more children are `blocked`, `skipped`, or `out-of-scope`, and each
+    gap must be named explicitly.
 
 # Outputs
 
 - an ordered project-bootstrap decision record
 - all in-scope bootstrap surfaces delegated to the correct child skills
+- a per-child status record using only `completed`, `blocked`, `skipped`, or
+  `out-of-scope`
+- explicit child handoff outputs and named remaining gaps when the bootstrap is
+  partial
 - a coherent starting project baseline across repository, instructions,
   framework, CI, and documentation
 
@@ -73,11 +97,18 @@ This is a composite skill. It orchestrates these children in dependency order:
 - do not reorder the bootstrap sequence without an explicit dependency reason
 - do not broaden this skill into release, maintenance, or long-term governance
 - do not treat a skipped bootstrap surface as implicitly complete
+- do not report the composite bootstrap as complete without a per-child status
+  and handoff record
+- do not describe a partial bootstrap as a full bootstrap
 
 # Exit Checks
 
 - each in-scope bootstrap surface was handled by the correct child skill
 - the execution order preserved repository before framework and CI before final
   documentation
-- skipped or blocked child surfaces are explicit
+- every child surface has one explicit status from `completed`, `blocked`,
+  `skipped`, or `out-of-scope`
+- child handoff outputs and remaining blockers or gaps are explicit
+- skipped, blocked, or out-of-scope child surfaces are explicit
+- the result is labeled full or partial bootstrap correctly
 - the result is a coherent starting point rather than disconnected setup steps

--- a/skills/ai-skills-bootstrap-project/SKILL.md
+++ b/skills/ai-skills-bootstrap-project/SKILL.md
@@ -109,9 +109,9 @@ This is a composite skill. It orchestrates these children in dependency order:
 
 - an ordered project-bootstrap decision record
 - all in-scope bootstrap surfaces delegated to the correct child skills
-- a per-child status record using only `completed`, `blocked`, `skipped`, or
+- a per-surface status record using only `completed`, `blocked`, `skipped`, or
   `out-of-scope`
-- explicit child handoff outputs and named remaining gaps when the bootstrap is
+- explicit surface handoff outputs and named remaining gaps when the bootstrap is
   partial
 - a coherent starting project baseline across repository, instructions,
   framework, CI, and documentation
@@ -122,8 +122,8 @@ This is a composite skill. It orchestrates these children in dependency order:
 - do not reorder the bootstrap sequence without an explicit dependency reason
 - do not broaden this skill into release, maintenance, or long-term governance
 - do not treat a skipped bootstrap surface as implicitly complete
-- do not report the composite bootstrap as complete without a per-child status
-  and handoff record
+- do not report the composite bootstrap as complete without a per-surface
+  status and handoff record
 - do not describe a partial bootstrap as a full bootstrap
 
 # Exit Checks

--- a/skills/ai-skills-bootstrap-project/references/bootstrap-surface-status.md
+++ b/skills/ai-skills-bootstrap-project/references/bootstrap-surface-status.md
@@ -1,0 +1,28 @@
+# Bootstrap Surface Status
+
+The composed bootstrap skill should report one status for each child surface:
+
+- `completed`: the child skill ran and produced the expected bootstrap output
+- `blocked`: the child skill could not complete because a prerequisite,
+  dependency, or external decision is missing
+- `skipped`: the child was intentionally not run even though the broader
+  bootstrap remains in scope
+- `out-of-scope`: the surface is intentionally excluded from the current
+  bootstrap request
+
+For each child surface, record:
+
+1. surface name
+2. child skill used
+3. final status
+4. handoff output for downstream bootstrap work
+5. blocker, skip reason, or named gap when the status is not `completed`
+
+Composite classification:
+
+- full bootstrap: every in-scope child surface is `completed`
+- partial bootstrap: one or more child surfaces are `blocked`, `skipped`, or
+  `out-of-scope`
+
+Do not describe a bootstrap as complete unless the child-status record shows a
+full bootstrap.

--- a/skills/ai-skills-bootstrap-project/references/bootstrap-surface-status.md
+++ b/skills/ai-skills-bootstrap-project/references/bootstrap-surface-status.md
@@ -20,9 +20,10 @@ For each child surface, record:
 
 Composite classification:
 
-- full bootstrap: every in-scope child surface is `completed`
-- partial bootstrap: one or more child surfaces are `blocked`, `skipped`, or
-  `out-of-scope`
+- full bootstrap: every in-scope child surface is `completed` and every
+  excluded surface is explicitly `out-of-scope`
+- partial bootstrap: one or more in-scope child surfaces are `blocked` or
+  `skipped`
 
 Do not describe a bootstrap as complete unless the child-status record shows a
 full bootstrap.

--- a/skills/ai-skills-bootstrap-project/references/bootstrap-surface-status.md
+++ b/skills/ai-skills-bootstrap-project/references/bootstrap-surface-status.md
@@ -19,6 +19,14 @@ For each child surface, record:
    not yield one
 5. blocker, skip reason, or named gap when the status is not `completed`
 
+Use these canonical surface names and record each exactly once:
+
+- `repository`
+- `ai-instructions`
+- `framework`
+- `ci`
+- `documentation`
+
 Composite classification:
 
 - full bootstrap: every in-scope child surface is `completed` and every

--- a/skills/ai-skills-bootstrap-project/references/bootstrap-surface-status.md
+++ b/skills/ai-skills-bootstrap-project/references/bootstrap-surface-status.md
@@ -18,7 +18,8 @@ For each child surface, record:
 3. final status
 4. handoff output for downstream bootstrap work, or `none` when the status did
    not yield one
-5. blocker, skip reason, or named gap when the status is not `completed`
+5. reason or rationale when the status is not `completed`, such as a blocker,
+   skip reason, out-of-scope rationale, or named gap
 
 Use these canonical surface names and record each exactly once:
 

--- a/skills/ai-skills-bootstrap-project/references/bootstrap-surface-status.md
+++ b/skills/ai-skills-bootstrap-project/references/bootstrap-surface-status.md
@@ -15,7 +15,8 @@ For each child surface, record:
 1. surface name
 2. child skill used
 3. final status
-4. handoff output for downstream bootstrap work
+4. handoff output for downstream bootstrap work, or `none` / `not produced`
+   when the status did not yield one
 5. blocker, skip reason, or named gap when the status is not `completed`
 
 Composite classification:
@@ -24,6 +25,10 @@ Composite classification:
   excluded surface is explicitly `out-of-scope`
 - partial bootstrap: one or more in-scope child surfaces are `blocked` or
   `skipped`
+
+Do not use `out-of-scope` as a substitute for skipping an in-scope surface.
+When the broader bootstrap still includes a surface but the child was not run,
+record it as `skipped` with a reason.
 
 Do not describe a bootstrap as complete unless the child-status record shows a
 full bootstrap.

--- a/skills/ai-skills-bootstrap-project/references/bootstrap-surface-status.md
+++ b/skills/ai-skills-bootstrap-project/references/bootstrap-surface-status.md
@@ -15,8 +15,8 @@ For each child surface, record:
 1. surface name
 2. child skill used
 3. final status
-4. handoff output for downstream bootstrap work, or `none` / `not produced`
-   when the status did not yield one
+4. handoff output for downstream bootstrap work, or `none` when the status did
+   not yield one
 5. blocker, skip reason, or named gap when the status is not `completed`
 
 Composite classification:

--- a/skills/ai-skills-bootstrap-project/references/bootstrap-surface-status.md
+++ b/skills/ai-skills-bootstrap-project/references/bootstrap-surface-status.md
@@ -13,7 +13,8 @@ The composed bootstrap skill should report one status for each child surface:
 For each child surface, record:
 
 1. surface name
-2. child skill used
+2. child skill used, or the surface's assigned child skill when the child was
+   not run
 3. final status
 4. handoff output for downstream bootstrap work, or `none` when the status did
    not yield one
@@ -26,6 +27,15 @@ Use these canonical surface names and record each exactly once:
 - `framework`
 - `ci`
 - `documentation`
+
+Use these canonical child-skill assignments for the record, even when a
+surface is `out-of-scope` or `skipped` and the child did not run:
+
+- `repository` -> skill `ai-skills-bootstrap-repository`
+- `ai-instructions` -> skill `ai-skills-bootstrap-ai-instructions`
+- `framework` -> skill `ai-skills-bootstrap-framework-setup`
+- `ci` -> skill `ai-skills-bootstrap-ci-pipeline`
+- `documentation` -> skill `ai-skills-bootstrap-documentation`
 
 Composite classification:
 


### PR DESCRIPTION
Closes #204

## Implementation Summary
- require the composite bootstrap skill to report one explicit status per child surface using `completed`, `blocked`, `skipped`, or `out-of-scope`
- require a child handoff record for repository, ai-instructions, framework, CI, and documentation outputs
- distinguish full bootstrap from partial bootstrap and force named gaps when any child surface is not completed

## Review Focus
- whether the child-status vocabulary is clear enough for composed bootstrap reporting
- whether the full-vs-partial bootstrap distinction is enforced strongly enough

## Validation
- `corepack pnpm lint:md`
- `corepack pnpm validate`
- `corepack pnpm test`
- `corepack pnpm quality:cognitive`
- `corepack pnpm quality:crap`
- `corepack pnpm pack:dry-run`
