### PR TITLE
Clarify support policy boundaries

### DIFF
--- a/skills/ai-skills-version-support-policy/SKILL.md
+++ b/skills/ai-skills-version-support-policy/SKILL.md
@@ -24,7 +24,7 @@ documentation, CI, and compatibility promises all align.
 - use before skill `ai-skills-release` when the release changes the official
   support matrix or deprecates a previously supported line
 - use `references/support-policy-boundaries.md` for the boundary between
-  official support, tested best-effort compatibility, and unverified versions
+  official support, tested compatibility, and unverified versions
 
 # Inputs
 

--- a/skills/ai-skills-version-support-policy/SKILL.md
+++ b/skills/ai-skills-version-support-policy/SKILL.md
@@ -24,7 +24,7 @@ documentation, CI, and compatibility promises all align.
 - use before skill `ai-skills-release` when the release changes the official
   support matrix or deprecates a previously supported line
 - use `references/support-policy-boundaries.md` for the boundary between
-  official support, tested compatibility, and unverified versions
+  official support, tested compatibility only, and unverified versions
 
 # Inputs
 
@@ -47,8 +47,8 @@ documentation, CI, and compatibility promises all align.
 4. When maintained LTS releases exist, default official support to maintained
    LTS lines rather than non-LTS lines unless project policy requires broader
    support.
-5. Distinguish official support, tested compatibility, and unverified versions
-   instead of collapsing them into one claim. Use
+5. Distinguish official support, tested compatibility only, and unverified
+   versions instead of collapsing them into one claim. Use
    `references/support-policy-boundaries.md` for concrete boundary examples.
 6. If the project still needs framework, build-tool, or dependency version
    choices within the chosen support window, hand off to skill `ai-skills-version-dependency-selection`
@@ -84,8 +84,8 @@ documentation, CI, and compatibility promises all align.
 
 - supported versions are explicit and justified
 - EOL and LTS status were considered explicitly
-- the boundary between official support, tested compatibility, and unverified
-  versions is explicit
+- the boundary between official support, tested compatibility only, and
+  unverified versions is explicit
 - CI and documentation implications of the support policy are clear
 - any dependency-selection or release handoff triggered by the support policy is
   explicit

--- a/skills/ai-skills-version-support-policy/SKILL.md
+++ b/skills/ai-skills-version-support-policy/SKILL.md
@@ -21,6 +21,10 @@ documentation, CI, and compatibility promises all align.
   or application
 - use before skill `ai-skills-version-dependency-selection` when supported
   versions constrain which frameworks, tools, or dependencies remain viable
+- use before skill `ai-skills-release` when the release changes the official
+  support matrix or deprecates a previously supported line
+- use `references/support-policy-boundaries.md` for the boundary between
+  official support, tested best-effort compatibility, and unverified versions
 
 # Inputs
 
@@ -30,6 +34,7 @@ documentation, CI, and compatibility promises all align.
 - upstream vendor support windows, LTS status, and EOL status
 - current or intended CI coverage and documentation claims
 - any explicit user or maintainer policy about support breadth
+- `references/support-policy-boundaries.md`
 
 # Workflow
 
@@ -43,16 +48,27 @@ documentation, CI, and compatibility promises all align.
    LTS lines rather than non-LTS lines unless project policy requires broader
    support.
 5. Distinguish official support, tested compatibility, and unverified versions
-   instead of collapsing them into one claim.
-6. Define the minimum CI and documentation obligations needed to make the
+   instead of collapsing them into one claim. Use
+   `references/support-policy-boundaries.md` for concrete boundary examples.
+6. If the project still needs framework, build-tool, or dependency version
+   choices within the chosen support window, hand off to skill `ai-skills-version-dependency-selection`
+   instead of picking those versions here.
+7. If the support-policy change is part of a release, hand off the finalized
+   policy to skill `ai-skills-release` so release notes, docs, and publication
+   claims stay aligned.
+8. Define the minimum CI and documentation obligations needed to make the
    support policy credible.
-7. Surface any planned support additions, removals, or deprecations clearly
+9. Surface any planned support additions, removals, or deprecations clearly
    enough for downstream consumers to react.
 
 # Outputs
 
 - an explicit supported-version policy for the scoped runtimes or platforms
+- explicit classification of versions as officially supported, tested
+  compatibility only, or unverified
 - aligned expectations for CI coverage and documentation claims
+- clear handoff notes when dependency selection or release work must consume
+  the support decision
 - clear deprecation or exclusion notes when versions are no longer supported
 
 # Guardrails
@@ -61,10 +77,16 @@ documentation, CI, and compatibility promises all align.
 - do not claim broad compatibility without CI or documented testing support
 - do not conflate best-effort compatibility with official support
 - do not broaden this skill into dependency graph version selection
+- do not turn this skill into release semantic-version selection or release-note
+  drafting
 
 # Exit Checks
 
 - supported versions are explicit and justified
 - EOL and LTS status were considered explicitly
+- the boundary between official support, tested compatibility, and unverified
+  versions is explicit
 - CI and documentation implications of the support policy are clear
+- any dependency-selection or release handoff triggered by the support policy is
+  explicit
 - removed or unsupported versions are called out concretely

--- a/skills/ai-skills-version-support-policy/references/support-policy-boundaries.md
+++ b/skills/ai-skills-version-support-policy/references/support-policy-boundaries.md
@@ -9,8 +9,8 @@ Use this when the project commits to the version in docs, CI, and issue triage.
 
 Example:
 
-- `Node.js 24.x` is officially supported because it is a maintained LTS line
-  and the project runs CI on it
+- `Node.js <primary support line>` is officially supported because the project
+  documents it, runs CI on it, and triages issues against it
 
 ## Tested Compatibility Only
 
@@ -19,8 +19,9 @@ commit to full support obligations.
 
 Example:
 
-- `Node.js 22.x` is tested for compatibility in a smoke workflow, but the
-  project only triages official support bugs against `24.x`
+- `Node.js <compatibility-only line>` is tested for compatibility in a smoke
+  workflow, but the project only triages official support bugs against the
+  primary support line
 
 ## Unverified
 
@@ -28,8 +29,8 @@ Use this when the project has not committed to support or even limited testing.
 
 Example:
 
-- `Node.js 25.x` is unverified because the project has not added CI coverage or
-  documented support expectations yet
+- `Node.js <newly released line not yet in CI>` is unverified because the
+  project has not added CI coverage or documented support expectations yet
 
 ## Boundary Handoffs
 

--- a/skills/ai-skills-version-support-policy/references/support-policy-boundaries.md
+++ b/skills/ai-skills-version-support-policy/references/support-policy-boundaries.md
@@ -1,7 +1,7 @@
 # Support Policy Boundaries
 
 Use these categories explicitly instead of implying one broad compatibility
-claim.
+claim: officially supported, tested compatibility only, and unverified.
 
 ## Officially Supported
 

--- a/skills/ai-skills-version-support-policy/references/support-policy-boundaries.md
+++ b/skills/ai-skills-version-support-policy/references/support-policy-boundaries.md
@@ -1,0 +1,40 @@
+# Support Policy Boundaries
+
+Use these categories explicitly instead of implying one broad compatibility
+claim.
+
+## Officially Supported
+
+Use this when the project commits to the version in docs, CI, and issue triage.
+
+Example:
+
+- `Node.js 24.x` is officially supported because it is a maintained LTS line
+  and the project runs CI on it
+
+## Tested Compatibility Only
+
+Use this when the project has some evidence that the version works but does not
+commit to full support obligations.
+
+Example:
+
+- `Node.js 22.x` is tested for compatibility in a smoke workflow, but the
+  project only triages official support bugs against `24.x`
+
+## Unverified
+
+Use this when the project has not committed to support or even limited testing.
+
+Example:
+
+- `Node.js 25.x` is unverified because the project has not added CI coverage or
+  documented support expectations yet
+
+## Boundary Handoffs
+
+- hand off to skill `ai-skills-version-dependency-selection` when frameworks,
+  build tools, or dependencies still need concrete version choices inside the
+  chosen support window
+- hand off to skill `ai-skills-release` when the support-policy change must be
+  communicated in release notes, changelog entries, or publication claims


### PR DESCRIPTION
Closes #207

## Implementation Summary
- add explicit support-policy boundary examples for officially supported, tested compatibility only, and unverified versions
- make the main skill hand off concrete dependency-version choices to `ai-skills-version-dependency-selection`
- require support-policy changes in a release to hand off to `ai-skills-release` so release claims stay aligned

## Review Focus
- whether the three support categories are distinct enough in the reference examples
- whether the handoff boundaries keep this skill out of dependency-selection and release-versioning work

## Validation
- `corepack pnpm lint:md`
- `corepack pnpm validate`
- `corepack pnpm test`
- `corepack pnpm quality:cognitive`
- `corepack pnpm quality:crap`
- `corepack pnpm pack:dry-run`
