### PR TITLE
Tighten PR review response closure contract

### DIFF
--- a/skills/ai-skills-pr-review-loop/SKILL.md
+++ b/skills/ai-skills-pr-review-loop/SKILL.md
@@ -82,8 +82,9 @@ after the latest push has been reviewed.
    push, keep the PR active and continue with the next item.
 8. When the latest push has completed review results, apply
    skill `ai-skills-pr-review` and skill `ai-skills-pr-review-respond` to classify
-   findings, reply to each thread, fix valid issues, and resolve only the
-   threads that were actually handled.
+   handled findings as valid or invalid, reply to every handled thread, fix
+   every valid finding, and resolve all handled threads before the round is
+   complete.
 9. If fixes were pushed, restart the same post-push review cycle for that PR
    instead of treating earlier review results as sufficient, and explicitly
    re-trigger automated review for the new head commit. For strict GitHub
@@ -106,7 +107,8 @@ after the latest push has been reviewed.
 - explicit note when strict GitHub Copilot review was requested through the
   approved `gh` / GraphQL flow for the latest head commit
 - captured session preferences or explicit note that the loop was skipped
-- handled review threads with explicit valid, invalid, or unresolved treatment
+- handled review threads with explicit valid or invalid classification,
+  required replies, and final resolution
 - issue-link and focused-scope status for each PR
 - merged PRs only when post-push review readiness is satisfied and
   skill `ai-skills-pr-merge` allows merge execution
@@ -130,6 +132,8 @@ after the latest push has been reviewed.
 - do not mention `@copilot` in PR comments
 - do not delete review comments to make threads disappear; resolve handled
   threads and preserve the history
+- do not declare a review round complete while any handled thread lacks a
+  reply, any valid finding remains unfixed, or any handled thread remains open
 - do not resolve invalid findings without leaving a concise rationale first
 - do not merge a PR that lacks the required issue-closing link
 
@@ -145,6 +149,9 @@ after the latest push has been reviewed.
   platform review state
 - each merge-ready PR is focused on its linked issue and has an issue-closing
   link in the PR body
+- each completed review round classified handled findings as valid or invalid,
+  fixed all valid findings, replied to every handled thread, and resolved
+  handled threads
 - remaining blockers are concrete, not generic
 - merged PRs passed the review-readiness gate in the same evaluation round,
   and skill `ai-skills-pr-merge` then allowed merge execution

--- a/skills/ai-skills-pr-review-respond/SKILL.md
+++ b/skills/ai-skills-pr-review-respond/SKILL.md
@@ -105,7 +105,7 @@ that stops completion.
 # Exit Checks
 
 - the applicable review ruleset-read gate was satisfied before classification
-- every handled thread has an explicit valid or invalid classification
+- every handled finding has an explicit valid or invalid classification
 - higher-priority findings were triaged in the documented priority order
 - every valid finding has a fix with regression evidence or proof of behavior
 - invalid findings have a factual rationale

--- a/skills/ai-skills-pr-review-respond/SKILL.md
+++ b/skills/ai-skills-pr-review-respond/SKILL.md
@@ -1,24 +1,28 @@
 ---
 name: ai-skills-pr-review-respond
 description: >-
-  Respond to PR or MR review findings by classifying each finding, fixing
-  valid findings when appropriate, and replying to every thread with concise
-  rationale. Use when addressing review comments after a review pass.
+  Respond to PR or MR review findings by classifying each handled finding as
+  valid or invalid, fixing valid findings, replying to every handled thread,
+  and resolving handled review comments cleanly. Use when addressing review
+  comments after a review pass.
 ---
 <!-- markdownlint-disable MD025 -->
 
 # Purpose
 
 Handle review findings consistently so each thread gets a clear classification,
-an explicit response, and an appropriate fix or rationale.
+an explicit response, and either a completed fix path or a blocked precondition
+that stops completion.
 
 # When to Use
 
 - use when a PR or MR review produced actionable findings or questions
-- use when every review thread needs an explicit valid, invalid, or unresolved
+- use when every handled review thread needs an explicit valid or invalid
   classification
-- use when valid findings should be fixed on the branch with focused tests when
-  appropriate
+- use when valid findings must be fixed on the branch with focused tests or
+  proof of behavior before review handling is complete
+- use when handled review comments must receive both a reply and final
+  resolution
 - use as the response-handling child skill under skill `ai-skills-pr-review`
 - use `references/finding-classification.md` for valid versus invalid
   classification rules
@@ -45,9 +49,9 @@ an explicit response, and an appropriate fix or rationale.
 
 1. Verify that the applicable review ruleset-read gate has been satisfied
    before classifying findings or replying to threads, using parent workflow
-   evidence or skill `ai-skills-plan`. If evidence is missing, stop with an explicit
-   unresolved precondition.
-2. Classify each finding as valid, invalid, or unresolved based on the current
+   evidence or skill `ai-skills-plan`. If evidence is missing, stop with an
+   explicit blocked precondition.
+2. Classify each handled finding as valid or invalid based on the current
    code, rules, and evidence, using this priority order when triaging:
    correctness, security, compliance, data integrity, architecture,
    performance, observability, then maintainability. Interpret this consistently
@@ -55,16 +59,19 @@ an explicit response, and an appropriate fix or rationale.
 3. For dependency-related findings, verify the dependency need, security risk,
    license compatibility, and relevant transitive impact through
    skill `ai-skills-compliance-dependency` before classifying.
-4. For valid findings, apply a bounded fix when appropriate and prefer adding a
-   focused regression test or proof of behavior.
+4. For valid findings, apply a bounded fix before completion and prefer adding
+   a focused regression test or proof of behavior.
 5. For invalid findings, explain the concrete rationale instead of dismissing
    the concern vaguely.
-6. For unresolved findings, explain what evidence, clarification, or follow-up
-   is still needed and keep the thread open until that gap is closed.
-7. Reply to every thread with the classification, concise outcome, checks run,
-   and anything that remains unverified.
-8. Resolve handled threads only when repository or session rules allow the
-   current actor to resolve them.
+6. If missing evidence, missing ruleset-read confirmation, or missing closure
+   authority prevents confident handling, stop with an explicit blocked
+   precondition instead of treating the finding as handled.
+7. Reply to every handled thread with the classification, concise outcome,
+   checks run, and anything that remains unverified.
+8. Resolve every handled thread at the end of the response cycle. If
+   repository or session rules do not allow the current actor to resolve the
+   thread, stop with an explicit blocked precondition instead of treating the
+   response cycle as complete.
 9. Use `references/regression-test-expectations.md` to keep fixes and tests
    proportional to the finding.
 10. Use the bundled examples when a valid or invalid response shape helps.
@@ -72,22 +79,25 @@ an explicit response, and an appropriate fix or rationale.
 # Outputs
 
 - a classification for each handled review finding
-- bounded fixes and regression evidence for valid findings when appropriate
-- concise replies on every addressed review thread
+- bounded fixes and regression evidence for every valid finding
+- concise replies on every handled review thread
+- resolved handled review threads
 - checks run and explicit verification gaps for each addressed finding or
   response batch
-- explicit missing-evidence or follow-up requests for unresolved findings
+- explicit blocked-precondition reasons when evidence or closure authority is
+  missing
 
 # Guardrails
 
 - do not leave actionable review comments unanswered
+- do not leave handled review comments unresolved at completion
 - do not classify or reply before the applicable ruleset-read gate is satisfied
 - do not delete review comments; resolve or leave threads open according to
   repository rules
 - do not classify a finding as invalid without concrete rationale
 - do not classify dependency-related findings without checking dependency need,
   security risk, license compatibility, and relevant transitive impact
-- do not silently treat unresolved findings as valid or invalid
+- do not treat a blocked precondition as a handled finding classification
 - do not skip regression evidence when a valid finding changes behavior
 - do not omit what was verified and what remains unverified
 - do not broaden this skill into the full review loop or final merge decision
@@ -95,11 +105,13 @@ an explicit response, and an appropriate fix or rationale.
 # Exit Checks
 
 - the applicable review ruleset-read gate was satisfied before classification
-- every handled thread has an explicit classification
+- every handled thread has an explicit valid or invalid classification
 - higher-priority findings were triaged in the documented priority order
-- valid findings have a fix, a justified deferral, or clear blocking reason
+- every valid finding has a fix with regression evidence or proof of behavior
 - invalid findings have a factual rationale
-- unresolved findings state what is still needed before closure
+- every handled thread has a reply and is resolved
+- any blocked precondition is explicit instead of being modeled as a handled
+  finding state
 - dependency-related findings include dependency and license/security rationale
 - replies state checks run and remaining verification gaps
 - replies are concise and suitable for PR review flow

--- a/skills/ai-skills-pr-review-respond/SKILL.md
+++ b/skills/ai-skills-pr-review-respond/SKILL.md
@@ -84,7 +84,7 @@ that stops completion.
 - resolved handled review threads
 - checks run and explicit verification gaps for each addressed finding or
   response batch
-- explicit blocked-precondition reasons when evidence or closure authority is
+- explicit blocked precondition reasons when evidence or closure authority is
   missing
 
 # Guardrails

--- a/skills/ai-skills-pr-review-respond/SKILL.md
+++ b/skills/ai-skills-pr-review-respond/SKILL.md
@@ -51,21 +51,21 @@ that stops completion.
    before classifying findings or replying to threads, using parent workflow
    evidence or skill `ai-skills-plan`. If evidence is missing, stop with an
    explicit blocked precondition.
-2. Classify each handled finding as valid or invalid based on the current
+2. Confirm the available evidence is sufficient for a confident valid or
+   invalid classification. If not, stop with an explicit blocked precondition
+   instead of treating the finding as handled.
+3. Classify each handled finding as valid or invalid based on the current
    code, rules, and evidence, using this priority order when triaging:
    correctness, security, compliance, data integrity, architecture,
    performance, observability, then maintainability. Interpret this consistently
    with skill `ai-skills-pr-review-write`.
-3. For dependency-related findings, verify the dependency need, security risk,
+4. For dependency-related findings, verify the dependency need, security risk,
    license compatibility, and relevant transitive impact through
    skill `ai-skills-compliance-dependency` before classifying.
-4. For valid findings, apply a bounded fix before completion and prefer adding
+5. For valid findings, apply a bounded fix before completion and prefer adding
    a focused regression test or proof of behavior.
-5. For invalid findings, explain the concrete rationale instead of dismissing
+6. For invalid findings, explain the concrete rationale instead of dismissing
    the concern vaguely.
-6. If missing evidence, missing ruleset-read confirmation, or missing closure
-   authority prevents confident handling, stop with an explicit blocked
-   precondition instead of treating the finding as handled.
 7. Reply to every handled thread with the classification, concise outcome,
    checks run, and anything that remains unverified.
 8. Resolve every handled thread at the end of the response cycle. If

--- a/skills/ai-skills-pr-review-respond/references/finding-classification.md
+++ b/skills/ai-skills-pr-review-respond/references/finding-classification.md
@@ -5,9 +5,10 @@ Use these states:
 - `valid`: the finding identifies a real issue for the current scope
 - `invalid`: the finding does not hold given the current code, rules, or
   evidence
-- `unresolved`: available evidence is insufficient to classify confidently
 
 Every handled finding should move into one of these states explicitly.
+Missing evidence, missing ruleset-read confirmation, or missing closure
+authority is a blocked precondition, not a handled finding state.
 
 When multiple findings compete for attention, triage them in this priority
 order:

--- a/skills/ai-skills-pr-review/SKILL.md
+++ b/skills/ai-skills-pr-review/SKILL.md
@@ -57,7 +57,7 @@ must remain blocked.
    include severity, and aggregate those severities without redefining them in
    this root skill.
 8. Ensure each resolved thread has a final explanatory reply describing how it
-   was handled or why it was not addressed.
+   was handled and why resolution is appropriate.
 9. Delegate detailed finding-writing, response, loop, or merge behavior to the
    specialized child skills when those are available.
 10. Use `references/review-family-guardrails.md` and
@@ -96,8 +96,7 @@ must remain blocked.
   classification
 - severity-bearing findings preserve the child skill's severity model
 - every resolved thread has a final rationale comment
-- unclear ownership or unresolved responsibility are surfaced explicitly as
-  blockers
+- unclear ownership or responsibility are surfaced explicitly as blockers
 - missing closure authority is surfaced explicitly and leaves the thread open
 - blocked preconditions remain separate from handled-finding classification
 - no merge-loop or implementation behavior was silently inlined here

--- a/skills/ai-skills-pr-review/SKILL.md
+++ b/skills/ai-skills-pr-review/SKILL.md
@@ -73,7 +73,7 @@ must remain blocked.
 - inherited child-skill severity ranking when severity-bearing findings are
   present
 - concise thread responses or closure decisions
-- explicit blocked-precondition reasons when ownership, evidence, or closure
+- explicit blocked precondition reasons when ownership, evidence, or closure
   authority is missing
 
 # Guardrails

--- a/skills/ai-skills-pr-review/SKILL.md
+++ b/skills/ai-skills-pr-review/SKILL.md
@@ -9,7 +9,8 @@ description: >-
 # Purpose
 
 Define the canonical PR review responsibility boundary for classifying findings,
-handling review conversations, and deciding whether a thread may be resolved.
+handling review conversations, and deciding whether a thread may be resolved or
+must remain blocked.
 
 # When to Use
 
@@ -42,35 +43,38 @@ handling review conversations, and deciding whether a thread may be resolved.
 1. Verify that the applicable review ruleset-read gate has been satisfied
    before classifying or resolving findings. If evidence is missing, read the
    applicable review rules before continuing or stop with an explicit
-   unresolved precondition.
+   blocked precondition.
 2. Read the review state, changed scope, and active conversations.
 3. Determine whether the current actor is responsible for handling or resolving
    each thread.
 4. If conversation-resolution rules are missing or unclear, ask the
    user or maintainer whether the current actor may resolve review
    conversations and keep the thread open until that authority is clarified.
-5. Classify each finding as valid, invalid, or unresolved.
-6. Inherit severity ranking from the active child review skill when findings
+5. If ownership, evidence, or closure authority is missing, surface an
+   explicit blocked precondition instead of treating the finding as handled.
+6. Classify each handled finding as valid or invalid.
+7. Inherit severity ranking from the active child review skill when findings
    include severity, and aggregate those severities without redefining them in
    this root skill.
-7. Ensure each resolved thread has a final explanatory reply describing how it
+8. Ensure each resolved thread has a final explanatory reply describing how it
    was handled or why it was not addressed.
-8. Delegate detailed finding-writing, response, loop, or merge behavior to the
+9. Delegate detailed finding-writing, response, loop, or merge behavior to the
    specialized child skills when those are available.
-9. Use `references/review-family-guardrails.md` and
+10. Use `references/review-family-guardrails.md` and
    `references/review-boundary.md` to keep the root skill scoped correctly.
-10. Use `references/pr-review-loop-source.md` only for closure semantics that
+11. Use `references/pr-review-loop-source.md` only for closure semantics that
    belong in the root skill.
-11. Reuse `examples/thread-resolution.md` and
+12. Reuse `examples/thread-resolution.md` and
    `examples/resolution-comment.md` when they fit the current thread shape.
 
 # Outputs
 
-- a classified review state for the active findings
+- a classified review state for the handled findings
 - inherited child-skill severity ranking when severity-bearing findings are
   present
 - concise thread responses or closure decisions
-- an explicit list of unresolved items when ownership or evidence is missing
+- explicit blocked-precondition reasons when ownership, evidence, or closure
+  authority is missing
 
 # Guardrails
 
@@ -78,6 +82,7 @@ handling review conversations, and deciding whether a thread may be resolved.
 - do not classify review findings before the applicable review ruleset-read gate
   is satisfied
 - do not resolve review conversations when closure authority is unknown
+- do not treat a blocker as a third handled-finding classification state
 - do not redefine the severity model when a child review skill already owns it
 - do not close a thread without a final comment explaining the outcome
 - do not broaden this skill into full merge-loop orchestration
@@ -86,11 +91,13 @@ handling review conversations, and deciding whether a thread may be resolved.
 
 # Exit Checks
 
-- every handled thread has a classification
+- every handled thread has a valid or invalid classification
 - the applicable review ruleset-read gate was satisfied before review
   classification
 - severity-bearing findings preserve the child skill's severity model
 - every resolved thread has a final rationale comment
-- unclear ownership or unresolved responsibility are surfaced explicitly
+- unclear ownership or unresolved responsibility are surfaced explicitly as
+  blockers
 - missing closure authority is surfaced explicitly and leaves the thread open
+- blocked preconditions remain separate from handled-finding classification
 - no merge-loop or implementation behavior was silently inlined here

--- a/skills/ai-skills-pr-review/SKILL.md
+++ b/skills/ai-skills-pr-review/SKILL.md
@@ -91,7 +91,7 @@ must remain blocked.
 
 # Exit Checks
 
-- every handled thread has a valid or invalid classification
+- every handled finding has a valid or invalid classification
 - the applicable review ruleset-read gate was satisfied before review
   classification
 - severity-bearing findings preserve the child skill's severity model

--- a/skills/ai-skills-pr-review/examples/thread-resolution.md
+++ b/skills/ai-skills-pr-review/examples/thread-resolution.md
@@ -14,9 +14,10 @@ Classification: invalid
 Final reply: Leaving the implementation as-is because the referenced behavior
 is already covered by the existing guard clause and regression test.
 
-## Unresolved Ownership
+## Blocked Precondition: Missing Closure Authority
 
-Classification: unresolved
+Status: blocked precondition
 
 Final reply: Not resolving this conversation yet because the current review
-rules do not clearly assign ownership for closure.
+rules do not clearly assign ownership for closure. This does not count as
+completed handling until that authority is clarified.

--- a/skills/ai-skills-pr-review/examples/thread-resolution.md
+++ b/skills/ai-skills-pr-review/examples/thread-resolution.md
@@ -19,5 +19,5 @@ is already covered by the existing guard clause and regression test.
 Status: blocked precondition
 
 Final reply: Not resolving this conversation yet because the current review
-rules do not clearly assign ownership for closure. This does not count as
-completed handling until that authority is clarified.
+rules do not clearly grant closure authority to the current actor. This does
+not count as completed handling until that authority is clarified.

--- a/skills/ai-skills-pr-review/references/pr-review-loop-source.md
+++ b/skills/ai-skills-pr-review/references/pr-review-loop-source.md
@@ -4,8 +4,8 @@ Relevant review-loop heuristics used by this skill:
 
 - handling each review item on its own branch and PR often works best
 - review state should generally be re-evaluated after each push
-- missing ownership or unclear state should usually block conversation
-  handling completion and conversation resolution
+- missing ownership or unclear state should usually block handling completion
+  and conversation resolution
 - a clean merge gate typically includes green checks, no remaining valid
   findings, and no open review threads
 

--- a/skills/ai-skills-pr-review/references/pr-review-loop-source.md
+++ b/skills/ai-skills-pr-review/references/pr-review-loop-source.md
@@ -5,10 +5,10 @@ Relevant review-loop heuristics used by this skill:
 - handling each review item on its own branch and PR often works best
 - review state should generally be re-evaluated after each push
 - missing ownership or unclear state should usually block conversation
-  resolution
-- a clean merge gate typically includes green checks, no unresolved valid
-  findings, and
-  no open review threads
+  handling completion and conversation resolution
+- a clean merge gate typically includes green checks, no remaining valid
+  findings, and no open review threads
 
-The root `ai-skills-pr-review` skill uses these ideas only for responsibility and closure
-semantics. The detailed loop orchestration belongs in skill `ai-skills-pr-review-loop`.
+The root `ai-skills-pr-review` skill uses these ideas only for responsibility
+and closure semantics. The detailed loop orchestration belongs in
+skill `ai-skills-pr-review-loop`.

--- a/skills/ai-skills-pr-review/references/review-family-guardrails.md
+++ b/skills/ai-skills-pr-review/references/review-family-guardrails.md
@@ -7,6 +7,9 @@ Distilled from the review, code review, and PR review loop guidance sources.
 - inherit severity ranking from the active child review skill when severity is
   present
 - keep evidence and rationale visible in the thread
+- reply to every handled review comment before considering the thread complete
 - resolve conversations only when ownership and closure conditions are met
-- keep unresolved or ambiguous findings visible
+- keep blockers such as missing evidence or missing closure authority visible
+- treat handled findings as `valid` or `invalid`, not as a third ambiguous
+  completion state
 - treat post-push review state and green checks as separate merge conditions


### PR DESCRIPTION
Closes #222

## Summary
- tighten `ai-skills-pr-review-respond` so handled findings end only as `valid` or `invalid`
- require every handled review comment to receive a reply, require every valid finding to be fixed before completion, and require handled threads to be resolved at the end of the response cycle
- align `ai-skills-pr-review`, `ai-skills-pr-review-loop`, and the bundled review-family references/examples so missing evidence or closure authority is treated as an explicit blocked precondition instead of a third handled state

## Review Focus
- the contract wording across the three review-family skills
- consistency between the updated skill docs and the bundled references/examples
- keeping the scope limited to review-family documentation rather than expanding merge policy or tooling behavior

## Validation
- `corepack pnpm lint:md`
- `corepack pnpm validate`
- `corepack pnpm test`
- `corepack pnpm quality:cognitive`
- `corepack pnpm quality:crap`
- `corepack pnpm pack:dry-run`

## Residual Risk
- low; this is a documentation-only contract change, so the main risk is wording drift in downstream review workflows rather than runtime behavior