### PR TITLE
Clarify pending review signal handling in pr-review-loop

### DIFF
--- a/skills/ai-skills-pr-review-loop/SKILL.md
+++ b/skills/ai-skills-pr-review-loop/SKILL.md
@@ -72,12 +72,15 @@ after the latest push has been reviewed.
    previous pass assumptions, capture the current `headRefOid`, inspect
    required checks, inspect unresolved threads, and inspect both submitted
    automated reviews and review-request timeline evidence for that same head.
-6. If the current head already has a submitted automated review, treat that
-   head as `review-submitted` and continue with the latest review results.
+6. If the current head already has a submitted automated review tied to
+   `headRefOid` and submitted after `last-push-at`, treat that head as
+   `review-submitted` and continue with the latest review results.
 7. If the current head does not yet have a submitted automated review but a
-   visible automatic review request exists for that same head with no newer
-   removal event, treat that head as `review-request-pending` and continue with
-   the next item without re-triggering review.
+   visible automatic review request exists after both `last-push-at` and the
+   `PullRequestCommit` timeline item for `headRefOid`, with no newer
+   `ReviewRequestRemovedEvent` canceling that request, treat that head as
+   `review-request-pending` and continue with the next item without
+   re-triggering review.
 8. If the current head has neither a submitted automated review nor a pending
    review request and fewer than 5 minutes have elapsed since `last-push-at`,
    treat that head as `awaiting-automatic-review-signal` and continue with the

--- a/skills/ai-skills-pr-review-loop/SKILL.md
+++ b/skills/ai-skills-pr-review-loop/SKILL.md
@@ -37,13 +37,15 @@ after the latest push has been reviewed.
 - one or more active PRs with their latest head commits
 - session entry preferences when already answered:
   `RUN_REVIEW_LOOP`, `IMPLEMENT_AFTER_PLAN`, and `MERGE_AFTER_CLEAN_LOOP`
-- the latest push time, automated-review state, review threads, and required
-  checks for each PR
+- the latest push time, current head commit, automated-review state,
+  review-request timeline state, review threads, and required checks for each
+  PR
 - repository preferences about whether clean PRs should be merged
 - access to the PR platform APIs needed to request or inspect automated review
 - for strict GitHub Copilot review loops, access to
-  `gh pr view <PR_NUMBER> --json id --jq .id` and `gh api graphql` for the
-  approved review-request flow
+  `gh api graphql` to inspect current head review and timeline state plus
+  `gh pr view <PR_NUMBER> --json id --jq .id` for the approved manual
+  review-request flow
 - the main linked issue for each PR and whether the PR body contains an
   issue-closing link
 - the intended bounded scope for each PR, used to detect unrelated bundled
@@ -67,45 +69,65 @@ after the latest push has been reviewed.
 4. Process active items in round-robin order instead of waiting idly on a
    single PR.
 5. After each push, require fresh review state for that PR head: clear the
-   previous pass assumptions, inspect required checks, inspect unresolved
-   threads, and determine whether a post-push automated review already exists.
-6. If the latest push does not yet have a submitted automated review, request
-   one through the platform API or configured review mechanism, then move on to
-   the next item without blocking. For strict GitHub Copilot review loops,
-   first capture the PR node id with
-   `gh pr view <PR_NUMBER> --json id --jq .id`, then call `gh api graphql`
-   using the `requestReviewsByLogin` mutation for
+   previous pass assumptions, capture the current `headRefOid`, inspect
+   required checks, inspect unresolved threads, and inspect both submitted
+   automated reviews and review-request timeline evidence for that same head.
+6. If the current head already has a submitted automated review, treat that
+   head as `review-submitted` and continue with the latest review results.
+7. If the current head does not yet have a submitted automated review but a
+   visible automatic review request exists for that same head with no newer
+   removal event, treat that head as `review-request-pending` and continue with
+   the next item without re-triggering review.
+8. If the current head has neither a submitted automated review nor a pending
+   review request and fewer than 5 minutes have elapsed since `last-push-at`,
+   treat that head as `awaiting-automatic-review-signal` and continue with the
+   next item without blocking.
+9. If at least 5 minutes have elapsed since `last-push-at` and the current
+   head still has neither a submitted automated review nor a pending review
+   request, treat that head as `manual-review-request-eligible`, request
+   automated review once through the platform API or configured review
+   mechanism, record `last-review-requested-at` and
+   `last-review-requested-head-oid`, then move on to the next item without
+   blocking. For strict GitHub Copilot review loops, first capture the PR node
+   id with `gh pr view <PR_NUMBER> --json id --jq .id`, then call
+   `gh api graphql` using the `requestReviewsByLogin` mutation for
    `copilot-pull-request-reviewer`, and treat
    `references/copilot-review-trigger.md` as the copy-safe source for the exact
    mutation and verification steps.
-7. If checks are still running or a review is still in progress for the latest
-   push, keep the PR active and continue with the next item.
-8. When the latest push has completed review results, apply
+10. If checks are still running or a review is still in progress for the
+   latest push, keep the PR active and continue with the next item.
+11. When the latest push has completed review results, apply
    skill `ai-skills-pr-review` and skill `ai-skills-pr-review-respond` to classify
    handled findings as valid or invalid, reply to every handled thread, fix
    every valid finding, and resolve all handled threads before the round is
    complete.
-9. If fixes were pushed, restart the same post-push review cycle for that PR
-   instead of treating earlier review results as sufficient, and explicitly
-   re-trigger automated review for the new head commit. For strict GitHub
-   Copilot review loops, repeat the same approved `gh` CLI / GraphQL flow
-   instead of using PR comments or `@copilot` mentions.
-10. If no fixes were needed, verify the PR remains focused on the linked issue
+12. If fixes were pushed, restart the same post-push review cycle for that PR
+   instead of treating earlier review results as sufficient. Do not send a
+   second explicit manual review request for the same head unless the head
+   commit changed or review-request timeline evidence shows the pending request
+   was removed. For strict GitHub Copilot review loops, repeat the same
+   approved `gh` CLI / GraphQL flow instead of using PR comments or `@copilot`
+   mentions.
+13. If no fixes were needed, verify the PR remains focused on the linked issue
    and the PR body contains the issue-closing link, then evaluate the
    review-readiness gate from `references/review-loop-state.md`.
-11. When the review-readiness gate passes and
+14. When the review-readiness gate passes and
    `MERGE_AFTER_CLEAN_LOOP=true`, hand the PR to skill `ai-skills-pr-merge` for
    the remaining merge-policy checks and merge execution; otherwise report the
    blocking gate conditions or clean-but-unmerged status.
-12. Use `examples/review-loop-status.md` when communicating queue state,
+15. Use `examples/review-loop-status.md` when communicating queue state,
    remaining blockers, or clean completion.
 
 # Outputs
 
 - a per-PR status showing review state, remaining blockers, and merge
   readiness
-- explicit note when strict GitHub Copilot review was requested through the
-  approved `gh` / GraphQL flow for the latest head commit
+- explicit note when a current head is `awaiting-automatic-review-signal`,
+  `review-request-pending`, `review-submitted`, or
+  `manual-review-request-eligible`
+- explicit note when strict GitHub Copilot review was manually requested
+  through the approved `gh` / GraphQL flow for the latest head commit after
+  the 5-minute minimum from `last-push-at`
 - captured session preferences or explicit note that the loop was skipped
 - handled review threads with explicit valid or invalid classification,
   required replies, and final resolution
@@ -121,10 +143,16 @@ after the latest push has been reviewed.
 - do not treat a review that predates the latest push as sufficient for merge
 - do not wait idly on one PR when other active items can progress
 - do not use fixed wait timers as merge gates; use review/check/timeline state
+- do not manually request automated review before 5 minutes have elapsed since
+  `last-push-at`
+- do not send a second explicit manual review request for the same head while a
+  pending request for that head is still visible
 - do not merge while review is still running, checks are incomplete, or threads
   remain unresolved
 - do not trigger automated review through ad-hoc PR comments when the platform
   provides a proper API or workflow trigger
+- do not infer that no fresh review is pending from `latestReviews` alone when
+  richer timeline state is available
 - do not replace the approved `gh pr view` plus
   `gh api graphql` flow using the `requestReviewsByLogin` mutation with a
   weaker GitHub comment convention when strict GitHub Copilot review is
@@ -140,13 +168,16 @@ after the latest push has been reviewed.
 # Exit Checks
 
 - every active PR has an explicit current-state summary
+- every active PR state includes the current head commit and review-signal
+  state
 - session entry preferences were captured once or were already supplied by the
   user prompt
 - no PR is marked merge-ready without a completed post-push review for its
   latest head commit
 - when strict GitHub Copilot review is required, the latest head commit review
   came from the approved `gh` / GraphQL trigger flow or already-existing fresh
-  platform review state
+  platform review state, and any manual request honored the 5-minute minimum
+  from `last-push-at`
 - each merge-ready PR is focused on its linked issue and has an issue-closing
   link in the PR body
 - each completed review round classified handled findings as valid or invalid,

--- a/skills/ai-skills-pr-review-loop/examples/review-loop-status.md
+++ b/skills/ai-skills-pr-review-loop/examples/review-loop-status.md
@@ -1,10 +1,18 @@
 # Example Review Loop Status
 
 - `#71` skill `ai-skills-compliance-dependency`: checks green, issue link present, focused scope,
-  no valid findings, no open review threads, waiting only for merge execution
-- `#72` skill `ai-skills-performance-db`: one valid finding fixed and pushed, post-push review
-  requested through the approved `gh` / GraphQL flow, checks still running
-- `#73` skill `ai-skills-release-github`: no review submitted yet for the latest push, PR node id
-  captured with `gh pr view 73 --json id --jq .id`, Copilot review requested via
-  `gh api graphql` using the `requestReviewsByLogin` mutation, loop moved on to
-  the next item
+  no valid findings, no open review threads, `review-submitted`, waiting only
+  for merge execution
+- `#72` skill `ai-skills-performance-db`: one valid finding fixed and pushed
+  2 minutes ago, no submitted review or pending request visible yet,
+  `awaiting-automatic-review-signal`, loop moved on to the next item instead
+  of re-triggering
+- `#73` skill `ai-skills-release-github`: no review submitted yet for the
+  latest push, a pending automatic review request is visible for the current
+  head in GraphQL timeline state, `review-request-pending`, checks still
+  running
+- `#74` skill `ai-skills-bootstrap-ci-pipeline`: latest push is 9 minutes old,
+  no submitted review or pending request is visible for the current head,
+  `manual-review-request-eligible`, PR node id captured with
+  `gh pr view 74 --json id --jq .id`, Copilot review manually requested once
+  via `gh api graphql`, loop moved on to the next item

--- a/skills/ai-skills-pr-review-loop/references/copilot-review-trigger.md
+++ b/skills/ai-skills-pr-review-loop/references/copilot-review-trigger.md
@@ -3,9 +3,30 @@
 Use this reference when strict GitHub Copilot review is the configured
 automated review mechanism.
 
-After every fix push, explicitly request a fresh Copilot review for the PR head
-commit through the approved `gh` CLI / GitHub GraphQL flow. Do not use PR
+After every fix push, first inspect whether the current PR head already has a
+fresh submitted review or a visible pending review request. Do not use PR
 comments or `@copilot` mentions.
+
+Use `gh api graphql` to inspect the current PR `headRefOid`, submitted reviews
+with `commit.oid`, and timeline evidence needed to detect a pending request for
+that same head, including `PullRequestCommit`, `ReviewRequestedEvent`, and
+`ReviewRequestRemovedEvent`. Do not rely on `latestReviews` alone as proof that
+no fresh review is pending.
+
+Decide the current head state in this order:
+
+1. If a submitted automated review is tied to the current `headRefOid`, treat
+   the head as `review-submitted`.
+2. Otherwise, if a `ReviewRequestedEvent` is visible for the current
+   `headRefOid` after the latest push and no newer
+   `ReviewRequestRemovedEvent` cancels it, treat the head as
+   `review-request-pending`.
+3. Otherwise, if fewer than 5 minutes have elapsed since `last-push-at`, treat
+   the head as `awaiting-automatic-review-signal`.
+4. Otherwise, treat the head as `manual-review-request-eligible`.
+
+Only when the head is `manual-review-request-eligible` may the loop send an
+explicit manual request through the approved `gh` CLI / GitHub GraphQL flow.
 
 1. Capture the raw pull request node id:
 
@@ -13,7 +34,8 @@ comments or `@copilot` mentions.
    PR_ID="$(gh pr view <PR_NUMBER> --json id --jq .id)"
    ```
 
-2. Request review from the Copilot review bot with the mutation supplied inline:
+2. Request review from the Copilot review bot with the mutation supplied
+   inline:
 
    ```sh
    gh api graphql \
@@ -28,8 +50,13 @@ comments or `@copilot` mentions.
      -f bots="copilot-pull-request-reviewer"
    ```
 
-3. Verify a new review request or submitted review appears for the latest head
+3. Record `last-review-requested-at` and `last-review-requested-head-oid` for
+   the explicit manual request, then return the PR to the queue.
+4. Verify a new review request or submitted review appears for the latest head
    commit before treating the PR as reviewed.
+5. Do not send a second explicit manual request for the same head unless the
+   head changed or a `ReviewRequestRemovedEvent` proves the pending request was
+   removed.
 
 Treat this flow as the authoritative trigger procedure whenever the main skill
 requires strict GitHub Copilot review re-triggering.

--- a/skills/ai-skills-pr-review-loop/references/copilot-review-trigger.md
+++ b/skills/ai-skills-pr-review-loop/references/copilot-review-trigger.md
@@ -13,14 +13,16 @@ that same head, including `PullRequestCommit`, `ReviewRequestedEvent`, and
 `ReviewRequestRemovedEvent`. Do not rely on `latestReviews` alone as proof that
 no fresh review is pending.
 
+Treat `current-head-oid := headRefOid`.
+
 Decide the current head state in this order:
 
-1. If a submitted automated review is tied to the current `headRefOid`, treat
-   the head as `review-submitted`.
+1. If a submitted automated review is tied to the current `headRefOid` and was
+   submitted after `last-push-at`, treat the head as `review-submitted`.
 2. Otherwise, if a `ReviewRequestedEvent` is visible for the current
-   `headRefOid` after the latest push and no newer
-   `ReviewRequestRemovedEvent` cancels it, treat the head as
-   `review-request-pending`.
+   `headRefOid` after both `last-push-at` and the `PullRequestCommit` timeline
+   item for that head, and no newer `ReviewRequestRemovedEvent` cancels it,
+   treat the head as `review-request-pending`.
 3. Otherwise, if fewer than 5 minutes have elapsed since `last-push-at`, treat
    the head as `awaiting-automatic-review-signal`.
 4. Otherwise, treat the head as `manual-review-request-eligible`.

--- a/skills/ai-skills-pr-review-loop/references/review-loop-queue.md
+++ b/skills/ai-skills-pr-review-loop/references/review-loop-queue.md
@@ -4,22 +4,37 @@ Use round-robin progression across active PRs:
 
 1. inspect the next item
 2. push fixes if needed
-3. request fresh automated review when the latest push has no post-push review
-4. skip items with running checks or active review generation
-5. continue with the next item instead of waiting
+3. classify the current head as `review-submitted`,
+   `review-request-pending`, `awaiting-automatic-review-signal`, or
+   `manual-review-request-eligible`
+4. request fresh automated review only when the current head is
+   `manual-review-request-eligible`
+5. skip items with running checks, active review generation, or a visible
+   pending request for the current head
+6. continue with the next item instead of waiting
 
 This keeps multiple PRs moving in parallel while preserving the rule that each
 push needs its own fresh review state before merge.
 
-Treat review generation latency as operational state, not a fixed timer. Do
-not merge because an arbitrary wait elapsed; merge only from explicit
-review/check/thread state.
+Treat `awaiting-automatic-review-signal` and `review-request-pending` as
+operational queue states, not as instructions to block. Revisit those PRs on
+later passes while progressing other items.
 
-For strict GitHub Copilot review loops, after every fix push re-trigger review
-through the approved `gh pr view <PR_NUMBER> --json id --jq .id` plus
-`gh api graphql` flow using the `requestReviewsByLogin` mutation described in
-`copilot-review-trigger.md` under this skill's `references` directory. Do not
-use PR comments or `@copilot` mentions as the trigger.
+Treat the 5-minute minimum from `last-push-at` as a trigger-eligibility rule,
+not as a fixed wait timer for merge or review completion. Do not merge because
+an arbitrary wait elapsed; merge only from explicit review/check/thread state.
+
+For strict GitHub Copilot review loops, after every fix push first inspect the
+current head state described in `copilot-review-trigger.md` under this skill's
+`references` directory. Use the approved `gh pr view <PR_NUMBER> --json id
+--jq .id` plus `gh api graphql` flow only when the current head is
+`manual-review-request-eligible`. Do not use PR comments or `@copilot`
+mentions as the trigger.
+
+Do not send a second explicit manual request for the same head while a pending
+request remains visible. If a `ReviewRequestRemovedEvent` appears for the
+current head before a submitted review arrives, the PR can become
+`manual-review-request-eligible` again on a later pass.
 
 If a PR cannot proceed because of missing permissions, missing branch updates,
 or missing review infrastructure, keep it in the queue with an explicit blocker

--- a/skills/ai-skills-pr-review-loop/references/review-loop-state.md
+++ b/skills/ai-skills-pr-review-loop/references/review-loop-state.md
@@ -18,14 +18,17 @@ Track each active PR with at least these fields:
 
 Define `review-signal-state` as exactly one of:
 
+Treat `current-head-oid` as the current PR `headRefOid`.
+
 - `awaiting-automatic-review-signal`: fewer than 5 minutes have elapsed since
   `last-push-at`, no submitted automated review is visible for
   `current-head-oid`, and no pending review request is visible for that head
-- `review-request-pending`: a `ReviewRequestedEvent` is visible for
+- `review-request-pending`: a `ReviewRequestedEvent` is visible after both
+  `last-push-at` and the `PullRequestCommit` timeline item for
   `current-head-oid`, no newer `ReviewRequestRemovedEvent` cancels that
   request, and no submitted automated review is visible for that head yet
 - `review-submitted`: a submitted automated review is visible for
-  `current-head-oid`
+  `current-head-oid` and was submitted after `last-push-at`
 - `manual-review-request-eligible`: at least 5 minutes have elapsed since
   `last-push-at`, no submitted automated review is visible for
   `current-head-oid`, and no pending review request is visible for that head
@@ -33,7 +36,7 @@ Define `review-signal-state` as exactly one of:
 Use `last-review-requested-at` and `last-review-requested-head-oid` to record
 the most recent explicit manual review request issued by the loop so duplicate
 same-head triggers are prevented. A review request or review tied to an older
-head never satisfies `current-head-oid`.
+head, or predating `last-push-at`, never satisfies `current-head-oid`.
 
 The review-readiness gate passes only when all of these are true in the same
 evaluation round:

--- a/skills/ai-skills-pr-review-loop/references/review-loop-state.md
+++ b/skills/ai-skills-pr-review-loop/references/review-loop-state.md
@@ -3,7 +3,11 @@
 Track each active PR with at least these fields:
 
 - `last-push-at`
+- `current-head-oid`
 - `last-review-submitted-at`
+- `last-review-requested-at`
+- `last-review-requested-head-oid`
+- `review-signal-state`
 - `review-in-progress-after-last-push`
 - `open-review-threads`
 - `new-valid-findings`
@@ -12,10 +16,31 @@ Track each active PR with at least these fields:
 - `pr-scope-focused`
 - `review-readiness-gate-passed`
 
+Define `review-signal-state` as exactly one of:
+
+- `awaiting-automatic-review-signal`: fewer than 5 minutes have elapsed since
+  `last-push-at`, no submitted automated review is visible for
+  `current-head-oid`, and no pending review request is visible for that head
+- `review-request-pending`: a `ReviewRequestedEvent` is visible for
+  `current-head-oid`, no newer `ReviewRequestRemovedEvent` cancels that
+  request, and no submitted automated review is visible for that head yet
+- `review-submitted`: a submitted automated review is visible for
+  `current-head-oid`
+- `manual-review-request-eligible`: at least 5 minutes have elapsed since
+  `last-push-at`, no submitted automated review is visible for
+  `current-head-oid`, and no pending review request is visible for that head
+
+Use `last-review-requested-at` and `last-review-requested-head-oid` to record
+the most recent explicit manual review request issued by the loop so duplicate
+same-head triggers are prevented. A review request or review tied to an older
+head never satisfies `current-head-oid`.
+
 The review-readiness gate passes only when all of these are true in the same
 evaluation round:
 
+- `review-signal-state` is `review-submitted`
 - a review was submitted after the latest push
+- the submitted review covers `current-head-oid`
 - no review is still running for the latest push
 - no open review threads remain
 - no new valid findings remain


### PR DESCRIPTION
Closes #224

## Summary
- add head-aware review signal states to `ai-skills-pr-review-loop`
- require at least 5 minutes after `last-push-at` before any manual review request
- preserve round-robin parallel progress while waiting for automatic review signals

## Review Focus
- current-head review signal classification and transition rules
- the 5-minute manual trigger floor and same-head dedupe behavior
- preservation of non-idle queue progression while review signals are pending

## Validation
- `corepack pnpm lint:md`
- `corepack pnpm validate`
- `corepack pnpm test`
- `corepack pnpm quality:cognitive`
- `corepack pnpm quality:crap`
- `corepack pnpm pack:dry-run`

## Residual Risk
- the guidance assumes the relevant GitHub GraphQL timeline events remain available for automated review request detection