### PR TITLE
Fix #219 align CI stage families and quality gates

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,13 +83,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: node-modules-${{ matrix.os }}
-          path: node_modules
+          path: .
 
       - name: Download build outputs
         uses: actions/download-artifact@v4
         with:
           name: dist-${{ matrix.os }}
-          path: dist
+          path: .
 
       - name: Run unit tests
         run: corepack pnpm test
@@ -132,13 +132,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: node-modules-${{ matrix.os }}
-          path: node_modules
+          path: .
 
       - name: Download build outputs
         uses: actions/download-artifact@v4
         with:
           name: dist-${{ matrix.os }}
-          path: dist
+          path: .
 
       - name: Package dry run
         run: corepack pnpm pack:dry-run
@@ -166,13 +166,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: node-modules-ubuntu-latest
-          path: node_modules
+          path: .
 
       - name: Download build outputs
         uses: actions/download-artifact@v4
         with:
           name: dist-ubuntu-latest
-          path: dist
+          path: .
 
       - name: Run catalog validation
         run: corepack pnpm validate
@@ -200,19 +200,19 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: node-modules-ubuntu-latest
-          path: node_modules
+          path: .
 
       - name: Download build outputs
         uses: actions/download-artifact@v4
         with:
           name: dist-ubuntu-latest
-          path: dist
+          path: .
 
       - name: Download coverage
         uses: actions/download-artifact@v4
         with:
           name: coverage-ubuntu-latest
-          path: coverage
+          path: .
 
       - name: Run CRAP gate
         run: corepack pnpm quality:crap
@@ -240,13 +240,43 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: node-modules-ubuntu-latest
-          path: node_modules
+          path: .
 
       - name: Download build outputs
         uses: actions/download-artifact@v4
         with:
           name: dist-ubuntu-latest
-          path: dist
+          path: .
 
       - name: Run cognitive complexity gate
         run: corepack pnpm quality:cognitive
+
+  quality-crap-compat:
+    name: quality-crap
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs:
+      - quality-crap-ai-skills
+
+    steps:
+      - name: Fail when the CRAP gate failed
+        if: ${{ needs.quality-crap-ai-skills.result != 'success' }}
+        run: exit 1
+
+      - name: Confirm legacy CRAP gate
+        run: echo "CRAP gate succeeded."
+
+  quality-cognitive-compat:
+    name: quality-cognitive
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs:
+      - quality-cognitive-ai-skills
+
+    steps:
+      - name: Fail when the cognitive gate failed
+        if: ${{ needs.quality-cognitive-ai-skills.result != 'success' }}
+        run: exit 1
+
+      - name: Confirm legacy cognitive gate
+        run: echo "Cognitive gate succeeded."

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,21 +33,11 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
-      - name: Configure pnpm store
-        run: corepack pnpm config set store-dir .pnpm-store
-
       - name: Install dependencies
         run: corepack pnpm install --frozen-lockfile
 
       - name: Build
         run: corepack pnpm build
-
-      - name: Upload pnpm store
-        uses: actions/upload-artifact@v4
-        with:
-          name: pnpm-store-${{ matrix.os }}
-          path: .pnpm-store
-          if-no-files-found: error
 
       - name: Upload dependencies
         uses: actions/upload-artifact@v4
@@ -88,15 +78,6 @@ jobs:
 
       - name: Enable Corepack
         run: corepack enable
-
-      - name: Configure pnpm store
-        run: corepack pnpm config set store-dir .pnpm-store
-
-      - name: Download pnpm store
-        uses: actions/download-artifact@v4
-        with:
-          name: pnpm-store-${{ matrix.os }}
-          path: .pnpm-store
 
       - name: Download dependencies
         uses: actions/download-artifact@v4
@@ -147,15 +128,6 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
-      - name: Configure pnpm store
-        run: corepack pnpm config set store-dir .pnpm-store
-
-      - name: Download pnpm store
-        uses: actions/download-artifact@v4
-        with:
-          name: pnpm-store-${{ matrix.os }}
-          path: .pnpm-store
-
       - name: Download dependencies
         uses: actions/download-artifact@v4
         with:
@@ -190,15 +162,6 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
-      - name: Configure pnpm store
-        run: corepack pnpm config set store-dir .pnpm-store
-
-      - name: Download pnpm store
-        uses: actions/download-artifact@v4
-        with:
-          name: pnpm-store-ubuntu-latest
-          path: .pnpm-store
-
       - name: Download dependencies
         uses: actions/download-artifact@v4
         with:
@@ -232,15 +195,6 @@ jobs:
 
       - name: Enable Corepack
         run: corepack enable
-
-      - name: Configure pnpm store
-        run: corepack pnpm config set store-dir .pnpm-store
-
-      - name: Download pnpm store
-        uses: actions/download-artifact@v4
-        with:
-          name: pnpm-store-ubuntu-latest
-          path: .pnpm-store
 
       - name: Download dependencies
         uses: actions/download-artifact@v4
@@ -281,15 +235,6 @@ jobs:
 
       - name: Enable Corepack
         run: corepack enable
-
-      - name: Configure pnpm store
-        run: corepack pnpm config set store-dir .pnpm-store
-
-      - name: Download pnpm store
-        uses: actions/download-artifact@v4
-        with:
-          name: pnpm-store-ubuntu-latest
-          path: .pnpm-store
 
       - name: Download dependencies
         uses: actions/download-artifact@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,8 +9,8 @@ permissions:
   contents: read
 
 jobs:
-  package-check:
-    name: Package Check (${{ matrix.os }})
+  build:
+    name: build (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -33,23 +33,149 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
+      - name: Configure pnpm store
+        run: corepack pnpm config set store-dir .pnpm-store
+
       - name: Install dependencies
         run: corepack pnpm install --frozen-lockfile
 
       - name: Build
         run: corepack pnpm build
 
-      - name: Test and quality gates
+      - name: Upload pnpm store
+        uses: actions/upload-artifact@v4
+        with:
+          name: pnpm-store-${{ matrix.os }}
+          path: .pnpm-store
+          if-no-files-found: error
+
+      - name: Upload dependencies
+        uses: actions/upload-artifact@v4
+        with:
+          name: node-modules-${{ matrix.os }}
+          path: node_modules
+          if-no-files-found: error
+
+      - name: Upload build outputs
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ matrix.os }}
+          path: dist
+          if-no-files-found: error
+
+  test-unit:
+    name: test / unit (${{ matrix.os }})
+    needs:
+      - build
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24"
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Configure pnpm store
+        run: corepack pnpm config set store-dir .pnpm-store
+
+      - name: Download pnpm store
+        uses: actions/download-artifact@v4
+        with:
+          name: pnpm-store-${{ matrix.os }}
+          path: .pnpm-store
+
+      - name: Download dependencies
+        uses: actions/download-artifact@v4
+        with:
+          name: node-modules-${{ matrix.os }}
+          path: node_modules
+
+      - name: Download build outputs
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-${{ matrix.os }}
+          path: dist
+
+      - name: Run unit tests
         run: corepack pnpm test
 
-      - name: Validate catalog
-        run: corepack pnpm validate
+      - name: Upload coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.os }}
+          path: coverage
+          if-no-files-found: error
+
+  package:
+    name: package (${{ matrix.os }})
+    needs:
+      - build
+      - test-unit
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24"
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Configure pnpm store
+        run: corepack pnpm config set store-dir .pnpm-store
+
+      - name: Download pnpm store
+        uses: actions/download-artifact@v4
+        with:
+          name: pnpm-store-${{ matrix.os }}
+          path: .pnpm-store
+
+      - name: Download dependencies
+        uses: actions/download-artifact@v4
+        with:
+          name: node-modules-${{ matrix.os }}
+          path: node_modules
+
+      - name: Download build outputs
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-${{ matrix.os }}
+          path: dist
 
       - name: Package dry run
         run: corepack pnpm pack:dry-run
 
-  quality-cognitive:
-    name: quality-cognitive
+  validate-catalog:
+    name: verify / validate-catalog
+    needs:
+      - build
+      - test-unit
     runs-on: ubuntu-latest
 
     steps:
@@ -64,14 +190,35 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
-      - name: Install dependencies
-        run: corepack pnpm install --frozen-lockfile
+      - name: Configure pnpm store
+        run: corepack pnpm config set store-dir .pnpm-store
 
-      - name: Cognitive Complexity Gate
-        run: corepack pnpm quality:cognitive
+      - name: Download pnpm store
+        uses: actions/download-artifact@v4
+        with:
+          name: pnpm-store-ubuntu-latest
+          path: .pnpm-store
 
-  quality-crap:
-    name: quality-crap
+      - name: Download dependencies
+        uses: actions/download-artifact@v4
+        with:
+          name: node-modules-ubuntu-latest
+          path: node_modules
+
+      - name: Download build outputs
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-ubuntu-latest
+          path: dist
+
+      - name: Run catalog validation
+        run: corepack pnpm validate
+
+  quality-crap-ai-skills:
+    name: verify / quality-crap-ai-skills
+    needs:
+      - build
+      - test-unit
     runs-on: ubuntu-latest
 
     steps:
@@ -86,8 +233,75 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
-      - name: Install dependencies
-        run: corepack pnpm install --frozen-lockfile
+      - name: Configure pnpm store
+        run: corepack pnpm config set store-dir .pnpm-store
 
-      - name: CRAP Gate
+      - name: Download pnpm store
+        uses: actions/download-artifact@v4
+        with:
+          name: pnpm-store-ubuntu-latest
+          path: .pnpm-store
+
+      - name: Download dependencies
+        uses: actions/download-artifact@v4
+        with:
+          name: node-modules-ubuntu-latest
+          path: node_modules
+
+      - name: Download build outputs
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-ubuntu-latest
+          path: dist
+
+      - name: Download coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-ubuntu-latest
+          path: coverage
+
+      - name: Run CRAP gate
         run: corepack pnpm quality:crap
+
+  quality-cognitive-ai-skills:
+    name: verify / quality-cognitive-ai-skills
+    needs:
+      - build
+      - test-unit
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24"
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Configure pnpm store
+        run: corepack pnpm config set store-dir .pnpm-store
+
+      - name: Download pnpm store
+        uses: actions/download-artifact@v4
+        with:
+          name: pnpm-store-ubuntu-latest
+          path: .pnpm-store
+
+      - name: Download dependencies
+        uses: actions/download-artifact@v4
+        with:
+          name: node-modules-ubuntu-latest
+          path: node_modules
+
+      - name: Download build outputs
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-ubuntu-latest
+          path: dist
+
+      - name: Run cognitive complexity gate
+        run: corepack pnpm quality:cognitive

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,13 +83,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: node-modules-${{ matrix.os }}
-          path: .
+          path: node_modules
 
       - name: Download build outputs
         uses: actions/download-artifact@v4
         with:
           name: dist-${{ matrix.os }}
-          path: .
+          path: dist
 
       - name: Run unit tests
         run: corepack pnpm test
@@ -132,13 +132,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: node-modules-${{ matrix.os }}
-          path: .
+          path: node_modules
 
       - name: Download build outputs
         uses: actions/download-artifact@v4
         with:
           name: dist-${{ matrix.os }}
-          path: .
+          path: dist
 
       - name: Package dry run
         run: corepack pnpm pack:dry-run
@@ -166,13 +166,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: node-modules-ubuntu-latest
-          path: .
+          path: node_modules
 
       - name: Download build outputs
         uses: actions/download-artifact@v4
         with:
           name: dist-ubuntu-latest
-          path: .
+          path: dist
 
       - name: Run catalog validation
         run: corepack pnpm validate
@@ -200,19 +200,19 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: node-modules-ubuntu-latest
-          path: .
+          path: node_modules
 
       - name: Download build outputs
         uses: actions/download-artifact@v4
         with:
           name: dist-ubuntu-latest
-          path: .
+          path: dist
 
       - name: Download coverage
         uses: actions/download-artifact@v4
         with:
           name: coverage-ubuntu-latest
-          path: .
+          path: coverage
 
       - name: Run CRAP gate
         run: corepack pnpm quality:crap
@@ -240,13 +240,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: node-modules-ubuntu-latest
-          path: .
+          path: node_modules
 
       - name: Download build outputs
         uses: actions/download-artifact@v4
         with:
           name: dist-ubuntu-latest
-          path: .
+          path: dist
 
       - name: Run cognitive complexity gate
         run: corepack pnpm quality:cognitive

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "test": "tsc -p tsconfig.json && vitest run",
-    "quality:cognitive": "tsc -p tsconfig.json && vitest run --config vitest.cognitive.config.ts",
-    "quality:crap": "tsc -p tsconfig.json && vitest run --config vitest.crap.config.ts",
+    "test": "vitest run --coverage.enabled true",
+    "quality:cognitive": "vitest run --config vitest.cognitive.config.ts",
+    "quality:crap": "vitest run --config vitest.crap.config.ts",
     "validate": "node tools/validate-catalog.mjs",
     "lint:md": "markdownlint-cli2 \"**/*.md\" \"!**/node_modules/**\" --config .markdownlint.json",
     "pack:dry-run": "npm pack --dry-run",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "vitest run --coverage.enabled true",
-    "quality:cognitive": "vitest run --config vitest.cognitive.config.ts",
-    "quality:crap": "vitest run --config vitest.crap.config.ts",
+    "quality:cognitive": "node ./scripts/run-cognitive-typescript-gate.mjs src",
+    "quality:crap": "node ./scripts/run-crap-typescript-gate.mjs src",
     "validate": "node tools/validate-catalog.mjs",
     "lint:md": "markdownlint-cli2 \"**/*.md\" \"!**/node_modules/**\" --config .markdownlint.json",
     "pack:dry-run": "npm pack --dry-run",
@@ -41,7 +41,9 @@
   },
   "homepage": "https://github.com/fabian-barney/ai-skills#readme",
   "devDependencies": {
+    "@barney-media/cognitive-typescript-core": "^0.1.1",
     "@barney-media/cognitive-typescript-vitest": "^0.1.1",
+    "@barney-media/crap-typescript-core": "^0.3.0",
     "@barney-media/crap-typescript-vitest": "^0.3.0",
     "@types/node": "^24.12.3",
     "@vitest/coverage-v8": "^4.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,15 @@ importers:
 
   .:
     devDependencies:
+      '@barney-media/cognitive-typescript-core':
+        specifier: ^0.1.1
+        version: 0.1.1
       '@barney-media/cognitive-typescript-vitest':
         specifier: ^0.1.1
         version: 0.1.1(vitest@4.1.6)
+      '@barney-media/crap-typescript-core':
+        specifier: ^0.3.0
+        version: 0.3.0
       '@barney-media/crap-typescript-vitest':
         specifier: ^0.3.0
         version: 0.3.0(vitest@4.1.6)

--- a/scripts/run-cognitive-typescript-gate.mjs
+++ b/scripts/run-cognitive-typescript-gate.mjs
@@ -1,0 +1,43 @@
+import {
+  COGNITIVE_COMPLEXITY_THRESHOLD,
+  NO_ANALYZABLE_FUNCTIONS_MESSAGE,
+  NO_FILES_MESSAGE,
+  analyzeProject,
+  formatReport
+} from "@barney-media/cognitive-typescript-core";
+import { resolve } from "node:path";
+
+const targets = process.argv.slice(2).map((target) => resolve(target));
+
+if (targets.length === 0) {
+  console.error("Usage: node ./scripts/run-cognitive-typescript-gate.mjs <path...>");
+  process.exit(1);
+}
+
+const result = await analyzeProject({
+  explicitPaths: targets,
+  projectRoot: process.cwd()
+});
+
+if (result.selectedFiles.length === 0) {
+  console.log(NO_FILES_MESSAGE);
+  process.exit(0);
+}
+
+if (result.metrics.length === 0) {
+  console.log(NO_ANALYZABLE_FUNCTIONS_MESSAGE);
+  process.exit(0);
+}
+
+for (const warning of result.warnings) {
+  console.error(warning);
+}
+
+console.log(formatReport(result.metrics));
+
+if (result.thresholdExceeded) {
+  console.error(
+    `Cognitive Complexity threshold exceeded: ${result.maxCognitiveComplexity} > ${COGNITIVE_COMPLEXITY_THRESHOLD}`
+  );
+  process.exit(2);
+}

--- a/scripts/run-crap-typescript-gate.mjs
+++ b/scripts/run-crap-typescript-gate.mjs
@@ -1,0 +1,55 @@
+import {
+  NO_ANALYZABLE_FUNCTIONS_MESSAGE,
+  NO_FILES_MESSAGE,
+  analyzeProject,
+  formatAnalysisReport
+} from "@barney-media/crap-typescript-core";
+import { resolve } from "node:path";
+
+const targets = process.argv.slice(2).map((target) => resolve(target));
+
+if (targets.length === 0) {
+  console.error("Usage: node ./scripts/run-crap-typescript-gate.mjs <path...>");
+  process.exit(1);
+}
+
+const result = await analyzeProject({
+  explicitPaths: targets,
+  coverageMode: "existing-only",
+  coverageReportPath: "coverage/coverage-final.json",
+  projectRoot: process.cwd()
+});
+
+if (result.selectedFiles.length === 0) {
+  console.log(NO_FILES_MESSAGE);
+  process.exit(0);
+}
+
+if (result.metrics.length === 0) {
+  console.log(NO_ANALYZABLE_FUNCTIONS_MESSAGE);
+  process.exit(0);
+}
+
+for (const warning of result.warnings) {
+  console.error(warning);
+}
+
+console.log(
+  formatAnalysisReport(result.metrics, {
+    agent: true,
+    format: "text",
+    threshold: result.threshold
+  })
+);
+
+if (result.metrics.some((metric) => metric.coverage.status === "unknown")) {
+  console.error(
+    "CRAP analysis requires the existing coverage artifact to be available for every analyzable method."
+  );
+  process.exit(1);
+}
+
+if (result.thresholdExceeded) {
+  console.error(`CRAP threshold exceeded: ${result.maxCrap} > ${result.threshold}`);
+  process.exit(2);
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,19 +1,3 @@
-import { withCognitiveTypescriptVitest } from "@barney-media/cognitive-typescript-vitest";
-import { withCrapTypescriptVitest } from "@barney-media/crap-typescript-vitest";
-
 import baseConfig from "./vitest.base.config";
 
-export default withCognitiveTypescriptVitest(
-  withCrapTypescriptVitest(baseConfig, {
-    failuresOnly: true,
-    format: "text",
-    junit: false,
-    packageManager: "pnpm",
-    paths: ["src"],
-    projectRoot: process.cwd()
-  }),
-  {
-    paths: ["src"],
-    projectRoot: process.cwd()
-  }
-);
+export default baseConfig;


### PR DESCRIPTION
## Summary
- align the Node workflow to stage-family job names
- split CRAP and cognitive checks into dedicated jobs
- reuse installed dependencies, build outputs, and coverage artifacts across jobs
- keep temporary legacy `quality-crap` and `quality-cognitive` aliases for the current protected-check requirements

## Validation
- ran build, test, validate, CRAP, and cognitive pnpm commands locally in workflow order
- verified the latest GitHub Actions run on this head is green after restoring the artifact download paths

Closes #219