### PR TITLE
Fix #229 require PR review loops before release publishing

### DIFF
--- a/skills/ai-skills-release-github/SKILL.md
+++ b/skills/ai-skills-release-github/SKILL.md
@@ -41,9 +41,10 @@ annotated tags, and GitHub release notes aligned.
 - the repository default branch, or an intentionally isolated release branch
   created from the latest released tag when skill `ai-skills-release`
   explicitly requires that narrower source as an input to this skill
-- confirmation that no open release-bound PRs remain for the chosen release
-  source and intended release scope, or the release-bound PR list that must
-  complete the shared review loop before this skill may continue
+- confirmation that all required release-bound PRs are merged or explicitly
+  removed from scope for the chosen release source and intended release scope,
+  or the release-bound PR list that must complete the shared review loop
+  before this skill may continue
 - the latest released tag and the merged changes since that tag
 - any explicit target version provided by the user or repository policy
 - any framework, build-tool, dependency, or support-policy changes in the

--- a/skills/ai-skills-release-github/SKILL.md
+++ b/skills/ai-skills-release-github/SKILL.md
@@ -22,6 +22,8 @@ annotated tags, and GitHub release notes aligned.
   user-visible changes since the latest released tag
 - use when changelog content, tags, and GitHub release notes must describe the
   same release
+- use skill `ai-skills-pr-review-loop` when release work is intentionally
+  delivered through PRs before the release-preparation commit can be created
 - use skill `ai-skills-tooling-git-write` when the release flow will create a
   release-preparation commit or annotated tag whose message is already known
 - use skill `ai-skills-version-dependency-selection` when framework,
@@ -36,18 +38,19 @@ annotated tags, and GitHub release notes aligned.
 
 # Inputs
 
-- the repository default branch with all release-bound changes already merged,
-  or an intentionally isolated release branch created from the latest released
-  tag when skill `ai-skills-release` explicitly requires that narrower source
-  as an input to this skill
+- the repository default branch, or an intentionally isolated release branch
+  created from the latest released tag when skill `ai-skills-release`
+  explicitly requires that narrower source as an input to this skill
 - confirmation that no open release-bound PRs remain for the chosen release
-  source and intended release scope
+  source and intended release scope, or the release-bound PR list that must
+  complete the shared review loop before this skill may continue
 - the latest released tag and the merged changes since that tag
 - any explicit target version provided by the user or repository policy
 - any framework, build-tool, dependency, or support-policy changes in the
   release scope that affect compatibility claims
 - the changelog or strongest release-notes source for the repository
 - GitHub access capable of pushing tags and creating releases
+- skill `ai-skills-pr-review-loop`
 - skill `ai-skills-tooling-git-write`
 - `references/version-selection.md`
 - `references/github-release-flow.md`
@@ -58,46 +61,48 @@ annotated tags, and GitHub release notes aligned.
    release branch when skill `ai-skills-release` explicitly requires it and
    passes that requirement into this skill; create that branch from the latest
    released tag so unrelated unreleased default-branch work is excluded.
-2. Ensure the chosen release source is current for its intended scope, all
-   release-bound PRs for that scope are merged or intentionally recreated on
-   the isolated branch, and no open release-bound PRs remain for the chosen
-   release source and intended release scope; do not release from a feature
-   branch.
-3. If the release scope includes framework, build-tool, or dependency choices
+2. Ensure the chosen release source is correct for its intended scope,
+   identify any release-bound PRs that still must land for that scope, and do
+   not release from a feature branch.
+3. If the chosen release source still depends on release-bound PRs, apply
+   skill `ai-skills-pr-review-loop` to those PRs and do not continue until
+   each one completed a clean review loop and merged, or was explicitly
+   removed from the release scope.
+4. If the release scope includes framework, build-tool, or dependency choices
    that are not fixed yet, apply skill `ai-skills-version-dependency-selection`
    before finalizing release timing or compatibility notes.
-4. If the release changes officially supported runtimes or platforms and the
+5. If the release changes officially supported runtimes or platforms and the
    support policy is not explicit yet, apply skill `ai-skills-version-support-policy`
    before finalizing compatibility claims.
-5. Determine the target version: use an explicit version when provided;
+6. Determine the target version: use an explicit version when provided;
    otherwise classify the changes since the latest released tag and select the
    smallest valid semantic-version bump that fits the strongest user-visible
    change.
-6. Stop if there are no meaningful release changes instead of creating an empty
+7. Stop if there are no meaningful release changes instead of creating an empty
    tag.
-7. Verify the chosen release source contains only the intended scoped release
+8. Verify the chosen release source contains only the intended scoped release
    change set by inspecting the commits or file diff from the latest released
    tag to that source. Stop until the source is narrowed if unrelated
    unreleased work would be included.
-8. Update the changelog or release-notes source with the selected version, the
+9. Update the changelog or release-notes source with the selected version, the
    release date, and a concise summary of user-visible changes.
-9. Run `git grep -F "<previous-tag>"` before creating the release commit,
+10. Run `git grep -F "<previous-tag>"` before creating the release commit,
    replacing `<previous-tag>` with the actual latest released version tag, for
    example `v1.2.3`. Update every versioned release example or documentation
    reference found so it points at the new tag.
-10. Stage the changelog or release-notes source and all versioned-example
+11. Stage the changelog or release-notes source and all versioned-example
     updates together.
-11. Apply skill `ai-skills-tooling-git-write` so the release-preparation
+12. Apply skill `ai-skills-tooling-git-write` so the release-preparation
     commit and annotated tag use non-interactive git write commands when their
     messages are already known.
-12. Commit the release-preparation changes on the chosen release source,
+13. Commit the release-preparation changes on the chosen release source,
     create an annotated tag for the release commit, and push both branch and
     tag.
-13. Create the GitHub Release from the pushed tag using notes that stay
+14. Create the GitHub Release from the pushed tag using notes that stay
     aligned with the changelog or release-notes source. If both exist, treat
     the changelog as authoritative unless repository policy explicitly says
     otherwise.
-14. Verify that the tag and release page exist and point at the intended
+15. Verify that the tag and release page exist and point at the intended
     commit.
 
 # Outputs
@@ -105,6 +110,8 @@ annotated tags, and GitHub release notes aligned.
 - the selected release version and release commit
 - the release source used, including whether it was the default branch or an
   intentionally isolated release branch from the latest released tag
+- release-bound PR review-loop status when PR-based release preparation was
+  required
 - aligned changelog or release notes for that version
 - a pushed annotated tag and a published GitHub Release
 - a concise release summary or release URL for follow-up communication
@@ -114,12 +121,17 @@ annotated tags, and GitHub release notes aligned.
 - do not release from a feature branch or dirty branch state
 - do not use an isolated release branch unless skill `ai-skills-release`
   explicitly requires it
-- do not release while open release-bound PRs remain for the chosen release
-  source and intended release scope
+- do not release while a required release-bound PR for the chosen release
+  source and intended release scope lacks a completed shared review loop for
+  its latest head or remains unmerged
+- do not treat a merely closed or stale-reviewed release-bound PR as sufficient
+  release evidence
 - do not guess a version bump without checking the merged change set
 - do not create a release when there are no meaningful release changes
 - do not include unrelated unreleased default-branch work in the chosen release
   source
+- do not replace the shared PR review and merge skills with release-specific
+  PR handling when release preparation depends on PRs
 - do not skip the previous-tag `git grep` scan before the release-preparation
   commit
 - do not let the release-preparation commit or known tag message depend on an
@@ -132,6 +144,9 @@ annotated tags, and GitHub release notes aligned.
 - the target version is explicit and justified
 - the chosen release source is explicit and justified, and isolated release
   branch use is backed by an explicit skill `ai-skills-release` requirement
+- if release-bound PRs were needed for the intended scope, skill `ai-skills-pr-review-loop`
+  was applied and each required PR completed the shared review loop and merged
+  or was explicitly removed from scope before tagging
 - the default branch or isolated release branch includes all release-bound work
   for the intended scope and no open release-bound PRs remain
 - changelog or release notes, tag, and GitHub Release all reference the same

--- a/skills/ai-skills-release-github/references/github-release-flow.md
+++ b/skills/ai-skills-release-github/references/github-release-flow.md
@@ -13,26 +13,29 @@ Preferred sequence:
 2. if skill `ai-skills-release` explicitly passes an isolated release branch
    requirement into this flow, create that branch from the latest released tag
    and keep it limited to the scoped release change
-3. verify the chosen release source is current for its intended scope and no
-   release-bound PRs remain open for that scope
-4. inspect the commits or file diff from the latest released tag to the chosen
+3. verify the chosen release source is correct for its intended scope and
+   identify any release-bound PRs that still must land for that scope
+4. if release work still depends on release-bound PRs, advance them through
+   skill `ai-skills-pr-review-loop` until each required PR is freshly reviewed
+   and merged or explicitly removed from scope
+5. inspect the commits or file diff from the latest released tag to the chosen
    release source and stop if unrelated unreleased default-branch work would be
    included
-5. update release-notes source
-6. run `git grep -F "<previous-tag>"`, replacing `<previous-tag>` with the
+6. update release-notes source
+7. run `git grep -F "<previous-tag>"`, replacing `<previous-tag>` with the
    actual latest released tag, for example `v1.2.3`
-7. update every relevant versioned example or documentation reference to the new
+8. update every relevant versioned example or documentation reference to the new
    tag
-8. apply skill `ai-skills-tooling-git-write` so known release messages use
+9. apply skill `ai-skills-tooling-git-write` so known release messages use
    non-interactive git write commands
-9. create the release-preparation commit with `git commit -m "..."` for a
+10. create the release-preparation commit with `git commit -m "..."` for a
    single-line message or `git commit -F <temp-file>` for a multi-line message
-10. create the annotated tag on that commit with
+11. create the annotated tag on that commit with
     `git tag -a <tag> -m "..."` for a single-line tag message or
     `git tag -a <tag> -F <temp-file>` for a multi-line tag message
-11. push branch and tag
-12. create the GitHub Release from the pushed tag
-13. verify the tag and release page point at the same commit
+12. push branch and tag
+13. create the GitHub Release from the pushed tag
+14. verify the tag and release page point at the same commit
 
 When repository policy defines a release-note heading or formatting template,
 honor that policy rather than inventing a new layout during release.
@@ -40,6 +43,10 @@ honor that policy rather than inventing a new layout during release.
 If a repository has both a changelog and a separate release-notes source, decide
 which source is authoritative before creating the GitHub Release and keep the
 other one aligned or explicitly out of scope.
+
+Do not treat a merely closed or stale-reviewed release-bound PR as sufficient
+release evidence. When release preparation depends on PRs, the shared PR review
+loop must converge on the latest head before tagging proceeds.
 
 An isolated release branch is an exception path for intentionally scoped
 releases. It is not a substitute for a dirty or lagging default branch and

--- a/skills/ai-skills-release/SKILL.md
+++ b/skills/ai-skills-release/SKILL.md
@@ -28,6 +28,8 @@ not as rules to copy into downstream projects.
   framework, or build-tool change without also shipping unrelated unreleased
   default-branch work
 - use when skill `ai-skills-release-github` is necessary but not sufficient on its own
+- use skill `ai-skills-pr-review-loop` when the release creates, recreates, or
+  depends on release-bound PRs before tagging or publication can continue
 - use skill `ai-skills-version-dependency-selection` when dependency,
   framework, or build-tool choices are still open in the release scope
 - use skill `ai-skills-version-support-policy` when the release changes the
@@ -48,9 +50,11 @@ not as rules to copy into downstream projects.
 
 # Inputs
 
-- the repository default branch with release-bound changes already merged, the
-  latest released tag, and the exact scoped release change when a public
-  release may need isolation from unrelated unreleased work
+- the repository default branch, the latest released tag, and the exact scoped
+  release change when a public release may need isolation from unrelated
+  unreleased work
+- any release-bound PRs that must be created, recreated, or advanced through
+  review before tagging or publication can continue
 - repository-specific release policy, versioning rules, and publication rules
 - the strongest available final build and test commands or CI evidence
 - the delta since the latest release
@@ -59,6 +63,7 @@ not as rules to copy into downstream projects.
 - documentation, changelog, and versioned example locations that must be
   updated
 - the artifact publication targets actually used by the repository
+- skill `ai-skills-pr-review-loop`
 - skill `ai-skills-release-github`
 - `references/release-preconditions.md`
 - `references/isolated-public-release.md`
@@ -66,8 +71,8 @@ not as rules to copy into downstream projects.
 
 # Workflow
 
-1. Confirm the default branch is current, the release scope is merged, and the
-   repository is in releasable state.
+1. Confirm the default branch is current, the release scope is identified, and
+   the repository is in releasable state.
 2. Run or confirm the final build and test pass for the release candidate; do
    not continue if the final verification is red or missing.
 3. Apply the repository-specific release policy as an input, without copying
@@ -87,32 +92,38 @@ not as rules to copy into downstream projects.
    release change onto the isolated branch; stop if unrelated unreleased work
    is still present and do not proceed until the isolated branch contains only
    the scoped release change.
-8. Confirm versioned release examples and documentation references are known so
+8. If the chosen release path creates, recreates, or depends on release-bound
+   PRs before publication can continue, apply skill `ai-skills-pr-review-loop`
+   to those PRs and do not proceed until each PR either completed a clean
+   review loop and merged or was explicitly removed from the release scope.
+9. Confirm versioned release examples and documentation references are known so
    the release can update them to the new tag.
-9. Apply skill `ai-skills-release-github` to perform the GitHub-release workflow,
-   including version selection, changelog/docs alignment, release-prep commit,
-   versioned-example updates, tag creation, push, and GitHub Release creation,
-   using the default branch by default or the isolated release branch when the
-   isolated path was required.
-10. Publish release artifacts only after tag creation and GitHub Release
+10. Apply skill `ai-skills-release-github` to perform the GitHub-release workflow,
+    including version selection, changelog/docs alignment, release-prep
+    commit, versioned-example updates, tag creation, push, and GitHub Release
+    creation, using the default branch by default or the isolated release
+    branch when the isolated path was required.
+11. Publish release artifacts only after tag creation and GitHub Release
    creation both succeed. Publish to each applicable target registry listed in
    `references/publication-targets.md`, such as Maven Central, the Gradle
    Plugin Portal, or a private artifactory, and record any target that is
    intentionally not applicable.
-11. Verify the published artifacts and release metadata so version numbers,
-   tags, changelog entries, and published packages all match. Record the
-   released version, tag, chosen release source, and each target result.
-12. If an isolated release branch was used, merge back the same scoped release
-   change cleanly to the default branch or confirm the default branch already
-   contains an equivalent change set.
-13. Use `examples/release-checklist.md` when communicating the completed release
-   steps or any blocked publication target.
+12. Verify the published artifacts and release metadata so version numbers,
+    tags, changelog entries, and published packages all match. Record the
+    released version, tag, chosen release source, and each target result.
+13. If an isolated release branch was used, merge back the same scoped release
+    change cleanly to the default branch or confirm the default branch already
+    contains an equivalent change set.
+14. Use `examples/release-checklist.md` when communicating the completed release
+    steps or any blocked publication target.
 
 # Outputs
 
 - a selected release version and final release checklist
 - the chosen release source and, when applicable, isolated-branch merge-back
   status
+- explicit release-bound PR review-loop status when pre-publish PRs were part
+  of the release
 - aligned documentation, changelog, GitHub release, and publication artifacts
 - explicit publication status for each relevant release target
 - a concise release summary with follow-up blockers when publication was only
@@ -126,9 +137,14 @@ not as rules to copy into downstream projects.
 - do not release unrelated unreleased default-branch work to a public registry
 - do not create an isolated public-release branch from the default-branch tip;
   create it from the latest released tag
+- do not tag, publish, or create a GitHub Release while a required
+  release-bound PR lacks a completed shared review loop for its latest head or
+  remains unmerged in the intended release scope
 - do not skip versioned release example and documentation-reference updates
 - do not recreate or cherry-pick more than the scoped release change onto an
   isolated release branch
+- do not replace the shared PR review and merge skills with release-specific
+  ad-hoc PR handling when pre-publish release-bound PRs exist
 - do not publish artifacts whose version, changelog, or tag is out of sync
 - do not publish registry artifacts before the tag and GitHub Release exist
 - do not assume every repository publishes to Maven Central, the Gradle Plugin
@@ -144,6 +160,8 @@ not as rules to copy into downstream projects.
 - the selected version matches the documented delta from the previous release
 - the chosen release source is explicit, and any isolated public-release path
   started from the latest released tag
+- any release-bound PRs required before publication were advanced through skill `ai-skills-pr-review-loop`
+  and either merged cleanly or explicitly removed from the release scope
 - skill `ai-skills-release-github` was applied for the GitHub release portion
 - any isolated public-release branch contains only the scoped release change
   before tagging and publication
@@ -157,6 +175,8 @@ not as rules to copy into downstream projects.
   or explicitly marked not applicable
 - the final release report names the released version, tag, chosen release
   source, and each target outcome
+- the final release report names the release-bound PR review result or
+  explicitly states that no pre-publish release-bound PRs were needed
 - any isolated public release was merged back cleanly or confirmed equivalent on
   the default branch
 - the final release report is concrete enough for downstream consumers and

--- a/skills/ai-skills-release/examples/release-checklist.md
+++ b/skills/ai-skills-release/examples/release-checklist.md
@@ -6,6 +6,7 @@
 - semantic version: `1.8.0`
 - release tag: `v1.8.0`
 - release source: isolated branch from `v1.7.3`
+- release-bound PR review loop: not needed
 - docs/examples updated: yes
 - changelog updated: yes
 - GitHub release: published

--- a/skills/ai-skills-release/references/isolated-public-release.md
+++ b/skills/ai-skills-release/references/isolated-public-release.md
@@ -10,7 +10,8 @@ Sequence:
    current default-branch tip
 3. recreate or cherry-pick only the scoped release change onto that branch
 4. stop if unrelated unreleased work is still present
-5. run the normal release workflow on the isolated branch, including skill `ai-skills-release-github`
+5. run the normal release workflow on the isolated branch, including any
+   required release-bound PR review loop and skill `ai-skills-release-github`
 6. publish only to the repository-relevant targets
 7. verify the released version, tag, release notes, and target artifacts all
    match

--- a/skills/ai-skills-release/references/release-preconditions.md
+++ b/skills/ai-skills-release/references/release-preconditions.md
@@ -3,7 +3,9 @@
 Before running the release:
 
 - default branch is current
-- release-bound PRs are merged
+- release-bound PRs are already merged, or any release-bound PRs that still
+  must land before publication are explicitly identified for the shared PR
+  review loop
 - repository-specific release policy is identified and treated as local input
 - final build is green
 - final test run is green


### PR DESCRIPTION
Closes #229

## Implementation Summary
- Scope: tighten the release skill family so release-created or release-bound PRs must go through the shared PR review loop before tagging or publication continues.
- Key changes: add `skill \`ai-skills-pr-review-loop\`` integration to `ai-skills-release` and `ai-skills-release-github`, expand release inputs/workflow/guardrails/exit checks around release-bound PR handling, and update the release checklist/reference docs to report whether a pre-publish PR review loop was needed.
- Non-goals: no changes to other PR-family skills, no workflow or package-version changes, and no release-policy changes outside the bounded release-skill docs.

## Review Focus
- Generated/copied files and standard imports that can be skimmed: none; this PR only changes the six issue-scoped release skill Markdown files.
- Non-obvious code paths and rationale: check that the fast path for releases with no release-bound PRs is preserved, and that the new language consistently blocks publication until required PRs are freshly reviewed and merged rather than merely closed or previously reviewed.

## Validation
- Tests executed: `build`, `lint:md`, `validate`, `test`, `quality:cognitive`, `quality:crap`, `pack:dry-run`.
- Manual checks: reviewed the bounded diff to confirm the release skill family now hands off pre-publish PRs to `skill \`ai-skills-pr-review-loop\``, preserves the no-PR fast path, rejects stale-reviewed or merely closed PRs as sufficient release evidence, and records review-loop status in outputs/examples.
- Residual risks: none.
