### PR TITLE
Improve release skill handling for partial public releases

### DIFF
--- a/skills/ai-skills-release-github/SKILL.md
+++ b/skills/ai-skills-release-github/SKILL.md
@@ -3,14 +3,16 @@ name: ai-skills-release-github
 description: >-
   Publish a repository release on GitHub using a consistent tagged-release
   flow. Use when a version must be selected, changelog or release notes aligned,
-  and a GitHub Release created from the release commit.
+  and a GitHub Release draft or final publication managed from the release
+  commit.
 ---
 <!-- markdownlint-disable MD025 -->
 
 # Purpose
 
-Publish a clean GitHub release that keeps version selection, changelog updates,
-annotated tags, and GitHub release notes aligned.
+Publish a clean GitHub release record that keeps version selection, changelog
+updates, annotated tags, and GitHub release notes aligned across draft and
+final states.
 
 # When to Use
 
@@ -99,11 +101,19 @@ annotated tags, and GitHub release notes aligned.
 13. Commit the release-preparation changes on the chosen release source,
     create an annotated tag for the release commit, and push both branch and
     tag.
-14. Create the GitHub Release from the pushed tag using notes that stay
+14. Create the GitHub Release draft from the pushed tag using notes that stay
     aligned with the changelog or release-notes source. If both exist, treat
     the changelog as authoritative unless repository policy explicitly says
     otherwise.
-15. Verify that the tag and release page exist and point at the intended
+15. If repository policy or skill `ai-skills-release` says GitHub is the only
+    required public target, publish the draft after verification. Otherwise
+    keep the draft in place until the broader release workflow confirms all
+    required public targets succeeded, then publish or promote it to final.
+16. If a public target later fails after any public artifact was already
+    published, retain the draft or convert it into an explicitly labeled
+    historical partial-release record per repository policy instead of
+    pretending the release completed successfully.
+17. Verify that the tag and release page state exist and point at the intended
     commit.
 
 # Outputs
@@ -114,7 +124,8 @@ annotated tags, and GitHub release notes aligned.
 - release-bound PR review-loop status when PR-based release preparation was
   required
 - aligned changelog or release notes for that version
-- a pushed annotated tag and a published GitHub Release
+- a pushed annotated tag and a GitHub Release draft, plus a published final
+  GitHub Release when target success or repository policy allows it
 - a concise release summary or release URL for follow-up communication
 
 # Guardrails
@@ -137,6 +148,11 @@ annotated tags, and GitHub release notes aligned.
   commit
 - do not let the release-preparation commit or known tag message depend on an
   interactive editor
+- do not publish the final GitHub Release before required public targets
+  succeed when the release depends on non-GitHub public publication targets
+- do not discard GitHub release notes for a half-published public release;
+  retain them through a draft or explicitly labeled historical partial-release
+  record
 - do not let GitHub release notes drift from the authoritative changelog or
   release-notes source
 
@@ -150,8 +166,8 @@ annotated tags, and GitHub release notes aligned.
   or was explicitly removed from scope before tagging
 - the default branch or isolated release branch includes all release-bound work
   for the intended scope and no open release-bound PRs remain
-- changelog or release notes, tag, and GitHub Release all reference the same
-  release
+- changelog or release notes, tag, and GitHub Release state all reference the
+  same release
 - `git grep -F "<previous-tag>"` was run with the actual latest released tag and
   every relevant versioned example or documentation reference was updated or
   explicitly ruled out
@@ -161,5 +177,7 @@ annotated tags, and GitHub release notes aligned.
   release-preparation commit before tagging
 - the release was created from the intended default-branch commit or justified
   isolated release branch commit
+- the GitHub Release was drafted after tag push and published only when the
+  broader release outcome or repository policy allowed it
 - unrelated unreleased work was excluded from the chosen release source
 - the published result is specific enough for downstream consumers to use

--- a/skills/ai-skills-release-github/SKILL.md
+++ b/skills/ai-skills-release-github/SKILL.md
@@ -126,7 +126,8 @@ final states.
   required
 - aligned changelog or release notes for that version
 - a pushed annotated tag and a GitHub Release draft, plus a published final
-  GitHub Release when target success or repository policy allows it
+  GitHub Release after all required public targets succeed, or immediately
+  when GitHub is the only required public target
 - a concise release summary or release URL for follow-up communication
 
 # Guardrails

--- a/skills/ai-skills-release-github/SKILL.md
+++ b/skills/ai-skills-release-github/SKILL.md
@@ -179,7 +179,8 @@ final states.
   release-preparation commit before tagging
 - the release was created from the intended default-branch commit or justified
   isolated release branch commit
-- the GitHub Release was drafted after tag push and published only when the
-  broader release outcome or repository policy allowed it
+- the GitHub Release was drafted after tag push and published only after all
+  required public targets succeeded, or immediately when GitHub was the only
+  required public target
 - unrelated unreleased work was excluded from the chosen release source
 - the published result is specific enough for downstream consumers to use

--- a/skills/ai-skills-release-github/SKILL.md
+++ b/skills/ai-skills-release-github/SKILL.md
@@ -106,9 +106,10 @@ final states.
     the changelog as authoritative unless repository policy explicitly says
     otherwise.
 15. If repository policy or skill `ai-skills-release` says GitHub is the only
-    required public target, publish the draft after verification. Otherwise
-    keep the draft in place until the broader release workflow confirms all
-    required public targets succeeded, then publish or promote it to final.
+    required public target, publish the draft immediately after creation.
+    Otherwise keep the draft in place until the broader release workflow
+    confirms all required public targets succeeded, then publish or promote it
+    to final.
 16. If a public target later fails after any public artifact was already
     published, retain the draft or convert it into an explicitly labeled
     historical partial-release record per repository policy instead of

--- a/skills/ai-skills-release-github/SKILL.md
+++ b/skills/ai-skills-release-github/SKILL.md
@@ -10,19 +10,19 @@ description: >-
 
 # Purpose
 
-Publish a clean GitHub release record that keeps version selection, changelog
-updates, annotated tags, and GitHub release notes aligned across draft and
+Publish a clean GitHub Release record that keeps version selection, changelog
+updates, annotated tags, and GitHub Release notes aligned across draft and
 final states.
 
 # When to Use
 
-- use when a repository needs a new GitHub release from its default branch
+- use when a repository needs a new GitHub Release from its default branch
 - use when skill `ai-skills-release` intentionally requires an isolated
   release branch created from the latest released tag so unrelated unreleased
   default-branch work stays out of the release
 - use when a version must be chosen explicitly or inferred from merged
   user-visible changes since the latest released tag
-- use when changelog content, tags, and GitHub release notes must describe the
+- use when changelog content, tags, and GitHub Release notes must describe the
   same release
 - use skill `ai-skills-pr-review-loop` when release work is intentionally
   delivered through PRs before the release-preparation commit can be created
@@ -114,8 +114,8 @@ final states.
     published, retain the draft or convert it into an explicitly labeled
     historical partial-release record per repository policy instead of
     pretending the release completed successfully.
-17. Verify that the tag and release page state exist and point at the intended
-    commit.
+17. Verify that the tag exists and that the GitHub Release page points at the
+    intended commit and is in the intended state.
 
 # Outputs
 
@@ -151,10 +151,10 @@ final states.
   interactive editor
 - do not publish the final GitHub Release before required public targets
   succeed when the release depends on non-GitHub public publication targets
-- do not discard GitHub release notes for a half-published public release;
+- do not discard GitHub Release notes for a half-published public release;
   retain them through a draft or explicitly labeled historical partial-release
   record
-- do not let GitHub release notes drift from the authoritative changelog or
+- do not let GitHub Release notes drift from the authoritative changelog or
   release-notes source
 
 # Exit Checks

--- a/skills/ai-skills-release-github/SKILL.md
+++ b/skills/ai-skills-release-github/SKILL.md
@@ -110,10 +110,10 @@ final states.
     Otherwise keep the draft in place until the broader release workflow
     confirms all required public targets succeeded, then publish or promote it
     to final.
-16. If a public target later fails after any public artifact was already
-    published, retain the draft or convert it into an explicitly labeled
-    historical partial-release record per repository policy instead of
-    pretending the release completed successfully.
+16. If a public target later fails after any public artifact becomes public,
+    retain the draft or convert it into an explicitly labeled historical
+    partial-release record per repository policy instead of pretending the
+    release completed successfully.
 17. Verify that the tag exists and that the GitHub Release page points at the
     intended commit and is in the intended state.
 

--- a/skills/ai-skills-release-github/SKILL.md
+++ b/skills/ai-skills-release-github/SKILL.md
@@ -110,10 +110,10 @@ final states.
     Otherwise keep the draft in place until the broader release workflow
     confirms all required public targets succeeded, then publish or promote it
     to final.
-16. If a public target later fails after any public artifact becomes public,
-    retain the draft or convert it into an explicitly labeled historical
-    partial-release record per repository policy instead of pretending the
-    release completed successfully.
+16. If a required public target later fails after any public artifact becomes
+    public, retain the draft or convert it into an explicitly labeled
+    historical partial-release record per repository policy instead of
+    pretending the release completed successfully.
 17. Verify that the tag exists and that the GitHub Release page points at the
     intended commit and is in the intended state.
 
@@ -128,8 +128,8 @@ final states.
 - a pushed annotated tag and a GitHub Release record: published as final after
   all required public targets succeed, or immediately when GitHub is the only
   required public target, otherwise retained as a draft / explicitly labeled
-  historical partial-release record when a public target fails after any public
-  artifact becomes public
+  historical partial-release record when a required public target fails after
+  any public artifact becomes public
 - a concise release summary or release URL for follow-up communication
 
 # Guardrails
@@ -184,7 +184,7 @@ final states.
 - the GitHub Release was drafted after tag push and then either published only
   after all required public targets succeeded, or immediately when GitHub was
   the only required public target, otherwise retained as a draft / explicitly
-  labeled historical partial-release record when a public target failed after
-  any public artifact becomes public
+  labeled historical partial-release record when a required public target
+  failed after any public artifact becomes public
 - unrelated unreleased work was excluded from the chosen release source
 - the published result is specific enough for downstream consumers to use

--- a/skills/ai-skills-release-github/SKILL.md
+++ b/skills/ai-skills-release-github/SKILL.md
@@ -125,9 +125,11 @@ final states.
 - release-bound PR review-loop status when PR-based release preparation was
   required
 - aligned changelog or release notes for that version
-- a pushed annotated tag and a GitHub Release draft, plus a published final
-  GitHub Release after all required public targets succeed, or immediately
-  when GitHub is the only required public target
+- a pushed annotated tag and a GitHub Release record: published as final after
+  all required public targets succeed, or immediately when GitHub is the only
+  required public target, otherwise retained as a draft / explicitly labeled
+  historical partial-release record when a public target fails after any public
+  artifact becomes public
 - a concise release summary or release URL for follow-up communication
 
 # Guardrails
@@ -179,8 +181,10 @@ final states.
   release-preparation commit before tagging
 - the release was created from the intended default-branch commit or justified
   isolated release branch commit
-- the GitHub Release was drafted after tag push and published only after all
-  required public targets succeeded, or immediately when GitHub was the only
-  required public target
+- the GitHub Release was drafted after tag push and then either published only
+  after all required public targets succeeded, or immediately when GitHub was
+  the only required public target, otherwise retained as a draft / explicitly
+  labeled historical partial-release record when a public target failed after
+  any public artifact becomes public
 - unrelated unreleased work was excluded from the chosen release source
 - the published result is specific enough for downstream consumers to use

--- a/skills/ai-skills-release-github/examples/github-release-notes.md
+++ b/skills/ai-skills-release-github/examples/github-release-notes.md
@@ -5,5 +5,5 @@
 - added new bounded-scope review skills and supporting references
 - improved the shared skill catalog with clearer composition and capture-skill
   guidance
-- aligned release metadata, changelog content, and GitHub release notes for the
+- aligned release metadata, changelog content, and GitHub Release notes for the
   published tag

--- a/skills/ai-skills-release-github/references/github-release-flow.md
+++ b/skills/ai-skills-release-github/references/github-release-flow.md
@@ -5,7 +5,7 @@ Keep these release artifacts aligned:
 - changelog or authoritative release-notes source
 - versioned release examples and documentation references
 - annotated Git tag
-- GitHub Release page
+- GitHub Release page state
 
 Preferred sequence:
 
@@ -34,15 +34,27 @@ Preferred sequence:
     `git tag -a <tag> -m "..."` for a single-line tag message or
     `git tag -a <tag> -F <temp-file>` for a multi-line tag message
 12. push branch and tag
-13. create the GitHub Release from the pushed tag
-14. verify the tag and release page point at the same commit
+13. create the GitHub Release draft from the pushed tag
+14. if the broader release workflow has additional required public targets,
+    publish those targets next; if any public artifact becomes public and a
+    later required public target fails, burn the version, keep the tag as the
+    historical source pointer, and retain the draft or an explicitly labeled
+    historical partial-release record
+15. after all required public targets succeed, publish or promote the GitHub
+    Release from draft to final; if GitHub is the only required public target,
+    repository policy may allow immediate publication after draft verification
+16. verify the tag and release page state point at the same commit
 
 When repository policy defines a release-note heading or formatting template,
 honor that policy rather than inventing a new layout during release.
 
 If a repository has both a changelog and a separate release-notes source, decide
-which source is authoritative before creating the GitHub Release and keep the
-other one aligned or explicitly out of scope.
+which source is authoritative before creating the GitHub Release draft and keep
+the other one aligned or explicitly out of scope.
+
+If publication fails before any public artifact is successfully published, do
+not automatically assume the version is burned; same-version recovery remains a
+repository-policy decision.
 
 Do not treat a merely closed or stale-reviewed release-bound PR as sufficient
 release evidence. When release preparation depends on PRs, the shared PR review

--- a/skills/ai-skills-release-github/references/github-release-flow.md
+++ b/skills/ai-skills-release-github/references/github-release-flow.md
@@ -53,8 +53,8 @@ If a repository has both a changelog and a separate release-notes source, decide
 which source is authoritative before creating the GitHub Release draft and keep
 the other one aligned or explicitly out of scope.
 
-If publication fails before any public artifact is successfully published, do
-not automatically assume the version is burned; same-version recovery remains a
+If publication fails before any public artifact becomes public, do not
+automatically assume the version is burned; same-version recovery remains a
 repository-policy decision.
 
 Do not treat a merely closed or stale-reviewed release-bound PR as sufficient

--- a/skills/ai-skills-release-github/references/github-release-flow.md
+++ b/skills/ai-skills-release-github/references/github-release-flow.md
@@ -5,7 +5,7 @@ Keep these release artifacts aligned:
 - changelog or authoritative release-notes source
 - versioned release examples and documentation references
 - annotated Git tag
-- GitHub Release page state
+- GitHub Release state (draft vs published)
 
 Preferred sequence:
 

--- a/skills/ai-skills-release-github/references/github-release-flow.md
+++ b/skills/ai-skills-release-github/references/github-release-flow.md
@@ -42,7 +42,7 @@ Preferred sequence:
     historical partial-release record
 15. after all required public targets succeed, publish or promote the GitHub
     Release from draft to final; if GitHub is the only required public target,
-    repository policy may allow immediate publication after draft verification
+    repository policy may allow immediate publication after draft creation
 16. verify the tag and release page state point at the same commit
 
 When repository policy defines a release-note heading or formatting template,

--- a/skills/ai-skills-release-github/references/github-release-flow.md
+++ b/skills/ai-skills-release-github/references/github-release-flow.md
@@ -43,7 +43,8 @@ Preferred sequence:
 15. after all required public targets succeed, publish or promote the GitHub
     Release from draft to final; if GitHub is the only required public target,
     repository policy may allow immediate publication after draft creation
-16. verify the tag and release page state point at the same commit
+16. verify the tag exists and that the GitHub Release page points at the same
+    commit and is in the intended draft or published state
 
 When repository policy defines a release-note heading or formatting template,
 honor that policy rather than inventing a new layout during release.

--- a/skills/ai-skills-release/SKILL.md
+++ b/skills/ai-skills-release/SKILL.md
@@ -115,9 +115,10 @@ not as rules to copy into downstream projects.
 12. If publication fails before any public artifact becomes public, stop and
     defer same-version recovery to repository policy instead of automatically
     treating the version as burned. If any public artifact becomes public and
-    later publication fails, treat the version as burned, keep the tag as the
-    historical source pointer, and retain GitHub Release notes through the
-    draft or an explicitly labeled historical partial-release record.
+    a later required public target fails, treat the version as burned, keep
+    the tag as the historical source pointer, and retain GitHub Release notes
+    through the draft or an explicitly labeled historical partial-release
+    record.
 13. After all required public targets succeed, publish or promote the GitHub
     Release from draft to final, following repository policy for any non-public
     targets that remain out of scope.
@@ -165,8 +166,8 @@ not as rules to copy into downstream projects.
   the GitHub Release draft exists
 - do not publish the final GitHub Release before all required public targets
   succeed
-- do not retry a half-published public release under the same version once any
-  public artifact becomes public
+- do not retry a half-published public release under the same version when any
+  public artifact becomes public and a required public target later fails
 - do not move a failed release tag away from the true published source commit,
   except for a one-time correction that restores an already-moved tag to that
   true source pointer

--- a/skills/ai-skills-release/SKILL.md
+++ b/skills/ai-skills-release/SKILL.md
@@ -2,7 +2,7 @@
 name: ai-skills-release
 description: >-
   Execute the full repository release workflow from final verification through
-  GitHub release drafting/finalization and artifact publication. Use when a
+  GitHub Release drafting/finalization and artifact publication. Use when a
   repository needs the complete release sequence, not only the GitHub
   tag-and-release step. This is portable release orchestration;
   repository-specific release policy must be supplied as input rather than
@@ -13,7 +13,7 @@ description: >-
 # Purpose
 
 Run the full release workflow so the final build/test pass, version selection,
-documentation updates, changelog, GitHub release state, and registry
+documentation updates, changelog, GitHub Release state, and registry
 publications stay aligned.
 
 This skill is intentionally portable across repositories. Treat any
@@ -136,7 +136,7 @@ not as rules to copy into downstream projects.
   status
 - explicit release-bound PR review-loop status when pre-publish PRs were part
   of the release
-- aligned documentation, changelog, GitHub release state, and publication
+- aligned documentation, changelog, GitHub Release state, and publication
   artifacts
 - explicit publication status for each relevant release target
 - a concise release summary with follow-up blockers when publication was only
@@ -185,7 +185,7 @@ not as rules to copy into downstream projects.
   started from the latest released tag
 - any release-bound PRs required before publication were advanced through skill `ai-skills-pr-review-loop`
   and either merged cleanly or explicitly removed from the release scope
-- skill `ai-skills-release-github` was applied for the GitHub release portion
+- skill `ai-skills-release-github` was applied for the GitHub Release portion
 - any isolated public-release branch contains only the scoped release change
   before tagging and publication
 - skill `ai-skills-tooling-git-write` was applied indirectly through

--- a/skills/ai-skills-release/SKILL.md
+++ b/skills/ai-skills-release/SKILL.md
@@ -102,11 +102,11 @@ not as rules to copy into downstream projects.
 10. Apply skill `ai-skills-release-github` to perform the GitHub Release workflow,
     including version selection, changelog/docs alignment, release-prep
     commit, versioned-example updates, tag creation, push, and GitHub Release
-    draft creation. Complete the deferred final GitHub Release publication
-    later in step 13, after all required public targets succeed or immediately
-    when GitHub is the only required public target, using the default branch
-    by default or the isolated release branch when the isolated path was
-    required.
+    draft creation. Stop this step at draft creation. Use step 13 to publish or
+    promote that draft after all required public targets succeed; when GitHub is
+    the only required public target, step 13 may follow immediately after this
+    step. Use the default branch by default or the isolated release branch when
+    the isolated path was required.
 11. Publish release artifacts only after the tag is created and pushed and the
     GitHub Release draft is created. Publish to each applicable target registry
     listed in `references/publication-targets.md`, such as Maven Central, the
@@ -161,8 +161,8 @@ not as rules to copy into downstream projects.
 - do not replace the shared PR review and merge skills with release-specific
   ad-hoc PR handling when pre-publish release-bound PRs exist
 - do not publish artifacts whose version, changelog, or tag is out of sync
-- do not publish registry artifacts before the tag and GitHub Release draft
-  exist
+- do not publish registry artifacts before the tag is created and pushed and
+  the GitHub Release draft exists
 - do not publish the final GitHub Release before all required public targets
   succeed
 - do not retry a half-published public release under the same version once any
@@ -194,10 +194,11 @@ not as rules to copy into downstream projects.
   skill `ai-skills-release-github` when known release git-write messages existed
 - versioned examples and documentation references were updated to the new tag or
   explicitly ruled out
-- tag creation and push completed before GitHub Release draft creation, GitHub
-  Release draft creation completed before artifact publication, and final
-  GitHub Release publication happened only after required public targets
-  succeeded
+- tag creation and push completed before GitHub Release draft creation, and
+  GitHub Release draft creation completed before artifact publication
+- if all required public targets succeeded, final GitHub Release publication
+  happened only after that success; otherwise any partial-publication outcome
+  retained the draft or an explicitly labeled historical partial-release record
 - each repository-relevant publication target is either published successfully
   or explicitly marked not applicable
 - if any required public target failed after a public artifact became public,

--- a/skills/ai-skills-release/SKILL.md
+++ b/skills/ai-skills-release/SKILL.md
@@ -102,8 +102,11 @@ not as rules to copy into downstream projects.
 10. Apply skill `ai-skills-release-github` to perform the GitHub Release workflow,
     including version selection, changelog/docs alignment, release-prep
     commit, versioned-example updates, tag creation, push, and GitHub Release
-    draft creation, using the default branch by default or the isolated
-    release branch when the isolated path was required.
+    draft creation, plus the deferred final GitHub Release publication that
+    happens after all required public targets succeed or immediately when
+    GitHub is the only required public target, using the default branch by
+    default or the isolated release branch when the isolated path was
+    required.
 11. Publish release artifacts only after tag creation and GitHub Release draft
     creation both succeed. Publish to each applicable target registry listed
     in `references/publication-targets.md`, such as Maven Central, the Gradle

--- a/skills/ai-skills-release/SKILL.md
+++ b/skills/ai-skills-release/SKILL.md
@@ -107,18 +107,17 @@ not as rules to copy into downstream projects.
     when GitHub is the only required public target, using the default branch
     by default or the isolated release branch when the isolated path was
     required.
-11. Publish release artifacts only after tag creation and GitHub Release draft
-    creation both succeed. Publish to each applicable target registry listed
-    in `references/publication-targets.md`, such as Maven Central, the Gradle
-    Plugin Portal, or a private artifactory, and record any target that is
-    intentionally not applicable.
-12. If publication fails before any public artifact is successfully published,
-    stop and defer same-version recovery to repository policy instead of
-    automatically treating the version as burned. If any public artifact is
-    successfully published and later publication fails, treat the version as
-    burned, keep the tag as the historical source pointer, and retain GitHub
-    Release notes through the draft or an explicitly labeled historical
-    partial-release record.
+11. Publish release artifacts only after the tag is created and pushed and the
+    GitHub Release draft is created. Publish to each applicable target registry
+    listed in `references/publication-targets.md`, such as Maven Central, the
+    Gradle Plugin Portal, or a private artifactory, and record any target that
+    is intentionally not applicable.
+12. If publication fails before any public artifact becomes public, stop and
+    defer same-version recovery to repository policy instead of automatically
+    treating the version as burned. If any public artifact becomes public and
+    later publication fails, treat the version as burned, keep the tag as the
+    historical source pointer, and retain GitHub Release notes through the
+    draft or an explicitly labeled historical partial-release record.
 13. After all required public targets succeed, publish or promote the GitHub
     Release from draft to final, following repository policy for any non-public
     targets that remain out of scope.
@@ -195,14 +194,15 @@ not as rules to copy into downstream projects.
   skill `ai-skills-release-github` when known release git-write messages existed
 - versioned examples and documentation references were updated to the new tag or
   explicitly ruled out
-- tag creation completed before GitHub Release draft creation, GitHub Release
-  draft creation completed before artifact publication, and final GitHub
-  Release publication happened only after required public targets succeeded
+- tag creation and push completed before GitHub Release draft creation, GitHub
+  Release draft creation completed before artifact publication, and final
+  GitHub Release publication happened only after required public targets
+  succeeded
 - each repository-relevant publication target is either published successfully
   or explicitly marked not applicable
-- if any required public target failed after a public artifact was already
-  published, the result was treated as partial, the version was burned, and
-  the tag remained the historical source pointer
+- if any required public target failed after a public artifact became public,
+  the result was treated as partial, the version was burned, and the tag
+  remained the historical source pointer
 - the final release report names the released version, tag, chosen release
   source, and each target outcome
 - the final release report names the release-bound PR review result or

--- a/skills/ai-skills-release/SKILL.md
+++ b/skills/ai-skills-release/SKILL.md
@@ -2,18 +2,19 @@
 name: ai-skills-release
 description: >-
   Execute the full repository release workflow from final verification through
-  GitHub release and artifact publication. Use when a repository needs the
-  complete release sequence, not only the GitHub tag-and-release step. This is
-  portable release orchestration; repository-specific release policy must be
-  supplied as input rather than copied between projects.
+  GitHub release drafting/finalization and artifact publication. Use when a
+  repository needs the complete release sequence, not only the GitHub
+  tag-and-release step. This is portable release orchestration;
+  repository-specific release policy must be supplied as input rather than
+  copied between projects.
 ---
 <!-- markdownlint-disable MD025 -->
 
 # Purpose
 
 Run the full release workflow so the final build/test pass, version selection,
-documentation updates, changelog, GitHub release, and registry publications
-stay aligned.
+documentation updates, changelog, GitHub release state, and registry
+publications stay aligned.
 
 This skill is intentionally portable across repositories. Treat any
 repository-specific release rules as local policy inputs for that repository,
@@ -36,7 +37,7 @@ not as rules to copy into downstream projects.
   officially supported runtime or platform policy
 - use skill `ai-skills-release-github` for the full GitHub-release workflow,
   including version selection, docs/changelog alignment, the release-prep
-  commit and push, tag creation, and the GitHub Release itself
+  commit and push, tag creation, and GitHub Release drafting/finalization
 - rely on skill `ai-skills-tooling-git-write` through
   skill `ai-skills-release-github` so release-prep commits and known tag
   messages do not depend on an interactive editor
@@ -101,21 +102,32 @@ not as rules to copy into downstream projects.
 10. Apply skill `ai-skills-release-github` to perform the GitHub-release workflow,
     including version selection, changelog/docs alignment, release-prep
     commit, versioned-example updates, tag creation, push, and GitHub Release
-    creation, using the default branch by default or the isolated release
-    branch when the isolated path was required.
-11. Publish release artifacts only after tag creation and GitHub Release
-   creation both succeed. Publish to each applicable target registry listed in
-   `references/publication-targets.md`, such as Maven Central, the Gradle
-   Plugin Portal, or a private artifactory, and record any target that is
-   intentionally not applicable.
-12. Verify the published artifacts and release metadata so version numbers,
-    tags, changelog entries, and published packages all match. Record the
-    released version, tag, chosen release source, and each target result.
-13. If an isolated release branch was used, merge back the same scoped release
+    draft creation, using the default branch by default or the isolated
+    release branch when the isolated path was required.
+11. Publish release artifacts only after tag creation and GitHub Release draft
+    creation both succeed. Publish to each applicable target registry listed
+    in `references/publication-targets.md`, such as Maven Central, the Gradle
+    Plugin Portal, or a private artifactory, and record any target that is
+    intentionally not applicable.
+12. If publication fails before any public artifact is successfully published,
+    stop and defer same-version recovery to repository policy instead of
+    automatically treating the version as burned. If any public artifact is
+    successfully published and later publication fails, treat the version as
+    burned, keep the tag as the historical source pointer, and retain GitHub
+    release notes through the draft or an explicitly labeled historical
+    partial-release record.
+13. After all required public targets succeed, publish or promote the GitHub
+    Release from draft to final, following repository policy for any non-public
+    targets that remain out of scope.
+14. Verify the published artifacts and release metadata so version numbers,
+    tags, changelog entries, published packages, and GitHub Release state all
+    match. Record the released version, tag, chosen release source, each
+    target result, and whether the outcome was complete or partial.
+15. If an isolated release branch was used, merge back the same scoped release
     change cleanly to the default branch or confirm the default branch already
     contains an equivalent change set.
-14. Use `examples/release-checklist.md` when communicating the completed release
-    steps or any blocked publication target.
+16. Use `examples/release-checklist.md` when communicating the completed
+    release steps or any blocked publication target.
 
 # Outputs
 
@@ -124,7 +136,8 @@ not as rules to copy into downstream projects.
   status
 - explicit release-bound PR review-loop status when pre-publish PRs were part
   of the release
-- aligned documentation, changelog, GitHub release, and publication artifacts
+- aligned documentation, changelog, GitHub release state, and publication
+  artifacts
 - explicit publication status for each relevant release target
 - a concise release summary with follow-up blockers when publication was only
   partially completed
@@ -146,7 +159,17 @@ not as rules to copy into downstream projects.
 - do not replace the shared PR review and merge skills with release-specific
   ad-hoc PR handling when pre-publish release-bound PRs exist
 - do not publish artifacts whose version, changelog, or tag is out of sync
-- do not publish registry artifacts before the tag and GitHub Release exist
+- do not publish registry artifacts before the tag and GitHub Release draft
+  exist
+- do not publish the final GitHub Release before all required public targets
+  succeed
+- do not retry a half-published public release under the same version once any
+  public artifact exists
+- do not move a failed release tag away from the true published source commit,
+  except for a one-time correction that restores an already-moved tag to that
+  true source pointer
+- do not treat green preflight evidence as proof of tag-triggered publication
+  parity unless the same release-only checks are exercised
 - do not assume every repository publishes to Maven Central, the Gradle Plugin
   Portal, and private artifactory; treat each target as conditional
 - do not declare an isolated public release complete until the same scoped
@@ -169,10 +192,14 @@ not as rules to copy into downstream projects.
   skill `ai-skills-release-github` when known release git-write messages existed
 - versioned examples and documentation references were updated to the new tag or
   explicitly ruled out
-- tag creation completed before GitHub Release creation, and GitHub Release
-  creation completed before artifact publication
+- tag creation completed before GitHub Release draft creation, GitHub Release
+  draft creation completed before artifact publication, and final GitHub
+  Release publication happened only after required public targets succeeded
 - each repository-relevant publication target is either published successfully
   or explicitly marked not applicable
+- if any required public target failed after a public artifact was already
+  published, the result was treated as partial, the version was burned, and
+  the tag remained the historical source pointer
 - the final release report names the released version, tag, chosen release
   source, and each target outcome
 - the final release report names the release-bound PR review result or

--- a/skills/ai-skills-release/SKILL.md
+++ b/skills/ai-skills-release/SKILL.md
@@ -166,7 +166,7 @@ not as rules to copy into downstream projects.
 - do not publish the final GitHub Release before all required public targets
   succeed
 - do not retry a half-published public release under the same version once any
-  public artifact exists
+  public artifact becomes public
 - do not move a failed release tag away from the true published source commit,
   except for a one-time correction that restores an already-moved tag to that
   true source pointer

--- a/skills/ai-skills-release/SKILL.md
+++ b/skills/ai-skills-release/SKILL.md
@@ -200,8 +200,8 @@ not as rules to copy into downstream projects.
 - if all required public targets succeeded, final GitHub Release publication
   happened only after that success; otherwise any partial-publication outcome
   retained the draft or an explicitly labeled historical partial-release record
-- each repository-relevant publication target is either published successfully
-  or explicitly marked not applicable
+- each repository-relevant publication target has an explicitly recorded
+  result, such as published successfully, failed, or not applicable
 - if any required public target failed after a public artifact became public,
   the result was treated as partial, the version was burned, and the tag
   remained the historical source pointer

--- a/skills/ai-skills-release/SKILL.md
+++ b/skills/ai-skills-release/SKILL.md
@@ -35,7 +35,7 @@ not as rules to copy into downstream projects.
   framework, or build-tool choices are still open in the release scope
 - use skill `ai-skills-version-support-policy` when the release changes the
   officially supported runtime or platform policy
-- use skill `ai-skills-release-github` for the full GitHub-release workflow,
+- use skill `ai-skills-release-github` for the full GitHub Release workflow,
   including version selection, docs/changelog alignment, the release-prep
   commit and push, tag creation, and GitHub Release drafting/finalization
 - rely on skill `ai-skills-tooling-git-write` through
@@ -99,7 +99,7 @@ not as rules to copy into downstream projects.
    review loop and merged or was explicitly removed from the release scope.
 9. Confirm versioned release examples and documentation references are known so
    the release can update them to the new tag.
-10. Apply skill `ai-skills-release-github` to perform the GitHub-release workflow,
+10. Apply skill `ai-skills-release-github` to perform the GitHub Release workflow,
     including version selection, changelog/docs alignment, release-prep
     commit, versioned-example updates, tag creation, push, and GitHub Release
     draft creation, using the default branch by default or the isolated
@@ -114,7 +114,7 @@ not as rules to copy into downstream projects.
     automatically treating the version as burned. If any public artifact is
     successfully published and later publication fails, treat the version as
     burned, keep the tag as the historical source pointer, and retain GitHub
-    release notes through the draft or an explicitly labeled historical
+    Release notes through the draft or an explicitly labeled historical
     partial-release record.
 13. After all required public targets succeed, publish or promote the GitHub
     Release from draft to final, following repository policy for any non-public

--- a/skills/ai-skills-release/SKILL.md
+++ b/skills/ai-skills-release/SKILL.md
@@ -102,10 +102,10 @@ not as rules to copy into downstream projects.
 10. Apply skill `ai-skills-release-github` to perform the GitHub Release workflow,
     including version selection, changelog/docs alignment, release-prep
     commit, versioned-example updates, tag creation, push, and GitHub Release
-    draft creation, plus the deferred final GitHub Release publication that
-    happens after all required public targets succeed or immediately when
-    GitHub is the only required public target, using the default branch by
-    default or the isolated release branch when the isolated path was
+    draft creation. Complete the deferred final GitHub Release publication
+    later in step 13, after all required public targets succeed or immediately
+    when GitHub is the only required public target, using the default branch
+    by default or the isolated release branch when the isolated path was
     required.
 11. Publish release artifacts only after tag creation and GitHub Release draft
     creation both succeed. Publish to each applicable target registry listed

--- a/skills/ai-skills-release/examples/release-checklist.md
+++ b/skills/ai-skills-release/examples/release-checklist.md
@@ -1,5 +1,7 @@
 # Example Release Checklist
 
+## Complete Public Release
+
 - final build: pass
 - final tests: pass
 - delta to previous release: reviewed
@@ -9,12 +11,37 @@
 - release-bound PR review loop: not needed
 - docs/examples updated: yes
 - changelog updated: yes
-- GitHub release: published
-- artifact publication ordering: after tag and GitHub Release
+- GitHub release draft: created after tag push
+- artifact publication ordering: after tag and GitHub Release draft
 - Maven Central: published
 - Gradle Plugin Portal: not applicable
 - private artifactory: published
+- GitHub release final state: published
 - merge-back to default branch: completed cleanly
 
 Overall result: release completed successfully for all repository-relevant
 targets.
+
+## Partial Public Release
+
+- final build: pass
+- final tests: pass
+- delta to previous release: reviewed
+- semantic version: `1.8.1`
+- release tag: `v1.8.1`
+- release source: default branch
+- release-bound PR review loop: not needed
+- docs/examples updated: yes
+- changelog updated: yes
+- GitHub release draft: created after tag push
+- artifact publication ordering: after tag and GitHub Release draft
+- Maven Central: published
+- Gradle Plugin Portal: failed
+- private artifactory: not applicable
+- version burned: yes, because a public artifact was already published
+- release tag state: kept at the true published source commit
+- GitHub release final state: retained as draft or historical partial-release
+  record per repository policy
+
+Overall result: release partially completed. Roll forward with a new version
+for any later complete public release.

--- a/skills/ai-skills-release/examples/release-checklist.md
+++ b/skills/ai-skills-release/examples/release-checklist.md
@@ -38,7 +38,7 @@ targets.
 - Maven Central: published
 - Gradle Plugin Portal: failed
 - private artifactory: not applicable
-- version burned: yes, because a public artifact was already published
+- version burned: yes, because a public artifact became public
 - release tag state: kept at the true published source commit
 - GitHub Release final state: retained as draft or historical partial-release
   record per repository policy

--- a/skills/ai-skills-release/examples/release-checklist.md
+++ b/skills/ai-skills-release/examples/release-checklist.md
@@ -11,12 +11,12 @@
 - release-bound PR review loop: not needed
 - docs/examples updated: yes
 - changelog updated: yes
-- GitHub release draft: created after tag push
+- GitHub Release draft: created after tag push
 - artifact publication ordering: after tag and GitHub Release draft
 - Maven Central: published
 - Gradle Plugin Portal: not applicable
 - private artifactory: published
-- GitHub release final state: published
+- GitHub Release final state: published
 - merge-back to default branch: completed cleanly
 
 Overall result: release completed successfully for all repository-relevant
@@ -33,14 +33,14 @@ targets.
 - release-bound PR review loop: not needed
 - docs/examples updated: yes
 - changelog updated: yes
-- GitHub release draft: created after tag push
+- GitHub Release draft: created after tag push
 - artifact publication ordering: after tag and GitHub Release draft
 - Maven Central: published
 - Gradle Plugin Portal: failed
 - private artifactory: not applicable
 - version burned: yes, because a public artifact was already published
 - release tag state: kept at the true published source commit
-- GitHub release final state: retained as draft or historical partial-release
+- GitHub Release final state: retained as draft or historical partial-release
   record per repository policy
 
 Overall result: release partially completed. Roll forward with a new version

--- a/skills/ai-skills-release/references/publication-targets.md
+++ b/skills/ai-skills-release/references/publication-targets.md
@@ -6,7 +6,7 @@ Evaluate publication targets explicitly:
 - Gradle Plugin Portal
 - private artifactory or repository-specific package registry
 
-Before iterating the individual targets:
+Overall sequence around the per-target loop:
 
 1. create the GitHub Release draft after the tag is created and pushed, and
    before publishing any target

--- a/skills/ai-skills-release/references/publication-targets.md
+++ b/skills/ai-skills-release/references/publication-targets.md
@@ -25,12 +25,13 @@ For each target:
 3. if the target is applicable, publish to it only after the pushed tag and
    GitHub Release draft already exist
 4. verify the published artifact version and availability after publication
-5. if the target is public enough and any artifact becomes public, treat that
-   version as burned for retry purposes if later required public targets fail,
-   and keep the tag as the historical source pointer
-6. if publication fails before any public artifact becomes public, defer
-   same-version recovery to repository policy instead of automatically treating
-   the version as burned
+5. if the target is public enough and any artifact for that release version
+   becomes public in any target, treat the version as burned for retry
+   purposes if later required public targets fail, and keep the tag as the
+   historical source pointer
+6. if publication fails before any artifact for that release version becomes
+   public in any target, defer same-version recovery to repository policy
+   instead of automatically treating the version as burned
 7. record `not applicable` when the repository does not use that target
 
 Do not treat optional targets as mandatory, but do not silently skip required

--- a/skills/ai-skills-release/references/publication-targets.md
+++ b/skills/ai-skills-release/references/publication-targets.md
@@ -8,8 +8,8 @@ Evaluate publication targets explicitly:
 
 Before iterating the individual targets:
 
-1. create the GitHub Release draft after the tag exists and before publishing
-   any target
+1. create the GitHub Release draft after the tag is created and pushed, and
+   before publishing any target
 2. after all required public targets succeed, publish or promote the GitHub
    Release from draft to final
 
@@ -22,8 +22,8 @@ For each target:
    general public, such as Maven Central or the Gradle Plugin Portal, and do
    not treat private or access-controlled registries as public enough unless
    repository policy says they should follow the same isolation rule
-3. if the target is applicable, publish to it only after the tag and GitHub
-   Release draft already exist
+3. if the target is applicable, publish to it only after the pushed tag and
+   GitHub Release draft already exist
 4. verify the published artifact version and availability after publication
 5. if the target is public enough and any artifact becomes public, treat that
    version as burned for retry purposes if later required public targets fail,

--- a/skills/ai-skills-release/references/publication-targets.md
+++ b/skills/ai-skills-release/references/publication-targets.md
@@ -9,7 +9,7 @@ Evaluate publication targets explicitly:
 Before iterating the individual targets:
 
 1. create the GitHub Release draft after the tag exists and before publishing
-   public targets
+   any target
 2. after all required public targets succeed, publish or promote the GitHub
    Release from draft to final
 

--- a/skills/ai-skills-release/references/publication-targets.md
+++ b/skills/ai-skills-release/references/publication-targets.md
@@ -15,9 +15,18 @@ For each target:
    general public, such as Maven Central or the Gradle Plugin Portal, and do
    not treat private or access-controlled registries as public enough unless
    repository policy says they should follow the same isolation rule
-3. publish only after the tag exists and the GitHub Release was created
-4. verify the published artifact version and availability
-5. record `not applicable` when the repository does not use that target
+3. create the GitHub Release draft after the tag exists and before publishing
+   public targets
+4. if the target is public enough and any artifact becomes public, treat that
+   version as burned for retry purposes if later required public targets fail,
+   and keep the tag as the historical source pointer
+5. after all required public targets succeed, publish or promote the GitHub
+   Release from draft to final and verify the published artifact version and
+   availability
+6. if publication fails before any public artifact becomes public, defer
+   same-version recovery to repository policy instead of automatically treating
+   the version as burned
+7. record `not applicable` when the repository does not use that target
 
 Do not treat optional targets as mandatory, but do not silently skip required
 targets either.

--- a/skills/ai-skills-release/references/publication-targets.md
+++ b/skills/ai-skills-release/references/publication-targets.md
@@ -6,6 +6,13 @@ Evaluate publication targets explicitly:
 - Gradle Plugin Portal
 - private artifactory or repository-specific package registry
 
+Before iterating the individual targets:
+
+1. create the GitHub Release draft after the tag exists and before publishing
+   public targets
+2. after all required public targets succeed, publish or promote the GitHub
+   Release from draft to final
+
 For each target:
 
 1. determine whether the repository actually publishes there
@@ -15,18 +22,14 @@ For each target:
    general public, such as Maven Central or the Gradle Plugin Portal, and do
    not treat private or access-controlled registries as public enough unless
    repository policy says they should follow the same isolation rule
-3. create the GitHub Release draft after the tag exists and before publishing
-   public targets
-4. if the target is public enough and any artifact becomes public, treat that
+3. if the target is public enough and any artifact becomes public, treat that
    version as burned for retry purposes if later required public targets fail,
    and keep the tag as the historical source pointer
-5. after all required public targets succeed, publish or promote the GitHub
-   Release from draft to final and verify the published artifact version and
-   availability
-6. if publication fails before any public artifact becomes public, defer
+4. verify the published artifact version and availability after publication
+5. if publication fails before any public artifact becomes public, defer
    same-version recovery to repository policy instead of automatically treating
    the version as burned
-7. record `not applicable` when the repository does not use that target
+6. record `not applicable` when the repository does not use that target
 
 Do not treat optional targets as mandatory, but do not silently skip required
 targets either.

--- a/skills/ai-skills-release/references/publication-targets.md
+++ b/skills/ai-skills-release/references/publication-targets.md
@@ -22,14 +22,16 @@ For each target:
    general public, such as Maven Central or the Gradle Plugin Portal, and do
    not treat private or access-controlled registries as public enough unless
    repository policy says they should follow the same isolation rule
-3. if the target is public enough and any artifact becomes public, treat that
+3. if the target is applicable, publish to it only after the tag and GitHub
+   Release draft already exist
+4. verify the published artifact version and availability after publication
+5. if the target is public enough and any artifact becomes public, treat that
    version as burned for retry purposes if later required public targets fail,
    and keep the tag as the historical source pointer
-4. verify the published artifact version and availability after publication
-5. if publication fails before any public artifact becomes public, defer
+6. if publication fails before any public artifact becomes public, defer
    same-version recovery to repository policy instead of automatically treating
    the version as burned
-6. record `not applicable` when the repository does not use that target
+7. record `not applicable` when the repository does not use that target
 
 Do not treat optional targets as mandatory, but do not silently skip required
 targets either.

--- a/skills/ai-skills-release/references/release-preconditions.md
+++ b/skills/ai-skills-release/references/release-preconditions.md
@@ -16,6 +16,9 @@ Before running the release:
   may be required
 - changelog, versioned documentation, and versioned example locations are
   identified
+- if preflight CI evidence is being used, it is clear whether that preflight
+  mirrors the tag-triggered release-only checks; otherwise treat preflight as
+  release-plumbing evidence rather than full publication-parity evidence
 
 If any of these are missing, stop and surface the missing release input instead
 of guessing.


### PR DESCRIPTION
## Summary
- switch the `ai-skills-release` family from final-release-first wording to a draft-first GitHub Release flow for public registry releases
- define burned-version handling, immutable failed-tag handling, and the distinction between preflight plumbing checks and true tag-triggered publication parity
- extend the release checklist example with both complete and partial public release outcomes

## Review Focus
- wording consistency between `ai-skills-release` and `ai-skills-release-github`
- draft/final GitHub Release sequencing across the skill bodies, references, and example checklist
- burned-version and preflight guidance staying tool-agnostic rather than repo-specific

## Validation
- `corepack pnpm install`
- `corepack pnpm validate`
- `corepack pnpm lint:md`
- `corepack pnpm build`
- `corepack pnpm test`
- `corepack pnpm pack:dry-run`

## Residual Risk
- the change is documentation-only, so the main risk is wording drift or ambiguity in future release-family edits rather than runtime behavior

Closes #231
