### PR TITLE
Improve release, review, and capture guidance

### DIFF
--- a/skills/ai-skills-pr-review-loop/SKILL.md
+++ b/skills/ai-skills-pr-review-loop/SKILL.md
@@ -38,7 +38,8 @@ after the latest push has been reviewed.
 - session entry preferences when already answered:
   `RUN_REVIEW_LOOP`, `IMPLEMENT_AFTER_PLAN`, and `MERGE_AFTER_CLEAN_LOOP`
 - the latest push time, current head commit, automated-review state,
-  review-request timeline state, review threads, and required checks for each
+  review-request timeline state, review threads, any exposed suppressed,
+  hidden, or low-confidence automated findings, and required checks for each
   PR
 - repository preferences about whether clean PRs should be merged
 - access to the PR platform APIs needed to request or inspect automated review
@@ -99,26 +100,32 @@ after the latest push has been reviewed.
    mutation and verification steps.
 10. If checks are still running or a review is still in progress for the
    latest push, keep the PR active and continue with the next item.
-11. When the latest push has completed review results, apply
-   skill `ai-skills-pr-review` and skill `ai-skills-pr-review-respond` to classify
-   handled findings as valid or invalid, reply to every handled thread, fix
-   every valid finding, and resolve all handled threads before the round is
-   complete.
-12. If fixes were pushed, restart the same post-push review cycle for that PR
+11. When the latest push has completed review results, audit any suppressed,
+    hidden, or low-confidence automated findings that the current platform
+    surface exposes for that same `headRefOid`. Record whether the audit is
+    `completed`, `not-applicable`, or `unavailable`.
+12. For thread-backed findings, apply skill `ai-skills-pr-review` and skill `ai-skills-pr-review-respond`
+    to classify handled findings as valid or invalid, reply to every handled
+    thread, fix every valid finding, and resolve all handled threads before the
+    round is complete. For exposed non-thread findings, still classify them as
+    valid or invalid, fix or explain every valid finding, and record
+    explicitly when the platform gives no thread surface to reply on or
+    resolve.
+13. If fixes were pushed, restart the same post-push review cycle for that PR
    instead of treating earlier review results as sufficient. Do not send a
    second explicit manual review request for the same head unless the head
    commit changed or review-request timeline evidence shows the pending request
    was removed. For strict GitHub Copilot review loops, repeat the same
    approved `gh` CLI / GraphQL flow instead of using PR comments or `@copilot`
    mentions.
-13. If no fixes were needed, verify the PR remains focused on the linked issue
+14. If no fixes were needed, verify the PR remains focused on the linked issue
    and the PR body contains the issue-closing link, then evaluate the
    review-readiness gate from `references/review-loop-state.md`.
-14. When the review-readiness gate passes and
+15. When the review-readiness gate passes and
    `MERGE_AFTER_CLEAN_LOOP=true`, hand the PR to skill `ai-skills-pr-merge` for
    the remaining merge-policy checks and merge execution; otherwise report the
    blocking gate conditions or clean-but-unmerged status.
-15. Use `examples/review-loop-status.md` when communicating queue state,
+16. Use `examples/review-loop-status.md` when communicating queue state,
    remaining blockers, or clean completion.
 
 # Outputs
@@ -131,6 +138,8 @@ after the latest push has been reviewed.
 - explicit note when strict GitHub Copilot review was manually requested
   through the approved `gh` / GraphQL flow for the latest head commit after
   the 5-minute minimum from `last-push-at`
+- suppressed-finding audit status for the latest reviewed head: `completed`,
+  `not-applicable`, or `unavailable`
 - captured session preferences or explicit note that the loop was skipped
 - handled review threads with explicit valid or invalid classification,
   required replies, and final resolution
@@ -160,9 +169,15 @@ after the latest push has been reviewed.
   `gh api graphql` flow using the `requestReviewsByLogin` mutation with a
   weaker GitHub comment convention when strict GitHub Copilot review is
   required
+- do not declare a clean review round while platform-exposed suppressed,
+  hidden, or low-confidence findings for the latest reviewed head remain
+  untriaged
 - do not mention `@copilot` in PR comments
 - do not delete review comments to make threads disappear; resolve handled
   threads and preserve the history
+- do not pretend a non-thread finding was replied to or resolved in-thread when
+  the platform exposed no thread surface for it; record that limitation
+  explicitly instead
 - do not declare a review round complete while any handled thread lacks a
   reply, any valid finding remains unfixed, or any handled thread remains open
 - do not resolve invalid findings without leaving a concise rationale first
@@ -181,6 +196,10 @@ after the latest push has been reviewed.
   came from the approved `gh` / GraphQL trigger flow or already-existing fresh
   platform review state, and any manual request honored the 5-minute minimum
   from `last-push-at`
+- the latest reviewed head has a recorded suppressed-finding audit status of
+  `completed`, `not-applicable`, or `unavailable`, and any exposed suppressed,
+  hidden, or low-confidence findings were triaged before the PR was treated as
+  clean
 - each merge-ready PR is focused on its linked issue and has an issue-closing
   link in the PR body
 - each completed review round classified handled findings as valid or invalid,

--- a/skills/ai-skills-pr-review-loop/examples/review-loop-status.md
+++ b/skills/ai-skills-pr-review-loop/examples/review-loop-status.md
@@ -1,10 +1,12 @@
 # Example Review Loop Status
 
 - `#71` skill `ai-skills-compliance-dependency`: checks green, issue link present, focused scope,
-  no valid findings, no open review threads, `review-submitted`, waiting only
-  for merge execution
-- `#72` skill `ai-skills-performance-db`: one valid finding fixed and pushed
-  2 minutes ago, no submitted review or pending request visible yet,
+  no valid findings, no open review threads, `review-submitted`,
+  suppressed-finding audit `not-applicable`, waiting only for merge execution
+- `#72` skill `ai-skills-performance-db`: review submitted for the latest
+  head, one exposed low-confidence non-thread finding was explained and one
+  valid finding was fixed, suppressed-finding audit `completed`, new push
+  happened 2 minutes ago, no submitted review or pending request visible yet,
   `awaiting-automatic-review-signal`, loop moved on to the next item instead
   of re-triggering
 - `#73` skill `ai-skills-release-github`: no review submitted yet for the
@@ -13,6 +15,7 @@
   running
 - `#74` skill `ai-skills-bootstrap-ci-pipeline`: latest push is 9 minutes old,
   no submitted review or pending request is visible for the current head,
-  `manual-review-request-eligible`, PR node id captured with
+  `manual-review-request-eligible`, suppressed-finding audit `unavailable`
+  until a fresh review is exposed for the current head, PR node id captured with
   `gh pr view 74 --json id --jq .id`, Copilot review manually requested once
   via `gh api graphql`, loop moved on to the next item

--- a/skills/ai-skills-pr-review-loop/references/review-loop-queue.md
+++ b/skills/ai-skills-pr-review-loop/references/review-loop-queue.md
@@ -31,6 +31,12 @@ current head state described in `copilot-review-trigger.md` under this skill's
 `manual-review-request-eligible`. Do not use PR comments or `@copilot`
 mentions as the trigger.
 
+Once a fresh submitted review exists for the current head, inspect any
+platform-exposed suppressed, hidden, or low-confidence automated findings
+before treating the round as clean. This is an audit obligation attached to the
+latest reviewed head, not a new queue state. Record the outcome as
+`completed`, `not-applicable`, or `unavailable`.
+
 Do not send a second explicit manual request for the same head while a pending
 request remains visible. If a `ReviewRequestRemovedEvent` appears for the
 current head before a submitted review arrives, the PR can become

--- a/skills/ai-skills-pr-review-loop/references/review-loop-state.md
+++ b/skills/ai-skills-pr-review-loop/references/review-loop-state.md
@@ -11,6 +11,7 @@ Track each active PR with at least these fields:
 - `review-in-progress-after-last-push`
 - `open-review-threads`
 - `new-valid-findings`
+- `suppressed-findings-audit-status`
 - `required-checks-green`
 - `issue-link-present`
 - `pr-scope-focused`
@@ -38,6 +39,16 @@ the most recent explicit manual review request issued by the loop so duplicate
 same-head triggers are prevented. A review request or review tied to an older
 head, or predating `last-push-at`, never satisfies `current-head-oid`.
 
+Define `suppressed-findings-audit-status` as exactly one of:
+
+- `completed`: the inspected platform surface exposed suppressed, hidden, or
+  low-confidence automated findings for `current-head-oid`, and each exposed
+  item was triaged before the PR was treated as clean
+- `not-applicable`: the inspected platform surface exposed no suppressed,
+  hidden, or low-confidence automated findings for `current-head-oid`
+- `unavailable`: the platform surface used by the loop does not expose that
+  class of finding for `current-head-oid`
+
 The review-readiness gate passes only when all of these are true in the same
 evaluation round:
 
@@ -47,6 +58,8 @@ evaluation round:
 - no review is still running for the latest push
 - no open review threads remain
 - no new valid findings remain
+- `suppressed-findings-audit-status` is `completed`, `not-applicable`, or
+  `unavailable`
 - required checks are green
 - the PR body links the main issue with an issue-closing link
 - the PR scope remains focused on the linked issue without unrelated bundled

--- a/skills/ai-skills-release-github/SKILL.md
+++ b/skills/ai-skills-release-github/SKILL.md
@@ -24,6 +24,9 @@ final states.
   user-visible changes since the latest released tag
 - use when changelog content, tags, and GitHub Release notes must describe the
   same release
+- use skill `ai-skills-release-recovery` when the intended version or tag
+  already has failed-release or partial-release state and this normal
+  GitHub-release flow must stop for recovery classification
 - use skill `ai-skills-pr-review-loop` when release work is intentionally
   delivered through PRs before the release-preparation commit can be created
 - use skill `ai-skills-tooling-git-write` when the release flow will create a
@@ -43,6 +46,8 @@ final states.
 - the repository default branch, or an intentionally isolated release branch
   created from the latest released tag when skill `ai-skills-release`
   explicitly requires that narrower source as an input to this skill
+- the remote default-branch head at release start, or the ability to verify it
+  before version selection and again immediately before tagging
 - confirmation that all required release-bound PRs are merged or explicitly
   removed from scope for the chosen release source and intended release scope,
   or the release-bound PR list that must complete the shared review loop
@@ -53,6 +58,7 @@ final states.
   release scope that affect compatibility claims
 - the changelog or strongest release-notes source for the repository
 - GitHub access capable of pushing tags and creating releases
+- skill `ai-skills-release-recovery`
 - skill `ai-skills-pr-review-loop`
 - skill `ai-skills-tooling-git-write`
 - `references/version-selection.md`
@@ -64,57 +70,69 @@ final states.
    release branch when skill `ai-skills-release` explicitly requires it and
    passes that requirement into this skill; create that branch from the latest
    released tag so unrelated unreleased default-branch work is excluded.
-2. Ensure the chosen release source is correct for its intended scope,
+2. Verify the remote default-branch head before version selection, confirm the
+   local release source is current relative to that remote head, record the
+   checked head, and stop until the source is refreshed or clarified if the
+   remote or local state is ambiguous.
+3. Ensure the chosen release source is correct for its intended scope,
    identify any release-bound PRs that still must land for that scope, and do
    not release from a feature branch.
-3. If the chosen release source still depends on release-bound PRs, apply
+4. If the intended version or tag already has failed-release, partial-release,
+   or other recovery-state evidence, such as an existing tag, GitHub Release,
+   or publication attempt from a prior run, stop this normal flow and apply
+   skill `ai-skills-release-recovery` before any retry or metadata change.
+5. If the chosen release source still depends on release-bound PRs, apply
    skill `ai-skills-pr-review-loop` to those PRs and do not continue until
    each one completed a clean review loop and merged, or was explicitly
    removed from the release scope.
-4. If the release scope includes framework, build-tool, or dependency choices
+6. If the release scope includes framework, build-tool, or dependency choices
    that are not fixed yet, apply skill `ai-skills-version-dependency-selection`
    before finalizing release timing or compatibility notes.
-5. If the release changes officially supported runtimes or platforms and the
+7. If the release changes officially supported runtimes or platforms and the
    support policy is not explicit yet, apply skill `ai-skills-version-support-policy`
    before finalizing compatibility claims.
-6. Determine the target version: use an explicit version when provided;
+8. Determine the target version: use an explicit version when provided;
    otherwise classify the changes since the latest released tag and select the
    smallest valid semantic-version bump that fits the strongest user-visible
    change.
-7. Stop if there are no meaningful release changes instead of creating an empty
+9. Stop if there are no meaningful release changes instead of creating an empty
    tag.
-8. Verify the chosen release source contains only the intended scoped release
+10. Verify the chosen release source contains only the intended scoped release
    change set by inspecting the commits or file diff from the latest released
    tag to that source. Stop until the source is narrowed if unrelated
    unreleased work would be included.
-9. Update the changelog or release-notes source with the selected version, the
+11. Update the changelog or release-notes source with the selected version, the
    release date, and a concise summary of user-visible changes.
-10. Run `git grep -F "<previous-tag>"` before creating the release commit,
+12. Run `git grep -F "<previous-tag>"` before creating the release commit,
    replacing `<previous-tag>` with the actual latest released version tag, for
    example `v1.2.3`. Update every versioned release example or documentation
    reference found so it points at the new tag.
-11. Stage the changelog or release-notes source and all versioned-example
+13. Stage the changelog or release-notes source and all versioned-example
     updates together.
-12. Apply skill `ai-skills-tooling-git-write` so the release-preparation
+14. Re-check the remote default-branch head immediately before tagging. If it
+    moved since the earlier verification, stop and recompute the intended
+    release scope and version before creating the release-preparation commit or
+    tag.
+15. Apply skill `ai-skills-tooling-git-write` so the release-preparation
     commit and annotated tag use non-interactive git write commands when their
     messages are already known.
-13. Commit the release-preparation changes on the chosen release source,
+16. Commit the release-preparation changes on the chosen release source,
     create an annotated tag for the release commit, and push both branch and
     tag.
-14. Create the GitHub Release draft from the pushed tag using notes that stay
+17. Create the GitHub Release draft from the pushed tag using notes that stay
     aligned with the changelog or release-notes source. If both exist, treat
     the changelog as authoritative unless repository policy explicitly says
     otherwise.
-15. If repository policy or skill `ai-skills-release` says GitHub is the only
+18. If repository policy or skill `ai-skills-release` says GitHub is the only
     required public target, publish the draft immediately after creation.
     Otherwise keep the draft in place until the broader release workflow
     confirms all required public targets succeeded, then publish or promote it
     to final.
-16. If a required public target later fails after any public artifact becomes
+19. If a required public target later fails after any public artifact becomes
     public, retain the draft or convert it into an explicitly labeled
     historical partial-release record per repository policy instead of
     pretending the release completed successfully.
-17. Verify that the tag exists and that the GitHub Release page points at the
+20. Verify that the tag exists and that the GitHub Release page points at the
     intended commit and is in the intended state.
 
 # Outputs
@@ -122,6 +140,7 @@ final states.
 - the selected release version and release commit
 - the release source used, including whether it was the default branch or an
   intentionally isolated release branch from the latest released tag
+- recorded remote default-branch freshness evidence for the release source
 - release-bound PR review-loop status when PR-based release preparation was
   required
 - aligned changelog or release notes for that version
@@ -137,6 +156,12 @@ final states.
 - do not release from a feature branch or dirty branch state
 - do not use an isolated release branch unless skill `ai-skills-release`
   explicitly requires it
+- do not trust a local default branch or release source without checking the
+  remote default-branch head before version selection and again immediately
+  before tagging
+- do not continue this normal GitHub-release flow when the same intended
+  version or tag already has failed-release or partial-release state; classify
+  recovery first with skill `ai-skills-release-recovery`
 - do not release while a required release-bound PR for the chosen release
   source and intended release scope lacks a completed shared review loop for
   its latest head or remains unmerged
@@ -163,8 +188,14 @@ final states.
 # Exit Checks
 
 - the target version is explicit and justified
+- the remote default-branch head was recorded before version selection and was
+  rechecked immediately before tagging; if it moved, the scope and version were
+  recomputed or the release stopped
 - the chosen release source is explicit and justified, and isolated release
   branch use is backed by an explicit skill `ai-skills-release` requirement
+- any already-failed or already-partial release state for the intended version
+  or tag was handed to skill `ai-skills-release-recovery` instead of being
+  retried implicitly
 - if release-bound PRs were needed for the intended scope, skill `ai-skills-pr-review-loop`
   was applied and each required PR completed the shared review loop and merged
   or was explicitly removed from scope before tagging

--- a/skills/ai-skills-release-github/references/github-release-flow.md
+++ b/skills/ai-skills-release-github/references/github-release-flow.md
@@ -10,40 +10,49 @@ Keep these release artifacts aligned:
 Preferred sequence:
 
 1. treat the default branch as the normal release source
-2. if skill `ai-skills-release` explicitly passes an isolated release branch
+2. verify the remote default-branch head before version selection and stop
+   until the local source is refreshed or clarified if it is stale or
+   ambiguous relative to that remote head
+3. if skill `ai-skills-release` explicitly passes an isolated release branch
    requirement into this flow, create that branch from the latest released tag
    and keep it limited to the scoped release change
-3. verify the chosen release source is correct for its intended scope and
+4. if the same intended version or tag already has failed-release,
+   partial-release, or other recovery-state evidence from a prior run, stop
+   this normal flow and classify the recovery path first with skill `ai-skills-release-recovery`
+5. verify the chosen release source is correct for its intended scope and
    identify any release-bound PRs that still must land for that scope
-4. if release work still depends on release-bound PRs, advance them through
+6. if release work still depends on release-bound PRs, advance them through
    skill `ai-skills-pr-review-loop` until each required PR is freshly reviewed
    and merged or explicitly removed from scope
-5. inspect the commits or file diff from the latest released tag to the chosen
+7. inspect the commits or file diff from the latest released tag to the chosen
    release source and stop if unrelated unreleased default-branch work would be
    included
-6. update release-notes source
-7. run `git grep -F "<previous-tag>"`, replacing `<previous-tag>` with the
+8. update release-notes source
+9. run `git grep -F "<previous-tag>"`, replacing `<previous-tag>` with the
    actual latest released tag, for example `v1.2.3`
-8. update every relevant versioned example or documentation reference to the new
-   tag
-9. apply skill `ai-skills-tooling-git-write` so known release messages use
-   non-interactive git write commands
-10. create the release-preparation commit with `git commit -m "..."` for a
-   single-line message or `git commit -F <temp-file>` for a multi-line message
-11. create the annotated tag on that commit with
+10. update every relevant versioned example or documentation reference to the
+    new tag
+11. re-check the remote default-branch head immediately before tagging; if it
+    moved, stop and recompute the intended scope and version before creating
+    the release-preparation commit or tag
+12. apply skill `ai-skills-tooling-git-write` so known release messages use
+    non-interactive git write commands
+13. create the release-preparation commit with `git commit -m "..."` for a
+    single-line message or `git commit -F <temp-file>` for a multi-line message
+14. create the annotated tag on that commit with
     `git tag -a <tag> -m "..."` for a single-line tag message or
     `git tag -a <tag> -F <temp-file>` for a multi-line tag message
-12. push branch and tag
-13. create the GitHub Release draft from the pushed tag
-14. if the broader release workflow has additional required public targets,
+15. push branch and tag
+16. create the GitHub Release draft from the pushed tag
+17. if the broader release workflow has additional required public targets,
     publish those targets next; if any public artifact becomes public and a
     later required public target fails, burn the version, keep the tag as the
     historical source pointer, and retain the draft or an explicitly labeled
     historical partial-release record
-15. after all required public targets succeed, publish or promote the GitHub
+18. after all required public targets succeed, publish or promote the GitHub
     Release from draft to final; if GitHub is the only required public target,
     repository policy may allow immediate publication after draft creation
-16. verify the tag exists and that the GitHub Release page points at the same
+19. verify the tag exists and that the GitHub Release page points at the same
     commit and is in the intended draft or published state
 
 When repository policy defines a release-note heading or formatting template,

--- a/skills/ai-skills-release-recovery/SKILL.md
+++ b/skills/ai-skills-release-recovery/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: ai-skills-release-recovery
+description: >-
+  Classify and stabilize an already-failed or already-partial release so the
+  real public state, tag history, and next recovery action are explicit before
+  any retry or follow-up release work begins.
+---
+<!-- markdownlint-disable MD025 -->
+
+# Purpose
+
+Audit an already-failed or already-partial release so the actual public state
+is known, the historical tag and GitHub Release state stay accurate, and the
+next recovery action is chosen explicitly instead of guessed mid-retry.
+
+# When to Use
+
+- use when a release attempt already created a tag, a GitHub Release record,
+  or publication activity and the outcome is failed, blocked, ambiguous, or
+  partial
+- use when deciding whether the same version may be recovered safely or must be
+  treated as burned because a required public target already exposed artifacts
+- use when a release tag or GitHub Release record may need preservation as a
+  historical source pointer before any follow-up work continues
+- use `references/recovery-state.md` for the compact state-to-action map
+- use `examples/same-version-recovery.md` and
+  `examples/burned-version-follow-up.md` when a concrete outcome shape helps
+
+# Inputs
+
+- the intended or attempted release version and tag
+- the repository default branch, the attempted release source commit, and any
+  evidence that the release source may already have moved
+- the current tag state, GitHub Release state, and publication status for each
+  repository-relevant target
+- repository-specific release policy, especially around same-version retry,
+  historical release records, and target applicability
+- evidence for whether any artifact for the attempted version became public
+- the likely failure point or remaining blocker when known
+- `references/recovery-state.md`
+
+# Workflow
+
+1. Confirm this is a recovery case by checking whether the attempted version or
+   tag already has a tag, a GitHub Release record, target-publication activity,
+   or another concrete failed-release artifact. If none exist, stop and use the
+   normal release workflow instead.
+2. Inspect the real release state for the attempted version across every
+   repository-relevant target and record the current facts: tag presence and
+   target commit, GitHub Release presence and state, per-target publication
+   result, and whether any artifact is already public.
+3. Verify whether the existing tag already points at the true published source
+   commit. If it does, preserve it. If it was incorrectly moved away earlier,
+   allow only a one-time correction that restores it to that true historical
+   source pointer.
+4. Classify the recovery state using `references/recovery-state.md`: no-public
+   same-version recovery candidate, partial public release with a burned
+   version, or metadata-only repair on an otherwise complete public release.
+5. For a no-public same-version recovery candidate, record the blocker to fix,
+   preserve any existing draft or release metadata that still reflects reality,
+   and define the next action as resuming the normal release workflow only
+   after the blocker is fixed and the no-public state is reverified.
+6. For a burned-version case, preserve the historical tag and GitHub Release
+   record as they actually occurred, record the partially published targets,
+   and define the next action as a fresh follow-up release under a new version
+   after the root cause is fixed.
+7. For a metadata-only repair case, keep the already-published version and
+   release source intact, define the smallest in-place metadata repair allowed
+   by repository policy, and do not invent a new release version solely for
+   notes or GitHub Release state.
+8. Return a concrete next-action outcome that names the verified state, the
+   recovery classification, what must remain historically true, and what the
+   next normal release or repair workflow must do next.
+
+# Outputs
+
+- a verified recovery-state summary for the attempted version and tag
+- an explicit classification: same-version recovery candidate, burned-version
+  follow-up, or metadata-only repair
+- the preserved historical tag and GitHub Release expectations for that case
+- a concrete next-action handoff describing the required repair or follow-up
+  release path
+
+# Guardrails
+
+- do not treat an already-failed or already-partial release as a fresh normal
+  release attempt
+- do not move a failed release tag away from the true published source commit,
+  except for a one-time correction that restores an already-moved tag to that
+  true historical source pointer
+- do not declare a version burned before confirming that at least one artifact
+  for that version became public in a required public target
+- do not retry a burned public version under the same version number
+- do not discard an existing GitHub Release draft or historical partial-release
+  record when it is the truthful record of what happened
+- do not broaden this skill into the full normal release workflow after the
+  recovery classification is known
+
+# Exit Checks
+
+- the attempted version, tag, and release source are explicit
+- the per-target public state is explicit
+- the recovery classification is explicit and evidence-based
+- the historical tag and GitHub Release preservation rules are explicit
+- the next action is concrete enough for a later normal release or metadata
+  repair workflow to continue without guessing

--- a/skills/ai-skills-release-recovery/examples/burned-version-follow-up.md
+++ b/skills/ai-skills-release-recovery/examples/burned-version-follow-up.md
@@ -1,0 +1,13 @@
+# Example Burned-Version Follow-Up
+
+- attempted version: `1.8.3`
+- tag `v1.8.3`: exists and points at the true published source commit
+- GitHub Release: draft exists and reflects the partial publication
+- Maven Central: published successfully
+- Gradle Plugin Portal: failed after Maven Central was already public
+- any public artifact visible: yes
+- classification: burned-version follow-up
+- preserved history: keep `v1.8.3` and the GitHub Release draft or historical
+  partial-release record as the truthful record of the partial public release
+- next action: fix the failure cause and cut a new version, such as `1.8.4`,
+  through the normal release workflow

--- a/skills/ai-skills-release-recovery/examples/same-version-recovery.md
+++ b/skills/ai-skills-release-recovery/examples/same-version-recovery.md
@@ -1,0 +1,13 @@
+# Example Same-Version Recovery
+
+- attempted version: `1.8.2`
+- tag `v1.8.2`: exists and points at the intended release commit
+- GitHub Release: draft exists
+- Maven Central: failed before publication
+- Gradle Plugin Portal: not attempted
+- any public artifact visible: no
+- classification: same-version recovery candidate
+- preserved history: keep the tag and draft aligned with the intended release
+  source; no burned-version record is needed
+- next action: fix the publication blocker, re-check that no public target has
+  exposed `1.8.2`, then resume the normal release workflow for `1.8.2`

--- a/skills/ai-skills-release-recovery/references/recovery-state.md
+++ b/skills/ai-skills-release-recovery/references/recovery-state.md
@@ -1,0 +1,19 @@
+# Recovery State Map
+
+Use this skill only after a release attempt already left concrete state behind.
+
+- no tag, no GitHub Release, and no publication activity: not a recovery case;
+  use the normal release workflow instead
+- tag or GitHub Release exists, but no artifact for the attempted version
+  became public in any required public target: same-version recovery candidate
+  after fixing the blocker and re-verifying the no-public state
+- at least one artifact for the attempted version became public in a required
+  public target, and a later required public target failed: burned version;
+  keep the historical tag and release record, then roll forward with a new
+  version after the cause is fixed
+- all required public targets succeeded, but GitHub Release metadata or notes
+  are inconsistent with reality: metadata-only repair; keep the published
+  version and fix the release metadata in place per repository policy
+- existing tag does not point at the true published source commit because it
+  was moved later: restore it only to that true historical source pointer, then
+  continue with the appropriate recovery class above

--- a/skills/ai-skills-release/SKILL.md
+++ b/skills/ai-skills-release/SKILL.md
@@ -28,6 +28,9 @@ not as rules to copy into downstream projects.
 - use when a public release must ship a narrowly scoped dependency,
   framework, or build-tool change without also shipping unrelated unreleased
   default-branch work
+- use skill `ai-skills-release-recovery` when the intended version or tag
+  already has failed-release or partial-release state and the normal release
+  flow must stop for explicit recovery classification
 - use when skill `ai-skills-release-github` is necessary but not sufficient on its own
 - use skill `ai-skills-pr-review-loop` when the release creates, recreates, or
   depends on release-bound PRs before tagging or publication can continue
@@ -54,6 +57,8 @@ not as rules to copy into downstream projects.
 - the repository default branch, the latest released tag, and the exact scoped
   release change when a public release may need isolation from unrelated
   unreleased work
+- the remote default-branch head at release start, or the ability to verify it
+  before version selection and again immediately before tagging
 - any release-bound PRs that must be created, recreated, or advanced through
   review before tagging or publication can continue
 - repository-specific release policy, versioning rules, and publication rules
@@ -65,6 +70,7 @@ not as rules to copy into downstream projects.
   updated
 - the artifact publication targets actually used by the repository
 - skill `ai-skills-pr-review-loop`
+- skill `ai-skills-release-recovery`
 - skill `ai-skills-release-github`
 - `references/release-preconditions.md`
 - `references/isolated-public-release.md`
@@ -72,64 +78,72 @@ not as rules to copy into downstream projects.
 
 # Workflow
 
-1. Confirm the default branch is current, the release scope is identified, and
-   the repository is in releasable state.
+1. Verify the remote default-branch head before version selection, confirm the
+   local release source is not stale relative to that remote head, record the
+   checked head, and stop until the source is refreshed or clarified if the
+   remote or local state is ambiguous.
 2. Run or confirm the final build and test pass for the release candidate; do
    not continue if the final verification is red or missing.
 3. Apply the repository-specific release policy as an input, without copying
    policy text into downstream projects.
-4. If dependency, framework, or build-tool choices in the release scope are
+4. If the intended version or tag already has a failed-release, partial-release,
+   or other recovery-state artifact, such as an existing tag, GitHub Release,
+   or target-publication evidence from a prior attempt, stop the normal flow
+   and apply skill `ai-skills-release-recovery` before any retry or follow-up
+   publication decision.
+5. If dependency, framework, or build-tool choices in the release scope are
    still open, apply skill `ai-skills-version-dependency-selection` before
    finalizing the release candidate.
-5. If support-policy decisions in the release scope are still open, apply
+6. If support-policy decisions in the release scope are still open, apply
    skill `ai-skills-version-support-policy` before finalizing the release
    candidate.
-6. Detect the applicable publication targets from
+7. Detect the applicable publication targets from
    `references/publication-targets.md`. If a public registry release would ship
    unrelated unreleased default-branch work, switch to the isolated-release
    path in `references/isolated-public-release.md` and create the release
    source from the latest released tag.
-7. On the isolated-release path, recreate or cherry-pick only the scoped
+8. On the isolated-release path, recreate or cherry-pick only the scoped
    release change onto the isolated branch; stop if unrelated unreleased work
    is still present and do not proceed until the isolated branch contains only
    the scoped release change.
-8. If the chosen release path creates, recreates, or depends on release-bound
+9. If the chosen release path creates, recreates, or depends on release-bound
    PRs before publication can continue, apply skill `ai-skills-pr-review-loop`
    to those PRs and do not proceed until each PR either completed a clean
    review loop and merged or was explicitly removed from the release scope.
-9. Confirm versioned release examples and documentation references are known so
+10. Confirm versioned release examples and documentation references are known so
    the release can update them to the new tag.
-10. Apply skill `ai-skills-release-github` to perform the GitHub Release workflow,
+11. Apply skill `ai-skills-release-github` to perform the GitHub Release workflow,
     including version selection, changelog/docs alignment, release-prep
-    commit, versioned-example updates, tag creation, push, and GitHub Release
-    draft creation. Stop this step at draft creation. Use step 13 to publish or
-    promote that draft after all required public targets succeed; when GitHub is
-    the only required public target, step 13 may follow immediately after this
-    step. Use the default branch by default or the isolated release branch when
-    the isolated path was required.
-11. Publish release artifacts only after the tag is created and pushed and the
+    commit, versioned-example updates, a second remote default-branch head
+    verification immediately before tagging, tag creation, push, and GitHub
+    Release draft creation. Stop this step at draft creation. Use step 14 to
+    publish or promote that draft after all required public targets succeed;
+    when GitHub is the only required public target, step 14 may follow
+    immediately after this step. Use the default branch by default or the
+    isolated release branch when the isolated path was required.
+12. Publish release artifacts only after the tag is created and pushed and the
     GitHub Release draft is created. Publish to each applicable target registry
     listed in `references/publication-targets.md`, such as Maven Central, the
     Gradle Plugin Portal, or a private artifactory, and record any target that
     is intentionally not applicable.
-12. If publication fails before any public artifact becomes public, stop and
-    defer same-version recovery to repository policy instead of automatically
-    treating the version as burned. If any public artifact becomes public and
-    a later required public target fails, treat the version as burned, keep
-    the tag as the historical source pointer, and retain GitHub Release notes
-    through the draft or an explicitly labeled historical partial-release
-    record.
-13. After all required public targets succeed, publish or promote the GitHub
+13. If publication leaves the release incomplete, stop the normal flow with an
+    explicit recovery decision point. When no public artifact became public,
+    record that same-version recovery remains possible only after recovery
+    classification. When any public artifact became public and a later required
+    public target failed, record that the version is burned and the historical
+    tag and GitHub Release state must be preserved for a later new-version
+    follow-up.
+14. After all required public targets succeed, publish or promote the GitHub
     Release from draft to final, following repository policy for any non-public
     targets that remain out of scope.
-14. Verify the published artifacts and release metadata so version numbers,
+15. Verify the published artifacts and release metadata so version numbers,
     tags, changelog entries, published packages, and GitHub Release state all
     match. Record the released version, tag, chosen release source, each
     target result, and whether the outcome was complete or partial.
-15. If an isolated release branch was used, merge back the same scoped release
+16. If an isolated release branch was used, merge back the same scoped release
     change cleanly to the default branch or confirm the default branch already
     contains an equivalent change set.
-16. Use `examples/release-checklist.md` when communicating the completed
+17. Use `examples/release-checklist.md` when communicating the completed
     release steps or any blocked publication target.
 
 # Outputs
@@ -139,6 +153,8 @@ not as rules to copy into downstream projects.
   status
 - explicit release-bound PR review-loop status when pre-publish PRs were part
   of the release
+- recorded remote default-branch freshness evidence for the chosen release
+  source
 - aligned documentation, changelog, GitHub Release state, and publication
   artifacts
 - explicit publication status for each relevant release target
@@ -150,6 +166,12 @@ not as rules to copy into downstream projects.
 - do not skip the final build or test verification before release
 - do not copy repository-specific release rules into downstream projects; use
   local release policy as input
+- do not trust a local default branch or release source without checking the
+  remote default-branch head before version selection and again immediately
+  before tagging
+- do not continue a normal release attempt when the same intended version or
+  tag already has failed-release or partial-release state; classify recovery
+  first with skill `ai-skills-release-recovery`
 - do not release unrelated unreleased default-branch work to a public registry
 - do not create an isolated public-release branch from the default-branch tip;
   create it from the latest released tag
@@ -184,8 +206,14 @@ not as rules to copy into downstream projects.
 
 - final build and test evidence are green and explicit
 - the selected version matches the documented delta from the previous release
+- the remote default-branch head was recorded before version selection and was
+  rechecked immediately before tagging; if it moved, the release scope and
+  version were recomputed or the release stopped
 - the chosen release source is explicit, and any isolated public-release path
   started from the latest released tag
+- any already-failed or already-partial release state for the intended version
+  or tag was handed to skill `ai-skills-release-recovery` instead of being
+  retried implicitly
 - any release-bound PRs required before publication were advanced through skill `ai-skills-pr-review-loop`
   and either merged cleanly or explicitly removed from the release scope
 - skill `ai-skills-release-github` was applied for the GitHub Release portion

--- a/skills/ai-skills-release/examples/release-checklist.md
+++ b/skills/ai-skills-release/examples/release-checklist.md
@@ -7,8 +7,11 @@
 - delta to previous release: reviewed
 - semantic version: `1.8.0`
 - release tag: `v1.8.0`
+- remote default-branch head before version selection: `abc1234`
+- remote default-branch head before tagging: unchanged at `abc1234`
 - release source: isolated branch from `v1.7.3`
 - release-bound PR review loop: not needed
+- recovery handoff: not needed
 - docs/examples updated: yes
 - changelog updated: yes
 - GitHub Release draft: created after tag push
@@ -29,8 +32,11 @@ targets.
 - delta to previous release: reviewed
 - semantic version: `1.8.1`
 - release tag: `v1.8.1`
+- remote default-branch head before version selection: `def5678`
+- remote default-branch head before tagging: unchanged at `def5678`
 - release source: default branch
 - release-bound PR review loop: not needed
+- recovery handoff after failure: skill `ai-skills-release-recovery`
 - docs/examples updated: yes
 - changelog updated: yes
 - GitHub Release draft: created after tag push

--- a/skills/ai-skills-release/references/isolated-public-release.md
+++ b/skills/ai-skills-release/references/isolated-public-release.md
@@ -6,16 +6,18 @@ otherwise ship unrelated unreleased default-branch work.
 Sequence:
 
 1. identify the exact scoped release change that must ship now
-2. start the isolated release branch from the latest released tag, not from the
+2. verify the remote default-branch head and stop until the local release
+   source is reconciled if the default branch is stale or ambiguous
+3. start the isolated release branch from the latest released tag, not from the
    current default-branch tip
-3. recreate or cherry-pick only the scoped release change onto that branch
-4. stop if unrelated unreleased work is still present
-5. run the normal release workflow on the isolated branch, including any
+4. recreate or cherry-pick only the scoped release change onto that branch
+5. stop if unrelated unreleased work is still present
+6. run the normal release workflow on the isolated branch, including any
    required release-bound PR review loop and skill `ai-skills-release-github`
-6. publish only to the repository-relevant targets
-7. verify the released version, tag, release notes, and target artifacts all
+7. publish only to the repository-relevant targets
+8. verify the released version, tag, release notes, and target artifacts all
    match
-8. merge back the same scoped release change cleanly to the default branch or
+9. merge back the same scoped release change cleanly to the default branch or
    confirm the default branch already contains an equivalent change set
 
 This path is primarily for intentionally scoped public releases such as a

--- a/skills/ai-skills-release/references/publication-targets.md
+++ b/skills/ai-skills-release/references/publication-targets.md
@@ -12,6 +12,9 @@ Overall sequence around the per-target loop:
    before publishing any target
 2. after all required public targets succeed, publish or promote the GitHub
    Release from draft to final
+3. if the same version or tag already has failed-release or partial-release
+   state from an earlier attempt, stop this normal target loop and classify the
+   recovery path with skill `ai-skills-release-recovery` first
 
 For each target:
 
@@ -30,8 +33,9 @@ For each target:
    purposes if later required public targets fail, and keep the tag as the
    historical source pointer
 6. if publication fails before any artifact for that release version becomes
-   public in any target, defer same-version recovery to repository policy
-   instead of automatically treating the version as burned
+   public in any target, stop with an explicit same-version recovery decision
+   point and defer the exact retry path to repository policy instead of
+   automatically treating the version as burned
 7. record `not applicable` when the repository does not use that target
 
 Do not treat optional targets as mandatory, but do not silently skip required

--- a/skills/ai-skills-release/references/release-preconditions.md
+++ b/skills/ai-skills-release/references/release-preconditions.md
@@ -2,10 +2,14 @@
 
 Before running the release:
 
-- default branch is current
+- remote default-branch head is checked before version selection and the local
+  release source is confirmed current relative to that remote head
 - release-bound PRs are already merged, or any release-bound PRs that still
   must land before publication are explicitly identified for the shared PR
   review loop
+- the intended version or tag does not already have failed-release,
+  partial-release, or ambiguous publication state; otherwise stop and classify
+  recovery first with skill `ai-skills-release-recovery`
 - repository-specific release policy is identified and treated as local input
 - final build is green
 - final test run is green
@@ -16,6 +20,9 @@ Before running the release:
   may be required
 - changelog, versioned documentation, and versioned example locations are
   identified
+- the workflow is prepared to re-check the remote default-branch head
+  immediately before tagging and to stop for scope/version recomputation if it
+  moved
 - if preflight CI evidence is being used, it is clear whether that preflight
   mirrors the tag-triggered release-only checks; otherwise treat preflight as
   release-plumbing evidence rather than full publication-parity evidence

--- a/skills/ai-skills-skill-improve/SKILL.md
+++ b/skills/ai-skills-skill-improve/SKILL.md
@@ -20,6 +20,9 @@ during unrelated daily work.
   reusable improvement to an existing skill
 - use when the target skill belongs to the public `ai-skills` catalog and the
   improvement should be proposed centrally for everyone
+- use when the gap was discovered while reading an installed local
+  `ai-skills-*` copy but the improvement still belongs in the upstream public
+  `ai-skills` catalog
 - use local-only capture when the improvement belongs to a downstream-project
   extension, private policy, or repo-specific skill rather than the central
   catalog
@@ -50,7 +53,9 @@ during unrelated daily work.
 - the rough improvement proposal or expected change in behavior
 - related skills, dependencies, or adjacent skill families
 - source context or notes from the originating task, including where the entry
-  should feed the later catalog update lifecycle when known
+  should feed the later catalog update lifecycle when known, and whether the
+  observation came from the upstream source repository or an installed local
+  skill copy
 - `references/improvement-triage.md` and
   `references/backlog-target-selection.md`
 
@@ -63,23 +68,27 @@ during unrelated daily work.
    examples, or references.
 3. Use `references/improvement-triage.md` to decide whether the proposal should
    be captured centrally or kept as a downstream-project/local extension.
-4. Normalize the improvement with skill `ai-skills-skill-template`, using
+4. If the observation came from an installed local `ai-skills-*` directory,
+   treat that installed copy as evidence only and keep the canonical
+   improvement target upstream in the public `ai-skills` backlog instead of
+   treating the installed bundle as the implementation target.
+5. Normalize the improvement with skill `ai-skills-skill-template`, using
    `change-type: improve` and recording the target skill, motivation,
    reusability rationale,
    trigger conditions, rough improvement shape, related skills, source
    context, and status.
-5. Choose the storage target with
+6. Choose the storage target with
    `references/backlog-target-selection.md`: GitHub issue when the improvement
    belongs in the public `ai-skills` backlog and access exists, otherwise local
    Markdown.
-6. In source context or notes, include how the entry should feed the catalog
+7. In source context or notes, include how the entry should feed the catalog
    update lifecycle, such as later triage, implementation PR,
    changelog/release-note entry, or explicit deferral.
-7. Render the canonical improvement entry for the chosen target without
+8. Render the canonical improvement entry for the chosen target without
    changing the underlying semantics.
-8. Hand GitHub-bound Markdown to skill `ai-skills-formatting-github-comment` when the rendered
+9. Hand GitHub-bound Markdown to skill `ai-skills-formatting-github-comment` when the rendered
    issue body still needs final normalization.
-9. Stop after the improvement proposal is captured and return any current
+10. Stop after the improvement proposal is captured and return any current
    implementation work to the normal agent workflow outside this skill.
 
 # Outputs
@@ -96,6 +105,8 @@ during unrelated daily work.
   exist; use skill `ai-skills-skill-new` instead
 - do not make GitHub the only supported storage target
 - do not let central backlog capture block the current task
+- do not treat an installed local `ai-skills-*` copy as the implementation
+  target for a public catalog improvement
 - do not silently change the canonical field set between renderings
 
 # Exit Checks
@@ -103,6 +114,8 @@ during unrelated daily work.
 - the proposal targets an existing skill and uses `change-type: improve`
 - the record explains whether the improvement belongs centrally in `ai-skills`
   or only in a downstream/local extension
+- when the observation came from an installed local copy, the record still
+  points the maintenance target upstream instead of at that installed bundle
 - the update-lifecycle handoff is explicit enough for later triage
 - the chosen storage target matches access and publication constraints
 - the rendered record stays aligned with the canonical template

--- a/skills/ai-skills-skill-improve/examples/local-skill-improvement-entry.md
+++ b/skills/ai-skills-skill-improve/examples/local-skill-improvement-entry.md
@@ -13,7 +13,8 @@ Rough workflow or responsibilities: add a child skill that classifies the
 finding, drafts the response, and leaves merge or loop orchestration to later
 skills
 Related skills or dependencies: skill `ai-skills-pr-review`, skill `ai-skills-pr-review-write`, skill `ai-skills-pr-review-loop`
-Source context or notes: captured while handling review findings on a company
-laptop without permission to create a central GitHub issue; transfer upstream to
-`ai-skills` issue triage when central GitHub access is available
+Source context or notes: observed while inspecting an installed local
+`ai-skills-*` copy on a company laptop without permission to create a central
+GitHub issue; the installed bundle is not the implementation target; transfer
+upstream to `ai-skills` issue triage when central GitHub access is available
 Status: idea

--- a/skills/ai-skills-skill-improve/references/backlog-target-selection.md
+++ b/skills/ai-skills-skill-improve/references/backlog-target-selection.md
@@ -7,12 +7,18 @@ Use a GitHub issue in `ai-skills` when:
 - the target skill is part of the public `ai-skills` catalog
 - the improvement should benefit the shared catalog
 - the acting environment has permission to create the issue
+- the improvement was observed from an installed local `ai-skills-*` copy but
+  still belongs upstream in the canonical catalog
 
 Use a local Markdown record when:
 
 - GitHub access is unavailable
 - the current environment cannot reach the central GitHub repository
 - the improvement should still be preserved for later transfer upstream
+
+When local Markdown is used only because central GitHub access is unavailable,
+record the improvement locally, note that the upstream `ai-skills` backlog is
+still the canonical destination, and transfer the entry upstream later.
 
 Do not block the current task if central issue creation is unavailable. Record
 the improvement locally and continue with normal work.

--- a/skills/ai-skills-skill-new/SKILL.md
+++ b/skills/ai-skills-skill-new/SKILL.md
@@ -21,6 +21,9 @@ important context.
 - use when the candidate appears useful beyond the current repository or task
 - use when the idea should be recorded centrally in `ai-skills` instead of only
   in local notes
+- use when the reusable idea was discovered while inspecting an installed local
+  `ai-skills-*` copy but still belongs in the upstream public `ai-skills`
+  backlog
 - use when GitHub access is unavailable and the same canonical backlog entry
   must be preserved as local Markdown instead
 - use `references/public-skill-triage.md` to decide whether the candidate is
@@ -46,7 +49,8 @@ important context.
 - related skills, dependencies, or adjacent existing skills
 - source context or notes from the originating task, limited to observations
   rather than design decisions or implementation plans; include related lessons
-  learned here when known and relevant
+  learned here when known and relevant, and whether the idea was observed in
+  the upstream source repository or an installed local skill copy
 - `references/public-skill-triage.md` and
   `references/backlog-target-selection.md`
 
@@ -56,20 +60,24 @@ important context.
    convention or implementation detail.
 2. Decide whether the candidate belongs in the public `ai-skills` backlog by
    using `references/public-skill-triage.md`.
-3. Normalize the idea with skill `ai-skills-skill-template`, including title, change type,
+3. If the idea was discovered from an installed local `ai-skills-*` directory,
+   treat that installed copy as evidence only and keep the canonical backlog
+   target upstream in the public `ai-skills` catalog rather than treating the
+   installed bundle as the implementation target.
+4. Normalize the idea with skill `ai-skills-skill-template`, including title, change type,
    proposed skill id or name, motivation, reusability rationale, when to use,
    rough workflow, related skills, source context, and status.
-4. Choose the storage target with
+5. Choose the storage target with
    `references/backlog-target-selection.md`: GitHub issue when central
    publication is appropriate and access exists, otherwise local Markdown.
-5. Render the canonical backlog entry for the chosen target without changing
+6. Render the canonical backlog entry for the chosen target without changing
    the underlying semantics.
-6. Use `targets/github-issue.md` and `targets/local-backlog-entry.md` as
+7. Use `targets/github-issue.md` and `targets/local-backlog-entry.md` as
    target-specific renderings of the canonical record when a concrete artifact
    shape helps.
-7. Hand GitHub-bound Markdown to skill `ai-skills-formatting-github-comment` when the rendered
+8. Hand GitHub-bound Markdown to skill `ai-skills-formatting-github-comment` when the rendered
    issue body still needs final normalization.
-8. Stop after the canonical backlog entry is recorded or rendered.
+9. Stop after the canonical backlog entry is recorded or rendered.
 
 # Outputs
 
@@ -84,6 +92,8 @@ important context.
   plans, or claims that the proposed skill was implemented
 - do not create a central backlog item for a purely local, repo-specific need
 - do not make GitHub the only supported storage target
+- do not treat an installed local `ai-skills-*` copy as the implementation
+  target for a new public catalog skill
 - do not silently change the canonical field set between renderings
 - do not fail the workflow just because GitHub issue creation is unavailable
 
@@ -92,6 +102,8 @@ important context.
 - the candidate is captured with the full canonical backlog-entry field set
 - source context or notes are observational and do not contain implementation
   claims
+- when the idea came from an installed local copy, the record still points the
+  maintenance target upstream instead of at that installed bundle
 - the chosen storage target matches access and publication constraints
 - the rendered record stays aligned with the canonical template
 - the workflow stops after capture rather than drifting into implementation

--- a/skills/ai-skills-skill-new/references/backlog-target-selection.md
+++ b/skills/ai-skills-skill-new/references/backlog-target-selection.md
@@ -7,6 +7,8 @@ Use a GitHub issue in `ai-skills` when:
 - the candidate is public and centrally reusable
 - the acting environment has permission to create the issue
 - the central backlog is the right place for later implementation tracking
+- the idea was observed from an installed local `ai-skills-*` copy but still
+  belongs in the upstream canonical catalog
 
 Use a local Markdown record when:
 
@@ -15,5 +17,6 @@ Use a local Markdown record when:
 - the idea still deserves capture for later transfer into `ai-skills`
 
 If GitHub issue creation is unavailable, record the local Markdown entry and
-continue normal work. Do not block the primary task just because backlog
-publication is deferred.
+continue normal work. Make the local entry explicit that upstream `ai-skills`
+issue triage is still the canonical destination, then transfer it later. Do
+not block the primary task just because backlog publication is deferred.

--- a/skills/ai-skills-skill-new/targets/local-backlog-entry.md
+++ b/skills/ai-skills-skill-new/targets/local-backlog-entry.md
@@ -11,7 +11,9 @@ When to use / trigger: when a change adds or updates third-party dependencies
 Rough workflow or responsibilities: inspect dependency deltas, identify policy
 or license concerns, and produce review findings or a clean pass result
 Related skills or dependencies: skill `ai-skills-security-secrets`, skill `ai-skills-quality-sonar`
-Source context or notes: captured during a repository review on a locked-down
-company laptop without GitHub issue permissions; related lessons learned: none
-known
+Source context or notes: captured while inspecting an installed local
+`ai-skills-*` catalog copy during a repository review on a locked-down company
+laptop without GitHub issue permissions; the installed bundle is not the
+implementation target; transfer upstream to `ai-skills` issue triage when
+access returns; related lessons learned: none known
 Status: idea


### PR DESCRIPTION
## Summary
- add `ai-skills-release-recovery` for failed or partial release classification and handoff
- tighten the release family around remote default-branch freshness checks and explicit recovery decision points
- tighten PR review-loop suppressed-finding handling and capture-skill upstream-target guidance

## Validation
- corepack pnpm lint:md
- corepack pnpm validate
- corepack pnpm build
- corepack pnpm test
- corepack pnpm quality:cognitive
- corepack pnpm quality:crap
- corepack pnpm pack:dry-run

Closes #234