### PR TITLE
Update dependency workflow pins

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -109,7 +109,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd
+      - uses: DavidAnson/markdownlint-cli2-action@fa0cd0f1a052f54da593c83860f2292982f5d142
         with:
           globs: |
             **/*.md


### PR DESCRIPTION
## Summary
- Refreshes the markdownlint workflow action pin.

## Version decisions
- Preserves `node >=22.12.0`.
- Skips pnpm 11.5.0 and internal TypeScript tool updates that require `node >=22.13.0`.

## Validation
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm build`
- `corepack pnpm test`
- `corepack pnpm validate`
- `corepack pnpm quality:crap`
- `corepack pnpm quality:cognitive`
- `corepack pnpm pack:dry-run`

Closes #237