### PR TITLE
Add cached CRAP CLI helper

### DIFF
--- a/skills/ai-skills-quality-crap/SKILL.md
+++ b/skills/ai-skills-quality-crap/SKILL.md
@@ -14,6 +14,8 @@ with excessive combined complexity and weak coverage are rejected before merge.
 - use when the repository or delivery flow exposes a CRAP metric or equivalent
   combined complexity-and-coverage score
 - use when reviewing or refactoring methods touched by the current change
+- use `scripts/run-crap-cli.mjs` and `references/cli-tooling.md` when no
+  stronger repository-owned CRAP gate is already available
 - use `references/crap-threshold.md` for the hard threshold, evidence order,
   and reduction levers
 - use `examples/crap-review-finding.md` when reporting a failing method in
@@ -24,28 +26,41 @@ with excessive combined complexity and weak coverage are rejected before merge.
 - the changed files, methods, or bounded diff under review
 - the strongest available CRAP evidence, such as CI output or a local
   `crap-java-check` report
+- access to the skill-owned CLI helper or a repository-owned equivalent gate
+- the applicable language, relevant paths, and desired threshold argument for
+  the bounded scope
 - available tests or coverage-improvement options for the bounded scope
+- `scripts/run-crap-cli.mjs`
+- `references/cli-tooling.md`
 - `references/crap-threshold.md`
 
 # Workflow
 
 1. Collect the strongest available CRAP evidence for the changed scope from CI,
-   local tooling, or an equivalent report.
-2. Treat every relevant method with CRAP score greater than `8` as a failing
+   repository-owned tooling, the skill-owned CLI helper, or an equivalent
+   report.
+2. When repository-owned tooling is unavailable, run `scripts/run-crap-cli.mjs`
+   for the relevant language with `--agent`, the desired `--threshold`, and
+   only the files or directories in the bounded scope.
+3. Let the helper resolve and cache the latest language-specific CRAP CLI, using
+   the cached tool when the weekly metadata refresh is unavailable.
+4. Treat every relevant method with CRAP score greater than `8` as a failing
    result.
-3. If the score is unavailable for the relevant scope, surface missing evidence
+5. If the score is unavailable for the relevant scope, surface missing evidence
    instead of inventing an exact CRAP value.
-4. Reduce failing scores by simplifying control flow, extracting cohesive
+6. Reduce failing scores by simplifying control flow, extracting cohesive
    methods, or adding focused tests that cover the risky branches.
-5. Re-run the metric after changes and record the final worst score for the
+7. Re-run the metric after changes and record the final worst score for the
    bounded scope.
-6. Use `examples/crap-review-finding.md` when communicating the remaining
+8. Use `examples/crap-review-finding.md` when communicating the remaining
    finding or the final pass result.
 
 # Outputs
 
 - a pass or fail result for the bounded scope against the `<= 8` threshold
 - method-level findings with metric evidence when the threshold is violated
+- CLI command, version, cache status, and threshold used when the skill-owned
+  helper supplies the evidence
 - explicit note when evidence is missing and the gate cannot be confirmed
 
 # Guardrails
@@ -54,11 +69,15 @@ with excessive combined complexity and weak coverage are rejected before merge.
 - do not guess an exact CRAP number when tool evidence is unavailable
 - do not mask a high score with unrelated cleanup outside the bounded change
 - do not claim the gate passed unless the metric evidence supports that result
+- do not analyze the whole repository through the helper when changed paths are
+  available and sufficient for the bounded scope
 
 # Exit Checks
 
 - every relevant method is backed by CRAP evidence or an explicit missing
   evidence note
 - no relevant method exceeds CRAP score `8` without a failing result
+- helper-backed evidence uses `--agent`, the intended threshold, and scoped
+  paths, or documents why that was not possible
 - any refactor or test addition preserves behavior and stays bounded to the
   identified risk

--- a/skills/ai-skills-quality-crap/references/cli-tooling.md
+++ b/skills/ai-skills-quality-crap/references/cli-tooling.md
@@ -1,0 +1,34 @@
+# CRAP CLI Tooling
+
+Use the skill-owned helper when the target repository does not already provide
+a stronger CRAP gate.
+
+## Commands
+
+Run from the target repository root:
+
+```bash
+node path/to/skills/ai-skills-quality-crap/scripts/run-crap-cli.mjs typescript -- --agent --threshold 8 src
+node path/to/skills/ai-skills-quality-crap/scripts/run-crap-cli.mjs java -- --agent --threshold 8 src/main/java
+```
+
+The helper forwards all arguments after `--` to the downloaded CLI. Pass only
+the relevant files or directories when the bounded change is narrower than the
+full repository.
+
+## Tool Resolution
+
+- TypeScript resolves `@barney-media/crap-typescript` from npm.
+- Java resolves `media.barney:crap-java-cli` from Maven Central.
+- The helper stores tools under a user cache directory grouped by this skill id.
+- Set `AI_SKILLS_TOOL_CACHE_DIR` to override the base cache location.
+- Latest-version metadata is refreshed at most once every seven days.
+- If the refresh is unavailable and a cached tool exists, the helper warns and
+  uses that cached tool.
+
+## Evidence Expectations
+
+Record the language, CLI version, command arguments, cache status, threshold,
+and final worst relevant CRAP score. If the helper cannot resolve a tool and no
+repository-owned gate is available, treat the result as missing evidence rather
+than estimating a CRAP score.

--- a/skills/ai-skills-quality-crap/references/cli-tooling.md
+++ b/skills/ai-skills-quality-crap/references/cli-tooling.md
@@ -12,9 +12,10 @@ node path/to/skills/ai-skills-quality-crap/scripts/run-crap-cli.mjs typescript -
 node path/to/skills/ai-skills-quality-crap/scripts/run-crap-cli.mjs java -- --agent --threshold 8 src/main/java
 ```
 
-The helper forwards all arguments after `--` to the downloaded CLI. Pass only
-the relevant files or directories when the bounded change is narrower than the
-full repository.
+The helper forwards tool arguments after the language. Use `--` as an optional
+separator when the first tool argument also starts with a dash. Pass only the
+relevant files or directories when the bounded change is narrower than the full
+repository.
 
 ## Tool Resolution
 

--- a/skills/ai-skills-quality-crap/scripts/run-crap-cli.mjs
+++ b/skills/ai-skills-quality-crap/scripts/run-crap-cli.mjs
@@ -43,7 +43,7 @@ export function parseNpmLatestVersion(metadata) {
     throw new Error("npm metadata does not include dist-tags.latest");
   }
 
-  return latest;
+  return safeVersionPathSegment(latest, "npm metadata dist-tags.latest");
 }
 
 export function parseMavenLatestVersion(metadataXml) {
@@ -53,6 +53,18 @@ export function parseMavenLatestVersion(metadataXml) {
 
   if (version === undefined || version.length === 0) {
     throw new Error("Maven metadata does not include latest or release version");
+  }
+
+  return safeVersionPathSegment(version, "Maven metadata version");
+}
+
+export function safeVersionPathSegment(version, source) {
+  if (typeof version !== "string" || version.length === 0) {
+    throw new Error(`${source} is not a safe version path segment`);
+  }
+
+  if (!/^[A-Za-z0-9][A-Za-z0-9._+-]*$/u.test(version) || version.includes("..")) {
+    throw new Error(`${source} is not a safe version path segment`);
   }
 
   return version;
@@ -195,11 +207,68 @@ async function readState(statePath, deps) {
 }
 
 async function getCachedTool(language, languageRoot, state, deps) {
-  if (typeof state.version !== "string" || state.version.length === 0) {
+  const stateTool = await getCachedToolFromState(language, languageRoot, state, deps);
+
+  return stateTool ?? getCachedToolFromDisk(language, languageRoot, deps);
+}
+
+async function getCachedToolFromState(language, languageRoot, state, deps) {
+  if (typeof state.version !== "string") {
     return undefined;
   }
 
-  const executablePath = executablePathFor(language, languageRoot, state.version);
+  let version;
+
+  try {
+    version = safeVersionPathSegment(state.version, "cached CRAP CLI state version");
+  } catch (error) {
+    deps.warn(`Ignoring cached CRAP ${language} CLI state: ${toErrorMessage(error)}`);
+    return undefined;
+  }
+
+  return getCachedToolForVersion(language, languageRoot, version, deps);
+}
+
+async function getCachedToolFromDisk(language, languageRoot, deps) {
+  let entries;
+
+  try {
+    entries = await deps.readDir(languageRoot);
+  } catch {
+    return undefined;
+  }
+
+  const versions = entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => safeVersionCandidate(entry.name, `cached CRAP ${language} CLI directory`, deps))
+    .filter((version) => version !== undefined)
+    .sort((left, right) => right.localeCompare(left, undefined, {
+      numeric: true,
+      sensitivity: "base"
+    }));
+
+  for (const version of versions) {
+    const cachedTool = await getCachedToolForVersion(language, languageRoot, version, deps);
+
+    if (cachedTool !== undefined) {
+      return cachedTool;
+    }
+  }
+
+  return undefined;
+}
+
+function safeVersionCandidate(version, source, deps) {
+  try {
+    return safeVersionPathSegment(version, source);
+  } catch (error) {
+    deps.warn(`Ignoring unsafe ${source}: ${toErrorMessage(error)}`);
+    return undefined;
+  }
+}
+
+async function getCachedToolForVersion(language, languageRoot, version, deps) {
+  const executablePath = executablePathFor(language, languageRoot, version);
 
   if (!await deps.exists(executablePath)) {
     return undefined;
@@ -209,7 +278,7 @@ async function getCachedTool(language, languageRoot, state, deps) {
     executablePath,
     language,
     stale: false,
-    version: state.version
+    version
   };
 }
 
@@ -270,12 +339,14 @@ async function installTool(language, languageRoot, version, deps) {
 }
 
 function executablePathFor(language, languageRoot, version) {
+  const safeVersion = safeVersionPathSegment(version, "CRAP CLI version");
+
   if (language === "typescript") {
-    return path.join(languageRoot, version, ...TOOL_CONFIG.npmBinPath);
+    return path.join(languageRoot, safeVersion, ...TOOL_CONFIG.npmBinPath);
   }
 
   if (language === "java") {
-    return path.join(languageRoot, version, `${TOOL_CONFIG.mavenArtifact}-${version}.jar`);
+    return path.join(languageRoot, safeVersion, `${TOOL_CONFIG.mavenArtifact}-${safeVersion}.jar`);
   }
 
   throw new Error(`Unsupported language: ${language}`);

--- a/skills/ai-skills-quality-crap/scripts/run-crap-cli.mjs
+++ b/skills/ai-skills-quality-crap/scripts/run-crap-cli.mjs
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -22,7 +23,7 @@ export function parseCliRequest(argv) {
   if (!SUPPORTED_LANGUAGES.has(language)) {
     return {
       ok: false,
-      message: "Usage: node scripts/run-crap-cli.mjs <typescript|java> [--] <tool args...>"
+      message: "Usage: node <run-crap-cli.mjs> <typescript|java> [--] <tool args...>"
     };
   }
 
@@ -107,6 +108,7 @@ export function createDefaultDeps() {
     mkdir: async (directory) => fs.mkdir(directory, { recursive: true }),
     now: () => Date.now(),
     readDir: async (directory) => fs.readdir(directory, { withFileTypes: true }),
+    readFile: async (filePath) => fs.readFile(filePath),
     readJson: async (filePath) => JSON.parse(await fs.readFile(filePath, "utf8")),
     rm: async (target) => fs.rm(target, { force: true, recursive: true }),
     runProcess,
@@ -145,7 +147,7 @@ export async function resolveTool(language, deps = createDefaultDeps()) {
       checkedAt: new Date(deps.now()).toISOString(),
       version: latestVersion
     });
-    await removeOutdatedVersions(languageRoot, latestVersion, deps);
+    await removeOutdatedVersions(language, languageRoot, latestVersion, deps);
 
     return {
       executablePath,
@@ -244,6 +246,7 @@ async function installTool(language, languageRoot, version, deps) {
         "--no-save",
         "--no-audit",
         "--no-fund",
+        "--ignore-scripts",
         `${TOOL_CONFIG.npmPackage}@${version}`
       ],
       { shell: npmCommand.shell === true }
@@ -257,7 +260,7 @@ async function installTool(language, languageRoot, version, deps) {
   }
 
   if (language === "java") {
-    await deps.downloadFile(mavenJarUrl(version), executablePathFor(language, languageRoot, version));
+    await downloadVerifiedMavenJar(languageRoot, version, deps);
     return;
   }
 
@@ -276,7 +279,21 @@ function executablePathFor(language, languageRoot, version) {
   throw new Error(`Unsupported language: ${language}`);
 }
 
-async function removeOutdatedVersions(languageRoot, currentVersion, deps) {
+async function downloadVerifiedMavenJar(languageRoot, version, deps) {
+  const jarPath = executablePathFor("java", languageRoot, version);
+  const expectedChecksum = parseSha256Checksum(await deps.fetchText(mavenJarChecksumUrl(version)));
+
+  await deps.downloadFile(mavenJarUrl(version), jarPath);
+
+  const actualChecksum = sha256(await deps.readFile(jarPath));
+
+  if (actualChecksum !== expectedChecksum) {
+    await deps.rm(jarPath);
+    throw new Error(`Maven JAR checksum mismatch for ${TOOL_CONFIG.mavenArtifact} ${version}`);
+  }
+}
+
+async function removeOutdatedVersions(language, languageRoot, currentVersion, deps) {
   let entries;
 
   try {
@@ -287,7 +304,13 @@ async function removeOutdatedVersions(languageRoot, currentVersion, deps) {
 
   await Promise.all(entries
     .filter((entry) => entry.isDirectory() && entry.name !== currentVersion)
-    .map((entry) => deps.rm(path.join(languageRoot, entry.name))));
+    .map(async (entry) => {
+      try {
+        await deps.rm(path.join(languageRoot, entry.name));
+      } catch (error) {
+        deps.warn(`Could not remove outdated CRAP ${language} CLI ${entry.name}: ${toErrorMessage(error)}`);
+      }
+    }));
 }
 
 function mavenMetadataUrl() {
@@ -296,6 +319,24 @@ function mavenMetadataUrl() {
 
 function mavenJarUrl(version) {
   return `https://repo.maven.apache.org/maven2/${TOOL_CONFIG.mavenGroupPath}/${TOOL_CONFIG.mavenArtifact}/${version}/${TOOL_CONFIG.mavenArtifact}-${version}.jar`;
+}
+
+function mavenJarChecksumUrl(version) {
+  return `${mavenJarUrl(version)}.sha256`;
+}
+
+export function parseSha256Checksum(checksumText) {
+  const checksum = checksumText.trim().split(/\s+/u)[0]?.toLowerCase();
+
+  if (checksum === undefined || !/^[a-f0-9]{64}$/u.test(checksum)) {
+    throw new Error("Maven checksum response does not include a SHA-256 digest");
+  }
+
+  return checksum;
+}
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
 }
 
 export async function npmCommandSpec(deps = createDefaultDeps(), platform = process.platform) {

--- a/skills/ai-skills-quality-crap/scripts/run-crap-cli.mjs
+++ b/skills/ai-skills-quality-crap/scripts/run-crap-cli.mjs
@@ -141,8 +141,8 @@ export async function resolveTool(language, deps = createDefaultDeps()) {
   const state = await readState(statePath, deps);
   const cachedTool = await getCachedTool(language, languageRoot, state, deps);
 
-  if (cachedTool !== undefined && !shouldRefreshMetadata(state.checkedAt, deps.now())) {
-    return cachedTool;
+  if (cachedTool?.fromState === true && !shouldRefreshMetadata(state.checkedAt, deps.now())) {
+    return toolResult(cachedTool);
   }
 
   try {
@@ -173,7 +173,7 @@ export async function resolveTool(language, deps = createDefaultDeps()) {
     if (cachedTool !== undefined) {
       deps.warn(`Using cached CRAP ${language} CLI ${cachedTool.version}: ${toErrorMessage(error)}`);
       return {
-        ...cachedTool,
+        ...toolResult(cachedTool),
         stale: true
       };
     }
@@ -226,7 +226,7 @@ async function getCachedToolFromState(language, languageRoot, state, deps) {
     return undefined;
   }
 
-  return getCachedToolForVersion(language, languageRoot, version, deps);
+  return getCachedToolForVersion(language, languageRoot, version, deps, true);
 }
 
 async function getCachedToolFromDisk(language, languageRoot, deps) {
@@ -248,7 +248,7 @@ async function getCachedToolFromDisk(language, languageRoot, deps) {
     }));
 
   for (const version of versions) {
-    const cachedTool = await getCachedToolForVersion(language, languageRoot, version, deps);
+    const cachedTool = await getCachedToolForVersion(language, languageRoot, version, deps, false);
 
     if (cachedTool !== undefined) {
       return cachedTool;
@@ -267,7 +267,7 @@ function safeVersionCandidate(version, source, deps) {
   }
 }
 
-async function getCachedToolForVersion(language, languageRoot, version, deps) {
+async function getCachedToolForVersion(language, languageRoot, version, deps, fromState) {
   const executablePath = executablePathFor(language, languageRoot, version);
 
   if (!await deps.exists(executablePath)) {
@@ -276,9 +276,19 @@ async function getCachedToolForVersion(language, languageRoot, version, deps) {
 
   return {
     executablePath,
+    fromState,
     language,
     stale: false,
     version
+  };
+}
+
+function toolResult(tool) {
+  return {
+    executablePath: tool.executablePath,
+    language: tool.language,
+    stale: tool.stale,
+    version: tool.version
   };
 }
 
@@ -380,13 +390,17 @@ async function removeOutdatedVersions(language, languageRoot, currentVersion, de
     return;
   }
 
-  await Promise.all(entries
-    .filter((entry) => entry.isDirectory() && entry.name !== currentVersion)
-    .map(async (entry) => {
+  const outdatedVersions = entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => safeVersionCandidate(entry.name, `outdated CRAP ${language} CLI directory`, deps))
+    .filter((version) => version !== undefined && version !== currentVersion);
+
+  await Promise.all(outdatedVersions
+    .map(async (version) => {
       try {
-        await deps.rm(path.join(languageRoot, entry.name));
+        await deps.rm(path.join(languageRoot, version));
       } catch (error) {
-        deps.warn(`Could not remove outdated CRAP ${language} CLI ${entry.name}: ${toErrorMessage(error)}`);
+        deps.warn(`Could not remove outdated CRAP ${language} CLI ${version}: ${toErrorMessage(error)}`);
       }
     }));
 }

--- a/skills/ai-skills-quality-crap/scripts/run-crap-cli.mjs
+++ b/skills/ai-skills-quality-crap/scripts/run-crap-cli.mjs
@@ -1,0 +1,375 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+export const TOOL_CONFIG = {
+  skillId: "ai-skills-quality-crap",
+  npmPackage: "@barney-media/crap-typescript",
+  npmBinPath: ["node_modules", "@barney-media", "crap-typescript", "dist", "bin.js"],
+  mavenGroupPath: "media/barney",
+  mavenArtifact: "crap-java-cli"
+};
+
+export const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+const SUPPORTED_LANGUAGES = new Set(["typescript", "java"]);
+
+export function parseCliRequest(argv) {
+  const [language, separator, ...rest] = argv;
+
+  if (!SUPPORTED_LANGUAGES.has(language)) {
+    return {
+      ok: false,
+      message: "Usage: node scripts/run-crap-cli.mjs <typescript|java> -- <tool args...>"
+    };
+  }
+
+  return {
+    ok: true,
+    language,
+    toolArgs: separator === "--"
+      ? rest
+      : argv.slice(1)
+  };
+}
+
+export function parseNpmLatestVersion(metadata) {
+  const latest = metadata?.["dist-tags"]?.latest;
+
+  if (typeof latest !== "string" || latest.length === 0) {
+    throw new Error("npm metadata does not include dist-tags.latest");
+  }
+
+  return latest;
+}
+
+export function parseMavenLatestVersion(metadataXml) {
+  const latestMatch = /<latest>([^<]+)<\/latest>/u.exec(metadataXml);
+  const releaseMatch = /<release>([^<]+)<\/release>/u.exec(metadataXml);
+  const version = latestMatch?.[1] ?? releaseMatch?.[1];
+
+  if (version === undefined || version.length === 0) {
+    throw new Error("Maven metadata does not include latest or release version");
+  }
+
+  return version;
+}
+
+export function shouldRefreshMetadata(checkedAt, nowMs) {
+  if (typeof checkedAt !== "string" || checkedAt.length === 0) {
+    return true;
+  }
+
+  const checkedAtMs = Date.parse(checkedAt);
+
+  return Number.isNaN(checkedAtMs) || nowMs - checkedAtMs >= WEEK_MS;
+}
+
+export function buildToolCommand(language, executablePath, toolArgs) {
+  if (language === "typescript") {
+    return {
+      command: process.execPath,
+      args: [executablePath, ...toolArgs]
+    };
+  }
+
+  if (language === "java") {
+    return {
+      command: "java",
+      args: ["-jar", executablePath, ...toolArgs]
+    };
+  }
+
+  throw new Error(`Unsupported language: ${language}`);
+}
+
+export function getCacheRoot(env = process.env, platform = process.platform) {
+  if (env.AI_SKILLS_TOOL_CACHE_DIR !== undefined && env.AI_SKILLS_TOOL_CACHE_DIR.trim() !== "") {
+    return path.resolve(env.AI_SKILLS_TOOL_CACHE_DIR, TOOL_CONFIG.skillId);
+  }
+
+  const baseCacheDir = env.XDG_CACHE_HOME
+    ?? (platform === "win32" ? env.LOCALAPPDATA : undefined)
+    ?? path.join(os.homedir(), ".cache");
+
+  return path.join(baseCacheDir, "ai-skills", TOOL_CONFIG.skillId);
+}
+
+export function createDefaultDeps() {
+  return {
+    cacheRoot: getCacheRoot(),
+    downloadFile,
+    exists: pathExists,
+    fetchJson,
+    fetchText,
+    mkdir: async (directory) => fs.mkdir(directory, { recursive: true }),
+    now: () => Date.now(),
+    readDir: async (directory) => fs.readdir(directory, { withFileTypes: true }),
+    readJson: async (filePath) => JSON.parse(await fs.readFile(filePath, "utf8")),
+    rm: async (target) => fs.rm(target, { force: true, recursive: true }),
+    runProcess,
+    warn: (message) => console.error(message),
+    writeJson: async (filePath, value) => {
+      await fs.mkdir(path.dirname(filePath), { recursive: true });
+      await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`);
+    }
+  };
+}
+
+export async function resolveTool(language, deps = createDefaultDeps()) {
+  const cacheRoot = deps.cacheRoot ?? getCacheRoot();
+  const languageRoot = path.join(cacheRoot, language);
+  const statePath = path.join(languageRoot, "state.json");
+  const state = await readState(statePath, deps);
+  const cachedTool = await getCachedTool(language, languageRoot, state, deps);
+
+  if (cachedTool !== undefined && !shouldRefreshMetadata(state.checkedAt, deps.now())) {
+    return cachedTool;
+  }
+
+  try {
+    const latestVersion = await fetchLatestVersion(language, deps);
+    const executablePath = executablePathFor(language, languageRoot, latestVersion);
+
+    if (!await deps.exists(executablePath)) {
+      await installTool(language, languageRoot, latestVersion, deps);
+    }
+
+    if (!await deps.exists(executablePath)) {
+      throw new Error(`installed CRAP ${language} CLI is missing at ${executablePath}`);
+    }
+
+    await deps.writeJson(statePath, {
+      checkedAt: new Date(deps.now()).toISOString(),
+      version: latestVersion
+    });
+    await removeOutdatedVersions(languageRoot, latestVersion, deps);
+
+    return {
+      executablePath,
+      language,
+      stale: false,
+      version: latestVersion
+    };
+  } catch (error) {
+    if (cachedTool !== undefined) {
+      deps.warn(`Using cached CRAP ${language} CLI ${cachedTool.version}: ${error.message}`);
+      return {
+        ...cachedTool,
+        stale: true
+      };
+    }
+
+    throw new Error(
+      `Cannot resolve CRAP ${language} CLI and no cached tool is available: ${error.message}`
+    );
+  }
+}
+
+export async function run(argv, deps = createDefaultDeps()) {
+  const request = parseCliRequest(argv);
+
+  if (!request.ok) {
+    console.error(request.message);
+    return 1;
+  }
+
+  const tool = await resolveTool(request.language, deps);
+  const command = buildToolCommand(request.language, tool.executablePath, request.toolArgs);
+
+  return deps.runProcess(command.command, command.args);
+}
+
+async function readState(statePath, deps) {
+  try {
+    return await deps.readJson(statePath);
+  } catch {
+    return {};
+  }
+}
+
+async function getCachedTool(language, languageRoot, state, deps) {
+  if (typeof state.version !== "string" || state.version.length === 0) {
+    return undefined;
+  }
+
+  const executablePath = executablePathFor(language, languageRoot, state.version);
+
+  if (!await deps.exists(executablePath)) {
+    return undefined;
+  }
+
+  return {
+    executablePath,
+    language,
+    stale: false,
+    version: state.version
+  };
+}
+
+async function fetchLatestVersion(language, deps) {
+  if (language === "typescript") {
+    const metadata = await deps.fetchJson(
+      `https://registry.npmjs.org/${encodeURIComponent(TOOL_CONFIG.npmPackage).replace("%40", "@")}`
+    );
+
+    return parseNpmLatestVersion(metadata);
+  }
+
+  if (language === "java") {
+    const metadataXml = await deps.fetchText(mavenMetadataUrl());
+
+    return parseMavenLatestVersion(metadataXml);
+  }
+
+  throw new Error(`Unsupported language: ${language}`);
+}
+
+async function installTool(language, languageRoot, version, deps) {
+  const versionRoot = path.join(languageRoot, version);
+
+  await deps.mkdir(versionRoot);
+
+  if (language === "typescript") {
+    const npmCommand = npmCommandSpec();
+    const exitCode = await deps.runProcess(npmCommand.command, [
+      ...npmCommand.args,
+      "install",
+      "--prefix",
+      versionRoot,
+      "--no-save",
+      "--no-audit",
+      "--no-fund",
+      `${TOOL_CONFIG.npmPackage}@${version}`
+    ]);
+
+    if (exitCode !== 0) {
+      throw new Error(`npm install failed with exit code ${exitCode}`);
+    }
+
+    return;
+  }
+
+  if (language === "java") {
+    await deps.downloadFile(mavenJarUrl(version), executablePathFor(language, languageRoot, version));
+    return;
+  }
+
+  throw new Error(`Unsupported language: ${language}`);
+}
+
+function executablePathFor(language, languageRoot, version) {
+  if (language === "typescript") {
+    return path.join(languageRoot, version, ...TOOL_CONFIG.npmBinPath);
+  }
+
+  if (language === "java") {
+    return path.join(languageRoot, version, `${TOOL_CONFIG.mavenArtifact}-${version}.jar`);
+  }
+
+  throw new Error(`Unsupported language: ${language}`);
+}
+
+async function removeOutdatedVersions(languageRoot, currentVersion, deps) {
+  let entries;
+
+  try {
+    entries = await deps.readDir(languageRoot);
+  } catch {
+    return;
+  }
+
+  await Promise.all(entries
+    .filter((entry) => entry.isDirectory() && entry.name !== currentVersion)
+    .map((entry) => deps.rm(path.join(languageRoot, entry.name))));
+}
+
+function mavenMetadataUrl() {
+  return `https://repo.maven.apache.org/maven2/${TOOL_CONFIG.mavenGroupPath}/${TOOL_CONFIG.mavenArtifact}/maven-metadata.xml`;
+}
+
+function mavenJarUrl(version) {
+  return `https://repo.maven.apache.org/maven2/${TOOL_CONFIG.mavenGroupPath}/${TOOL_CONFIG.mavenArtifact}/${version}/${TOOL_CONFIG.mavenArtifact}-${version}.jar`;
+}
+
+function npmCommandSpec() {
+  return {
+    command: process.execPath,
+    args: [npmCliPath()]
+  };
+}
+
+function npmCliPath() {
+  return path.join(path.dirname(process.execPath), "node_modules", "npm", "bin", "npm-cli.js");
+}
+
+async function fetchJson(url) {
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(`GET ${url} failed with ${response.status}`);
+  }
+
+  return response.json();
+}
+
+async function fetchText(url) {
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(`GET ${url} failed with ${response.status}`);
+  }
+
+  return response.text();
+}
+
+async function downloadFile(url, filePath) {
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(`GET ${url} failed with ${response.status}`);
+  }
+
+  const bytes = Buffer.from(await response.arrayBuffer());
+
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, bytes);
+}
+
+async function pathExists(filePath) {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function runProcess(command, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: "inherit"
+    });
+
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      resolve(code ?? 1);
+    });
+  });
+}
+
+const isEntrypoint = process.argv[1] !== undefined
+  && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+
+if (isEntrypoint) {
+  try {
+    process.exitCode = await run(process.argv.slice(2));
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/skills/ai-skills-quality-crap/scripts/run-crap-cli.mjs
+++ b/skills/ai-skills-quality-crap/scripts/run-crap-cli.mjs
@@ -142,9 +142,22 @@ export async function resolveTool(language, deps = createDefaultDeps()) {
   const statePath = path.join(languageRoot, "state.json");
   const state = await readState(statePath, deps);
   const cachedTool = await getCachedTool(language, languageRoot, state, deps);
+  const metadataIsFresh = !shouldRefreshMetadata(state.checkedAt, deps.now());
 
-  if (cachedTool?.fromState === true && !shouldRefreshMetadata(state.checkedAt, deps.now())) {
-    return toolResult(cachedTool);
+  if (metadataIsFresh) {
+    if (cachedTool?.fromState === true) {
+      return toolResult(cachedTool);
+    }
+
+    try {
+      const stateTool = await installFreshStateTool(language, languageRoot, state, deps);
+
+      if (stateTool !== undefined) {
+        return stateTool;
+      }
+    } catch (error) {
+      return cachedFallbackOrThrow(language, cachedTool, error, deps);
+    }
   }
 
   try {
@@ -172,17 +185,7 @@ export async function resolveTool(language, deps = createDefaultDeps()) {
       version: latestVersion
     };
   } catch (error) {
-    if (cachedTool !== undefined) {
-      deps.warn(`Using cached CRAP ${language} CLI ${cachedTool.version}: ${toErrorMessage(error)}`);
-      return {
-        ...toolResult(cachedTool),
-        stale: true
-      };
-    }
-
-    throw new Error(
-      `Cannot resolve CRAP ${language} CLI and no cached tool is available: ${toErrorMessage(error)}`
-    );
+    return cachedFallbackOrThrow(language, cachedTool, error, deps);
   }
 }
 
@@ -299,6 +302,51 @@ function toolResult(tool) {
     language: tool.language,
     stale: tool.stale,
     version: tool.version
+  };
+}
+
+function cachedFallbackOrThrow(language, cachedTool, error, deps) {
+  if (cachedTool !== undefined) {
+    deps.warn(`Using cached CRAP ${language} CLI ${cachedTool.version}: ${toErrorMessage(error)}`);
+    return {
+      ...toolResult(cachedTool),
+      stale: true
+    };
+  }
+
+  throw new Error(
+    `Cannot resolve CRAP ${language} CLI and no cached tool is available: ${toErrorMessage(error)}`
+  );
+}
+
+async function installFreshStateTool(language, languageRoot, state, deps) {
+  if (typeof state.version !== "string") {
+    return undefined;
+  }
+
+  const version = safeVersionCandidate(state.version, "cached CRAP CLI state version", deps);
+
+  if (version === undefined) {
+    return undefined;
+  }
+
+  const executablePath = executablePathFor(language, languageRoot, version);
+
+  if (!await deps.exists(executablePath)) {
+    await installTool(language, languageRoot, version, deps);
+  }
+
+  if (!await deps.exists(executablePath)) {
+    throw new Error(`installed CRAP ${language} CLI is missing at ${executablePath}`);
+  }
+
+  await removeOutdatedVersions(language, languageRoot, version, deps);
+
+  return {
+    executablePath,
+    language,
+    stale: false,
+    version
   };
 }
 

--- a/skills/ai-skills-quality-crap/scripts/run-crap-cli.mjs
+++ b/skills/ai-skills-quality-crap/scripts/run-crap-cli.mjs
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
@@ -24,7 +22,7 @@ export function parseCliRequest(argv) {
   if (!SUPPORTED_LANGUAGES.has(language)) {
     return {
       ok: false,
-      message: "Usage: node scripts/run-crap-cli.mjs <typescript|java> -- <tool args...>"
+      message: "Usage: node scripts/run-crap-cli.mjs <typescript|java> [--] <tool args...>"
     };
   }
 
@@ -66,7 +64,7 @@ export function shouldRefreshMetadata(checkedAt, nowMs) {
 
   const checkedAtMs = Date.parse(checkedAt);
 
-  return Number.isNaN(checkedAtMs) || nowMs - checkedAtMs >= WEEK_MS;
+  return Number.isNaN(checkedAtMs) || checkedAtMs > nowMs || nowMs - checkedAtMs >= WEEK_MS;
 }
 
 export function buildToolCommand(language, executablePath, toolArgs) {
@@ -157,7 +155,7 @@ export async function resolveTool(language, deps = createDefaultDeps()) {
     };
   } catch (error) {
     if (cachedTool !== undefined) {
-      deps.warn(`Using cached CRAP ${language} CLI ${cachedTool.version}: ${error.message}`);
+      deps.warn(`Using cached CRAP ${language} CLI ${cachedTool.version}: ${toErrorMessage(error)}`);
       return {
         ...cachedTool,
         stale: true
@@ -165,7 +163,7 @@ export async function resolveTool(language, deps = createDefaultDeps()) {
     }
 
     throw new Error(
-      `Cannot resolve CRAP ${language} CLI and no cached tool is available: ${error.message}`
+      `Cannot resolve CRAP ${language} CLI and no cached tool is available: ${toErrorMessage(error)}`
     );
   }
 }
@@ -235,17 +233,21 @@ async function installTool(language, languageRoot, version, deps) {
   await deps.mkdir(versionRoot);
 
   if (language === "typescript") {
-    const npmCommand = npmCommandSpec();
-    const exitCode = await deps.runProcess(npmCommand.command, [
-      ...npmCommand.args,
-      "install",
-      "--prefix",
-      versionRoot,
-      "--no-save",
-      "--no-audit",
-      "--no-fund",
-      `${TOOL_CONFIG.npmPackage}@${version}`
-    ]);
+    const npmCommand = await npmCommandSpec(deps);
+    const exitCode = await deps.runProcess(
+      npmCommand.command,
+      [
+        ...npmCommand.args,
+        "install",
+        "--prefix",
+        versionRoot,
+        "--no-save",
+        "--no-audit",
+        "--no-fund",
+        `${TOOL_CONFIG.npmPackage}@${version}`
+      ],
+      { shell: npmCommand.shell === true }
+    );
 
     if (exitCode !== 0) {
       throw new Error(`npm install failed with exit code ${exitCode}`);
@@ -296,15 +298,29 @@ function mavenJarUrl(version) {
   return `https://repo.maven.apache.org/maven2/${TOOL_CONFIG.mavenGroupPath}/${TOOL_CONFIG.mavenArtifact}/${version}/${TOOL_CONFIG.mavenArtifact}-${version}.jar`;
 }
 
-function npmCommandSpec() {
-  return {
-    command: process.execPath,
-    args: [npmCliPath()]
-  };
+export async function npmCommandSpec(deps = createDefaultDeps(), platform = process.platform) {
+  for (const candidate of npmCliPathCandidates()) {
+    if (await deps.exists(candidate)) {
+      return {
+        command: process.execPath,
+        args: [candidate]
+      };
+    }
+  }
+
+  return platform === "win32"
+    ? { command: "npm.cmd", args: [], shell: true }
+    : { command: "npm", args: [] };
 }
 
-function npmCliPath() {
-  return path.join(path.dirname(process.execPath), "node_modules", "npm", "bin", "npm-cli.js");
+function npmCliPathCandidates() {
+  const nodeBinDir = path.dirname(process.execPath);
+
+  return [
+    path.resolve(nodeBinDir, "node_modules", "npm", "bin", "npm-cli.js"),
+    path.resolve(nodeBinDir, "..", "lib", "node_modules", "npm", "bin", "npm-cli.js"),
+    path.resolve(nodeBinDir, "..", "node_modules", "npm", "bin", "npm-cli.js")
+  ];
 }
 
 async function fetchJson(url) {
@@ -349,9 +365,10 @@ async function pathExists(filePath) {
   }
 }
 
-function runProcess(command, args) {
+function runProcess(command, args, options = {}) {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
+      shell: options.shell === true,
       stdio: "inherit"
     });
 
@@ -369,7 +386,11 @@ if (isEntrypoint) {
   try {
     process.exitCode = await run(process.argv.slice(2));
   } catch (error) {
-    console.error(error.message);
+    console.error(toErrorMessage(error));
     process.exitCode = 1;
   }
+}
+
+function toErrorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/skills/ai-skills-quality-crap/scripts/run-crap-cli.mjs
+++ b/skills/ai-skills-quality-crap/scripts/run-crap-cli.mjs
@@ -14,6 +14,7 @@ export const TOOL_CONFIG = {
 };
 
 export const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+export const FETCH_TIMEOUT_MS = 30_000;
 
 const SUPPORTED_LANGUAGES = new Set(["typescript", "java"]);
 
@@ -465,8 +466,8 @@ function npmCliPathCandidates() {
   ];
 }
 
-async function fetchJson(url) {
-  const response = await fetch(url);
+export async function fetchJson(url) {
+  const response = await fetch(url, fetchRequestInit());
 
   if (!response.ok) {
     throw new Error(`GET ${url} failed with ${response.status}`);
@@ -475,8 +476,8 @@ async function fetchJson(url) {
   return response.json();
 }
 
-async function fetchText(url) {
-  const response = await fetch(url);
+export async function fetchText(url) {
+  const response = await fetch(url, fetchRequestInit());
 
   if (!response.ok) {
     throw new Error(`GET ${url} failed with ${response.status}`);
@@ -485,8 +486,8 @@ async function fetchText(url) {
   return response.text();
 }
 
-async function downloadFile(url, filePath) {
-  const response = await fetch(url);
+export async function downloadFile(url, filePath) {
+  const response = await fetch(url, fetchRequestInit());
 
   if (!response.ok) {
     throw new Error(`GET ${url} failed with ${response.status}`);
@@ -496,6 +497,12 @@ async function downloadFile(url, filePath) {
 
   await fs.mkdir(path.dirname(filePath), { recursive: true });
   await fs.writeFile(filePath, bytes);
+}
+
+function fetchRequestInit() {
+  return {
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS)
+  };
 }
 
 async function pathExists(filePath) {

--- a/skills/ai-skills-quality-crap/scripts/run-crap-cli.mjs
+++ b/skills/ai-skills-quality-crap/scripts/run-crap-cli.mjs
@@ -87,8 +87,10 @@ export function buildToolCommand(language, executablePath, toolArgs) {
 }
 
 export function getCacheRoot(env = process.env, platform = process.platform) {
-  if (env.AI_SKILLS_TOOL_CACHE_DIR !== undefined && env.AI_SKILLS_TOOL_CACHE_DIR.trim() !== "") {
-    return path.resolve(env.AI_SKILLS_TOOL_CACHE_DIR, TOOL_CONFIG.skillId);
+  const configuredCacheDir = env.AI_SKILLS_TOOL_CACHE_DIR?.trim();
+
+  if (configuredCacheDir !== undefined && configuredCacheDir !== "") {
+    return path.resolve(configuredCacheDir, TOOL_CONFIG.skillId);
   }
 
   const baseCacheDir = env.XDG_CACHE_HOME
@@ -288,7 +290,12 @@ async function downloadVerifiedMavenJar(languageRoot, version, deps) {
   const actualChecksum = sha256(await deps.readFile(jarPath));
 
   if (actualChecksum !== expectedChecksum) {
-    await deps.rm(jarPath);
+    try {
+      await deps.rm(jarPath);
+    } catch (error) {
+      deps.warn(`Could not remove invalid CRAP java CLI ${version}: ${toErrorMessage(error)}`);
+    }
+
     throw new Error(`Maven JAR checksum mismatch for ${TOOL_CONFIG.mavenArtifact} ${version}`);
   }
 }

--- a/skills/ai-skills-quality-crap/scripts/run-crap-cli.mjs
+++ b/skills/ai-skills-quality-crap/scripts/run-crap-cli.mjs
@@ -119,6 +119,7 @@ export function createDefaultDeps() {
     exists: pathExists,
     fetchJson,
     fetchText,
+    info: (message) => console.error(message),
     mkdir: async (directory) => fs.mkdir(directory, { recursive: true }),
     now: () => Date.now(),
     readDir: async (directory) => fs.readdir(directory, { withFileTypes: true }),
@@ -195,7 +196,15 @@ export async function run(argv, deps = createDefaultDeps()) {
   const tool = await resolveTool(request.language, deps);
   const command = buildToolCommand(request.language, tool.executablePath, request.toolArgs);
 
+  deps.info?.(formatResolvedToolMessage(tool));
+
   return deps.runProcess(command.command, command.args);
+}
+
+export function formatResolvedToolMessage(tool) {
+  const cacheStatus = tool.stale ? "stale-cache" : "cache";
+
+  return `Resolved CRAP ${tool.language} CLI ${tool.version} (${cacheStatus}) at ${tool.executablePath}`;
 }
 
 async function readState(statePath, deps) {

--- a/test/crap-cli-helper.test.ts
+++ b/test/crap-cli-helper.test.ts
@@ -17,6 +17,7 @@ import {
   parseNpmLatestVersion,
   parseSha256Checksum,
   resolveTool,
+  run,
   safeVersionPathSegment,
   shouldRefreshMetadata
 } from "../skills/ai-skills-quality-crap/scripts/run-crap-cli.mjs";
@@ -407,6 +408,50 @@ test("refreshes CRAP metadata when the fresh state version is missing", async ()
   assert.equal(tool.executablePath, executablePath);
   assert.equal(tool.stale, true);
   assert.match(warnings.join("\n"), /Using cached CRAP typescript CLI 0\.4\.1: offline/u);
+});
+
+test("logs resolved CRAP CLI evidence before execution", async () => {
+  const cacheRoot = await createTempDir();
+  const languageRoot = path.join(cacheRoot, "typescript");
+  const executablePath = path.join(
+    languageRoot,
+    "0.4.1",
+    "node_modules",
+    "@barney-media",
+    "crap-typescript",
+    "dist",
+    "bin.js"
+  );
+  const infoMessages: string[] = [];
+  const runCalls: Array<{ args: string[]; command: string }> = [];
+
+  await fs.mkdir(path.dirname(executablePath), { recursive: true });
+  await fs.writeFile(executablePath, "");
+  await fs.writeFile(
+    path.join(languageRoot, "state.json"),
+    JSON.stringify({
+      checkedAt: "2026-06-01T00:00:00.000Z",
+      version: "0.4.1"
+    })
+  );
+
+  const exitCode = await run(["typescript", "--", "--help"], {
+    ...createDefaultDeps(),
+    cacheRoot,
+    info: (message: string) => {
+      infoMessages.push(message);
+    },
+    now: () => Date.parse("2026-06-01T00:00:00.000Z"),
+    runProcess: async (command: string, args: string[]) => {
+      runCalls.push({ args, command });
+      return 0;
+    }
+  });
+
+  assert.equal(exitCode, 0);
+  assert.match(infoMessages[0] ?? "", /Resolved CRAP typescript CLI 0\.4\.1 \(cache\)/u);
+  assert.equal(runCalls[0]?.command, process.execPath);
+  assert.deepEqual(runCalls[0]?.args, [executablePath, "--help"]);
 });
 
 async function createTempDir() {

--- a/test/crap-cli-helper.test.ts
+++ b/test/crap-cli-helper.test.ts
@@ -9,6 +9,8 @@ import {
   WEEK_MS,
   buildToolCommand,
   createDefaultDeps,
+  npmCommandSpec,
+  parseCliRequest,
   parseMavenLatestVersion,
   parseNpmLatestVersion,
   resolveTool,
@@ -37,13 +39,29 @@ test("parses latest CRAP CLI versions from npm and Maven metadata", () => {
   );
 });
 
+test("parses CRAP helper requests with an optional argument separator", () => {
+  assert.deepEqual(parseCliRequest(["typescript", "--", "--agent", "src"]), {
+    ok: true,
+    language: "typescript",
+    toolArgs: ["--agent", "src"]
+  });
+  assert.deepEqual(parseCliRequest(["java", "--agent", "src"]), {
+    ok: true,
+    language: "java",
+    toolArgs: ["--agent", "src"]
+  });
+  assert.match(parseCliRequest(["ruby"]).message, /\[--\]/u);
+});
+
 test("refreshes cached CRAP CLI metadata at most weekly", () => {
   const now = Date.parse("2026-06-01T12:00:00Z");
   const sixDaysAgo = new Date(now - WEEK_MS + 1).toISOString();
   const sevenDaysAgo = new Date(now - WEEK_MS).toISOString();
+  const future = new Date(now + 1).toISOString();
 
   assert.equal(shouldRefreshMetadata(sixDaysAgo, now), false);
   assert.equal(shouldRefreshMetadata(sevenDaysAgo, now), true);
+  assert.equal(shouldRefreshMetadata(future, now), true);
   assert.equal(shouldRefreshMetadata("not-a-date", now), true);
 });
 
@@ -67,6 +85,32 @@ test("builds CRAP CLI commands for TypeScript and Java tools", () => {
       args: ["-jar", "cache/crap-java-cli.jar", "--agent", "--threshold", "8"]
     }
   );
+});
+
+test("resolves npm through bundled CLI paths before falling back to PATH", async () => {
+  const npmCli = path.resolve(
+    path.dirname(process.execPath),
+    "..",
+    "lib",
+    "node_modules",
+    "npm",
+    "bin",
+    "npm-cli.js"
+  );
+  const deps = {
+    ...createDefaultDeps(),
+    exists: async (candidate: string) => candidate === npmCli
+  };
+
+  assert.deepEqual(await npmCommandSpec(deps, "linux"), {
+    command: process.execPath,
+    args: [npmCli]
+  });
+  assert.deepEqual(await npmCommandSpec({ ...deps, exists: async () => false }, "win32"), {
+    command: "npm.cmd",
+    args: [],
+    shell: true
+  });
 });
 
 test("falls back to a cached CRAP CLI when weekly metadata refresh is offline", async () => {

--- a/test/crap-cli-helper.test.ts
+++ b/test/crap-cli-helper.test.ts
@@ -10,6 +10,9 @@ import {
   WEEK_MS,
   buildToolCommand,
   createDefaultDeps,
+  downloadFile,
+  fetchJson,
+  fetchText,
   getCacheRoot,
   npmCommandSpec,
   parseCliRequest,
@@ -452,6 +455,34 @@ test("logs resolved CRAP CLI evidence before execution", async () => {
   assert.match(infoMessages[0] ?? "", /Resolved CRAP typescript CLI 0\.4\.1 \(cache\)/u);
   assert.equal(runCalls[0]?.command, process.execPath);
   assert.deepEqual(runCalls[0]?.args, [executablePath, "--help"]);
+});
+
+test("uses request timeouts for CRAP metadata and downloads", async () => {
+  const originalFetch = globalThis.fetch;
+  const signals: Array<AbortSignal | null | undefined> = [];
+  const downloadPath = path.join(await createTempDir(), "tool.jar");
+
+  globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+    signals.push(init?.signal);
+
+    return new Response(JSON.stringify({ ok: true }), {
+      headers: {
+        "content-type": "application/json"
+      },
+      status: 200
+    });
+  }) as typeof fetch;
+
+  try {
+    assert.deepEqual(await fetchJson("https://example.test/metadata"), { ok: true });
+    assert.equal(await fetchText("https://example.test/text"), JSON.stringify({ ok: true }));
+    await downloadFile("https://example.test/tool.jar", downloadPath);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.equal(signals.length, 3);
+  assert.ok(signals.every((signal) => signal instanceof AbortSignal));
 });
 
 async function createTempDir() {

--- a/test/crap-cli-helper.test.ts
+++ b/test/crap-cli-helper.test.ts
@@ -10,6 +10,7 @@ import {
   WEEK_MS,
   buildToolCommand,
   createDefaultDeps,
+  getCacheRoot,
   npmCommandSpec,
   parseCliRequest,
   parseMavenLatestVersion,
@@ -40,6 +41,15 @@ test("parses latest CRAP CLI versions from npm and Maven metadata", () => {
     "0.6.1"
   );
   assert.equal(parseSha256Checksum("ABCDEF".padEnd(64, "0")), "abcdef".padEnd(64, "0"));
+});
+
+test("trims CRAP helper cache root overrides", () => {
+  const cacheDir = path.join(os.tmpdir(), "ai-skills-crap-cache-root");
+
+  assert.equal(
+    getCacheRoot({ AI_SKILLS_TOOL_CACHE_DIR: ` ${cacheDir} ` }, process.platform),
+    path.resolve(cacheDir, "ai-skills-quality-crap")
+  );
 });
 
 test("parses CRAP helper requests with an optional argument separator", () => {
@@ -203,6 +213,60 @@ test("validates downloaded Java CRAP CLIs against Maven SHA-256 checksums", asyn
 
   assert.equal(tool.executablePath, executablePath);
   assert.equal(tool.version, "0.6.1");
+});
+
+test("falls back to cached Java CRAP CLIs when checksum cleanup fails", async () => {
+  const cacheRoot = await createTempDir();
+  const languageRoot = path.join(cacheRoot, "java");
+  const cachedJar = path.join(languageRoot, "0.6.0", "crap-java-cli-0.6.0.jar");
+  const newestJar = path.join(languageRoot, "0.6.1", "crap-java-cli-0.6.1.jar");
+  const warnings: string[] = [];
+
+  await fs.mkdir(path.dirname(cachedJar), { recursive: true });
+  await fs.writeFile(cachedJar, "cached");
+  await fs.writeFile(
+    path.join(languageRoot, "state.json"),
+    JSON.stringify({
+      checkedAt: "2026-05-01T00:00:00.000Z",
+      version: "0.6.0"
+    })
+  );
+
+  const deps = {
+    ...createDefaultDeps(),
+    cacheRoot,
+    downloadFile: async (_url: string, filePath: string) => {
+      await fs.mkdir(path.dirname(filePath), { recursive: true });
+      await fs.writeFile(filePath, "bad");
+    },
+    fetchText: async (url: string) => url.endsWith(".sha256")
+      ? createHash("sha256").update("good").digest("hex")
+      : [
+        "<metadata>",
+        "  <versioning>",
+        "    <latest>0.6.1</latest>",
+        "  </versioning>",
+        "</metadata>"
+      ].join("\n"),
+    now: () => Date.parse("2026-06-01T00:00:00.000Z"),
+    rm: async (target: string) => {
+      if (target === newestJar) {
+        throw new Error("locked");
+      }
+
+      await fs.rm(target, { force: true, recursive: true });
+    },
+    warn: (message: string) => {
+      warnings.push(message);
+    }
+  };
+
+  const tool = await resolveTool("java", deps);
+
+  assert.equal(tool.executablePath, cachedJar);
+  assert.equal(tool.stale, true);
+  assert.match(warnings.join("\n"), /Could not remove invalid CRAP java CLI 0\.6\.1/u);
+  assert.match(warnings.join("\n"), /Maven JAR checksum mismatch/u);
 });
 
 test("falls back to a cached CRAP CLI when weekly metadata refresh is offline", async () => {

--- a/test/crap-cli-helper.test.ts
+++ b/test/crap-cli-helper.test.ts
@@ -166,6 +166,10 @@ test("installs TypeScript CRAP CLIs without lifecycle scripts and keeps cleanup 
       {
         isDirectory: () => true,
         name: "0.4.0"
+      },
+      {
+        isDirectory: () => true,
+        name: "..evil"
       }
     ],
     rm: async () => {
@@ -189,8 +193,8 @@ test("installs TypeScript CRAP CLIs without lifecycle scripts and keeps cleanup 
   assert.equal(tool.stale, false);
   assert.equal(runCalls.length, 1);
   assert.ok(runCalls[0]?.args.includes("--ignore-scripts"));
-  assert.equal(warnings.length, 1);
-  assert.match(warnings[0], /Could not remove outdated CRAP typescript CLI 0\.4\.0/u);
+  assert.match(warnings.join("\n"), /Ignoring unsafe outdated CRAP typescript CLI directory/u);
+  assert.match(warnings.join("\n"), /Could not remove outdated CRAP typescript CLI 0\.4\.0/u);
 });
 
 test("validates downloaded Java CRAP CLIs against Maven SHA-256 checksums", async () => {
@@ -360,6 +364,49 @@ test("discovers cached CRAP CLIs from disk when state is missing", async () => {
   assert.equal(tool.stale, true);
   assert.match(warnings.join("\n"), /Ignoring unsafe cached CRAP typescript CLI directory/u);
   assert.match(warnings.join("\n"), /Using cached CRAP typescript CLI 0\.4\.1/u);
+});
+
+test("refreshes CRAP metadata when the fresh state version is missing", async () => {
+  const cacheRoot = await createTempDir();
+  const languageRoot = path.join(cacheRoot, "typescript");
+  const executablePath = path.join(
+    languageRoot,
+    "0.4.1",
+    "node_modules",
+    "@barney-media",
+    "crap-typescript",
+    "dist",
+    "bin.js"
+  );
+  const warnings: string[] = [];
+
+  await fs.mkdir(path.dirname(executablePath), { recursive: true });
+  await fs.writeFile(executablePath, "");
+  await fs.writeFile(
+    path.join(languageRoot, "state.json"),
+    JSON.stringify({
+      checkedAt: "2026-06-01T00:00:00.000Z",
+      version: "0.5.0"
+    })
+  );
+
+  const deps = {
+    ...createDefaultDeps(),
+    cacheRoot,
+    fetchJson: async () => {
+      throw new Error("offline");
+    },
+    now: () => Date.parse("2026-06-01T00:00:00.000Z"),
+    warn: (message: string) => {
+      warnings.push(message);
+    }
+  };
+
+  const tool = await resolveTool("typescript", deps);
+
+  assert.equal(tool.executablePath, executablePath);
+  assert.equal(tool.stale, true);
+  assert.match(warnings.join("\n"), /Using cached CRAP typescript CLI 0\.4\.1: offline/u);
 });
 
 async function createTempDir() {

--- a/test/crap-cli-helper.test.ts
+++ b/test/crap-cli-helper.test.ts
@@ -370,10 +370,10 @@ test("discovers cached CRAP CLIs from disk when state is missing", async () => {
   assert.match(warnings.join("\n"), /Using cached CRAP typescript CLI 0\.4\.1/u);
 });
 
-test("refreshes CRAP metadata when the fresh state version is missing", async () => {
+test("reinstalls the fresh CRAP state version without refreshing metadata", async () => {
   const cacheRoot = await createTempDir();
   const languageRoot = path.join(cacheRoot, "typescript");
-  const executablePath = path.join(
+  const staleExecutablePath = path.join(
     languageRoot,
     "0.4.1",
     "node_modules",
@@ -382,10 +382,19 @@ test("refreshes CRAP metadata when the fresh state version is missing", async ()
     "dist",
     "bin.js"
   );
-  const warnings: string[] = [];
+  const stateExecutablePath = path.join(
+    languageRoot,
+    "0.5.0",
+    "node_modules",
+    "@barney-media",
+    "crap-typescript",
+    "dist",
+    "bin.js"
+  );
+  const runCalls: Array<{ args: string[] }> = [];
 
-  await fs.mkdir(path.dirname(executablePath), { recursive: true });
-  await fs.writeFile(executablePath, "");
+  await fs.mkdir(path.dirname(staleExecutablePath), { recursive: true });
+  await fs.writeFile(staleExecutablePath, "");
   await fs.writeFile(
     path.join(languageRoot, "state.json"),
     JSON.stringify({
@@ -398,19 +407,24 @@ test("refreshes CRAP metadata when the fresh state version is missing", async ()
     ...createDefaultDeps(),
     cacheRoot,
     fetchJson: async () => {
-      throw new Error("offline");
+      throw new Error("metadata refresh should not run");
     },
     now: () => Date.parse("2026-06-01T00:00:00.000Z"),
-    warn: (message: string) => {
-      warnings.push(message);
+    runProcess: async (_command: string, args: string[]) => {
+      runCalls.push({ args });
+      await fs.mkdir(path.dirname(stateExecutablePath), { recursive: true });
+      await fs.writeFile(stateExecutablePath, "");
+      return 0;
     }
   };
 
   const tool = await resolveTool("typescript", deps);
 
-  assert.equal(tool.executablePath, executablePath);
-  assert.equal(tool.stale, true);
-  assert.match(warnings.join("\n"), /Using cached CRAP typescript CLI 0\.4\.1: offline/u);
+  assert.equal(tool.executablePath, stateExecutablePath);
+  assert.equal(tool.version, "0.5.0");
+  assert.equal(tool.stale, false);
+  assert.equal(runCalls.length, 1);
+  assert.ok(runCalls[0]?.args.includes("@barney-media/crap-typescript@0.5.0"));
 });
 
 test("logs resolved CRAP CLI evidence before execution", async () => {

--- a/test/crap-cli-helper.test.ts
+++ b/test/crap-cli-helper.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -13,6 +14,7 @@ import {
   parseCliRequest,
   parseMavenLatestVersion,
   parseNpmLatestVersion,
+  parseSha256Checksum,
   resolveTool,
   shouldRefreshMetadata
 } from "../skills/ai-skills-quality-crap/scripts/run-crap-cli.mjs";
@@ -37,6 +39,7 @@ test("parses latest CRAP CLI versions from npm and Maven metadata", () => {
     ].join("\n")),
     "0.6.1"
   );
+  assert.equal(parseSha256Checksum("ABCDEF".padEnd(64, "0")), "abcdef".padEnd(64, "0"));
 });
 
 test("parses CRAP helper requests with an optional argument separator", () => {
@@ -111,6 +114,95 @@ test("resolves npm through bundled CLI paths before falling back to PATH", async
     args: [],
     shell: true
   });
+});
+
+test("installs TypeScript CRAP CLIs without lifecycle scripts and keeps cleanup best-effort", async () => {
+  const cacheRoot = await createTempDir();
+  const languageRoot = path.join(cacheRoot, "typescript");
+  const executablePath = path.join(
+    languageRoot,
+    "0.4.1",
+    "node_modules",
+    "@barney-media",
+    "crap-typescript",
+    "dist",
+    "bin.js"
+  );
+  const runCalls: Array<{ args: string[] }> = [];
+  const warnings: string[] = [];
+  let installed = false;
+
+  const deps = {
+    ...createDefaultDeps(),
+    cacheRoot,
+    exists: async (candidate: string) => installed && candidate === executablePath,
+    fetchJson: async () => ({
+      "dist-tags": {
+        latest: "0.4.1"
+      }
+    }),
+    now: () => Date.parse("2026-06-01T00:00:00.000Z"),
+    readDir: async () => [
+      {
+        isDirectory: () => true,
+        name: "0.4.0"
+      }
+    ],
+    rm: async () => {
+      throw new Error("locked");
+    },
+    runProcess: async (_command: string, args: string[]) => {
+      runCalls.push({ args });
+      await fs.mkdir(path.dirname(executablePath), { recursive: true });
+      await fs.writeFile(executablePath, "");
+      installed = true;
+      return 0;
+    },
+    warn: (message: string) => {
+      warnings.push(message);
+    }
+  };
+
+  const tool = await resolveTool("typescript", deps);
+
+  assert.equal(tool.executablePath, executablePath);
+  assert.equal(tool.stale, false);
+  assert.equal(runCalls.length, 1);
+  assert.ok(runCalls[0]?.args.includes("--ignore-scripts"));
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /Could not remove outdated CRAP typescript CLI 0\.4\.0/u);
+});
+
+test("validates downloaded Java CRAP CLIs against Maven SHA-256 checksums", async () => {
+  const cacheRoot = await createTempDir();
+  const languageRoot = path.join(cacheRoot, "java");
+  const jarBytes = Buffer.from("jar-bytes");
+  const checksum = createHash("sha256").update(jarBytes).digest("hex");
+  const executablePath = path.join(languageRoot, "0.6.1", "crap-java-cli-0.6.1.jar");
+
+  const deps = {
+    ...createDefaultDeps(),
+    cacheRoot,
+    downloadFile: async (_url: string, filePath: string) => {
+      await fs.mkdir(path.dirname(filePath), { recursive: true });
+      await fs.writeFile(filePath, jarBytes);
+    },
+    fetchText: async (url: string) => url.endsWith(".sha256")
+      ? checksum
+      : [
+        "<metadata>",
+        "  <versioning>",
+        "    <latest>0.6.1</latest>",
+        "  </versioning>",
+        "</metadata>"
+      ].join("\n"),
+    now: () => Date.parse("2026-06-01T00:00:00.000Z")
+  };
+
+  const tool = await resolveTool("java", deps);
+
+  assert.equal(tool.executablePath, executablePath);
+  assert.equal(tool.version, "0.6.1");
 });
 
 test("falls back to a cached CRAP CLI when weekly metadata refresh is offline", async () => {

--- a/test/crap-cli-helper.test.ts
+++ b/test/crap-cli-helper.test.ts
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { onTestFinished, test } from "vitest";
+
+import {
+  WEEK_MS,
+  buildToolCommand,
+  createDefaultDeps,
+  parseMavenLatestVersion,
+  parseNpmLatestVersion,
+  resolveTool,
+  shouldRefreshMetadata
+} from "../skills/ai-skills-quality-crap/scripts/run-crap-cli.mjs";
+
+test("parses latest CRAP CLI versions from npm and Maven metadata", () => {
+  assert.equal(
+    parseNpmLatestVersion({
+      "dist-tags": {
+        latest: "0.4.1"
+      }
+    }),
+    "0.4.1"
+  );
+  assert.equal(
+    parseMavenLatestVersion([
+      "<metadata>",
+      "  <versioning>",
+      "    <latest>0.6.1</latest>",
+      "    <release>0.6.0</release>",
+      "  </versioning>",
+      "</metadata>"
+    ].join("\n")),
+    "0.6.1"
+  );
+});
+
+test("refreshes cached CRAP CLI metadata at most weekly", () => {
+  const now = Date.parse("2026-06-01T12:00:00Z");
+  const sixDaysAgo = new Date(now - WEEK_MS + 1).toISOString();
+  const sevenDaysAgo = new Date(now - WEEK_MS).toISOString();
+
+  assert.equal(shouldRefreshMetadata(sixDaysAgo, now), false);
+  assert.equal(shouldRefreshMetadata(sevenDaysAgo, now), true);
+  assert.equal(shouldRefreshMetadata("not-a-date", now), true);
+});
+
+test("builds CRAP CLI commands for TypeScript and Java tools", () => {
+  assert.deepEqual(
+    buildToolCommand("typescript", "cache/crap-typescript/dist/bin.js", [
+      "--agent",
+      "--threshold",
+      "8",
+      "src"
+    ]),
+    {
+      command: process.execPath,
+      args: ["cache/crap-typescript/dist/bin.js", "--agent", "--threshold", "8", "src"]
+    }
+  );
+  assert.deepEqual(
+    buildToolCommand("java", "cache/crap-java-cli.jar", ["--agent", "--threshold", "8"]),
+    {
+      command: "java",
+      args: ["-jar", "cache/crap-java-cli.jar", "--agent", "--threshold", "8"]
+    }
+  );
+});
+
+test("falls back to a cached CRAP CLI when weekly metadata refresh is offline", async () => {
+  const cacheRoot = await createTempDir();
+  const languageRoot = path.join(cacheRoot, "typescript");
+  const executablePath = path.join(
+    languageRoot,
+    "0.4.0",
+    "node_modules",
+    "@barney-media",
+    "crap-typescript",
+    "dist",
+    "bin.js"
+  );
+  const warnings: string[] = [];
+
+  await fs.mkdir(path.dirname(executablePath), { recursive: true });
+  await fs.writeFile(executablePath, "#!/usr/bin/env node\n");
+  await fs.writeFile(
+    path.join(languageRoot, "state.json"),
+    JSON.stringify({
+      checkedAt: "2026-05-01T00:00:00.000Z",
+      version: "0.4.0"
+    })
+  );
+
+  const deps = {
+    ...createDefaultDeps(),
+    cacheRoot,
+    fetchJson: async () => {
+      throw new Error("offline");
+    },
+    now: () => Date.parse("2026-06-01T00:00:00.000Z"),
+    warn: (message: string) => {
+      warnings.push(message);
+    }
+  };
+
+  const tool = await resolveTool("typescript", deps);
+
+  assert.equal(tool.version, "0.4.0");
+  assert.equal(tool.executablePath, executablePath);
+  assert.equal(tool.stale, true);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /Using cached CRAP typescript CLI 0\.4\.0/);
+});
+
+async function createTempDir() {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "ai-skills-crap-cli-"));
+
+  onTestFinished(async () => {
+    await fs.rm(tempDir, { force: true, recursive: true });
+  });
+
+  return tempDir;
+}

--- a/test/crap-cli-helper.test.ts
+++ b/test/crap-cli-helper.test.ts
@@ -17,6 +17,7 @@ import {
   parseNpmLatestVersion,
   parseSha256Checksum,
   resolveTool,
+  safeVersionPathSegment,
   shouldRefreshMetadata
 } from "../skills/ai-skills-quality-crap/scripts/run-crap-cli.mjs";
 
@@ -41,6 +42,15 @@ test("parses latest CRAP CLI versions from npm and Maven metadata", () => {
     "0.6.1"
   );
   assert.equal(parseSha256Checksum("ABCDEF".padEnd(64, "0")), "abcdef".padEnd(64, "0"));
+  assert.equal(safeVersionPathSegment("1.2.3-alpha+1", "test version"), "1.2.3-alpha+1");
+  assert.throws(
+    () => parseNpmLatestVersion({ "dist-tags": { latest: "../bin" } }),
+    /safe version path segment/u
+  );
+  assert.throws(
+    () => parseMavenLatestVersion("<metadata><versioning><latest>1/2</latest></versioning></metadata>"),
+    /safe version path segment/u
+  );
 });
 
 test("trims CRAP helper cache root overrides", () => {
@@ -312,6 +322,44 @@ test("falls back to a cached CRAP CLI when weekly metadata refresh is offline", 
   assert.equal(tool.stale, true);
   assert.equal(warnings.length, 1);
   assert.match(warnings[0], /Using cached CRAP typescript CLI 0\.4\.0/);
+});
+
+test("discovers cached CRAP CLIs from disk when state is missing", async () => {
+  const cacheRoot = await createTempDir();
+  const languageRoot = path.join(cacheRoot, "typescript");
+  const executablePath = path.join(
+    languageRoot,
+    "0.4.1",
+    "node_modules",
+    "@barney-media",
+    "crap-typescript",
+    "dist",
+    "bin.js"
+  );
+  const warnings: string[] = [];
+
+  await fs.mkdir(path.dirname(executablePath), { recursive: true });
+  await fs.writeFile(executablePath, "");
+  await fs.mkdir(path.join(languageRoot, "..evil"), { recursive: true });
+
+  const deps = {
+    ...createDefaultDeps(),
+    cacheRoot,
+    fetchJson: async () => {
+      throw new Error("offline");
+    },
+    now: () => Date.parse("2026-06-01T00:00:00.000Z"),
+    warn: (message: string) => {
+      warnings.push(message);
+    }
+  };
+
+  const tool = await resolveTool("typescript", deps);
+
+  assert.equal(tool.executablePath, executablePath);
+  assert.equal(tool.stale, true);
+  assert.match(warnings.join("\n"), /Ignoring unsafe cached CRAP typescript CLI directory/u);
+  assert.match(warnings.join("\n"), /Using cached CRAP typescript CLI 0\.4\.1/u);
 });
 
 async function createTempDir() {


### PR DESCRIPTION
## Summary
- add a skill-owned CRAP CLI helper that caches TypeScript and Java CRAP tools by skill id
- document helper usage, cache behavior, weekly metadata refresh, and evidence expectations
- add focused tests for metadata parsing, cache staleness, command construction, and offline cached fallback

Closes #239.

## Validation
- corepack pnpm validate
- corepack pnpm lint:md
- corepack pnpm build
- corepack pnpm test
- corepack pnpm quality:cognitive
- corepack pnpm quality:crap
- node skills/ai-skills-quality-crap/scripts/run-crap-cli.mjs typescript -- --help
- node skills/ai-skills-quality-crap/scripts/run-crap-cli.mjs java -- --help