### PR TITLE
Release v0.3.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,17 +68,31 @@ jobs:
             echo "already_published=false" >> "${GITHUB_OUTPUT}"
           fi
 
-      - name: Publish to npm
-        if: steps.published.outputs.already_published == 'false'
-        run: npm publish --access public
-
-      - name: Create or update GitHub release
+      - name: Create or update GitHub release draft
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
         run: |
+          set -euo pipefail
           if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
-            gh release edit "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --notes-file release-notes.md
+            is_draft="$(gh release view "${GITHUB_REF_NAME}" --json isDraft --jq .isDraft)"
+            if [ "${is_draft}" = "true" ]; then
+              gh release edit "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --notes-file release-notes.md --draft
+            else
+              gh release edit "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --notes-file release-notes.md
+            fi
           else
-            gh release create "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --notes-file release-notes.md
+            gh release create "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --notes-file release-notes.md --draft
           fi
+
+      - name: Publish to npm
+        if: steps.published.outputs.already_published == 'false'
+        id: npm_publish
+        run: npm publish --access public
+
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh release edit "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --notes-file release-notes.md --draft=false --latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,7 @@ jobs:
 
       - name: Create or update GitHub release draft
         env:
+          ALREADY_PUBLISHED: ${{ steps.published.outputs.already_published }}
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
         run: |
@@ -79,6 +80,10 @@ jobs:
             if [ "${is_draft}" = "true" ]; then
               gh release edit "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --notes-file release-notes.md --draft
             else
+              if [ "${ALREADY_PUBLISHED}" != "true" ]; then
+                echo "::error::GitHub Release ${GITHUB_REF_NAME} is already published, but the npm package version is not published."
+                exit 1
+              fi
               gh release edit "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --notes-file release-notes.md
             fi
           else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 # Changelog
 
+## 0.3.0 - 2026-06-02
+
+### Added
+
+- Added skill-owned cached CRAP and cognitive-complexity CLI helpers for
+  TypeScript and Java, including per-skill user caches, weekly metadata
+  refresh, offline cached fallback, resolved-tool evidence, and focused cache
+  behavior tests.
+- Added CLI tooling references for the CRAP and cognitive-complexity skills so
+  agents prefer the skill-owned helpers with `--agent`, scoped changed paths,
+  explicit thresholds, and recorded evidence.
+
+### Changed
+
+- Updated compatible dependency and CI tooling versions, including artifact
+  action alignment and package-manager/toolchain updates.
+- Tightened release, review-loop, review-response, release-recovery, and skill
+  backlog guidance so release-bound PRs, pending review signals, handled
+  findings, and partial publication outcomes are tracked explicitly.
+
 ## 0.2.3 - 2026-05-25
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barney-media/ai-skills",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "Canonical AI skill catalog and installer CLI package.",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Summary
- bump `@barney-media/ai-skills` to `0.3.0`
- add the `0.3.0 - 2026-06-02` changelog section covering dependency/tooling updates, release/review skill updates, and cached CRAP/cognitive CLI helpers
- update the tag-triggered release workflow to create or update a GitHub Release draft before npm publish, then publish the GitHub Release only after npm publication cannot have failed

Release prep after #241 and #242.

## Validation
- corepack pnpm validate
- corepack pnpm lint:md
- corepack pnpm build
- corepack pnpm test
- corepack pnpm quality:cognitive
- corepack pnpm quality:crap
- corepack pnpm pack:dry-run
- node scripts/verify-release-version.mjs v0.3.0
- node scripts/render-release-notes.mjs v0.3.0
- main CI green for 10a5d9f